### PR TITLE
8321123: [Shenandoah/JDK21] Fix repo permissions

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -22,7 +22,7 @@ ignore-tabs=.*\.gmk|Makefile
 message=Merge
 
 [checks "reviewers"]
-reviewers=1
+committers=1
 ignore=duke
 
 [checks "committer"]

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,5 +1,5 @@
 [general]
-project=jdk-updates
+project=shenandoah
 jbs=JDK
 version=21.0.2
 

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,7 +1,7 @@
 [general]
 project=shenandoah
 jbs=JDK
-version=21.0.2
+version=21
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists


### PR DESCRIPTION
The Shenandoah/JDK21u repo has the wrong permissons: it inherits permissions from jdk-updates, but should use permission from she Shenandoah project instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321123](https://bugs.openjdk.org/browse/JDK-8321123): [Shenandoah/JDK21] Fix repo permissions (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/3.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/3.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/3#issuecomment-1834056195)