### PR TITLE
8323630: GenShen: Control thread may (still) ignore requests to start concurrent GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -62,7 +62,7 @@ ShenandoahControlThread::ShenandoahControlThread() :
   _control_lock(Mutex::nosafepoint - 2, "ShenandoahControlGC_lock", true),
   _regulator_lock(Mutex::nosafepoint - 2, "ShenandoahRegulatorGC_lock", true),
   _periodic_task(this),
-  _requested_gc_cause(GCCause::_no_cause_specified),
+  _requested_gc_cause(GCCause::_no_gc),
   _requested_generation(select_global_generation()),
   _degen_point(ShenandoahGC::_degenerated_outside_cycle),
   _degen_generation(nullptr),
@@ -92,11 +92,10 @@ void ShenandoahPeriodicPacerNotify::task() {
 }
 
 void ShenandoahControlThread::run_service() {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  ShenandoahHeap* const heap = ShenandoahHeap::heap();
 
-  GCMode default_mode = concurrent_normal;
+  const GCMode default_mode = concurrent_normal;
   ShenandoahGenerationType generation = select_global_generation();
-  GCCause::Cause default_cause = GCCause::_shenandoah_concurrent_gc;
 
   double last_shrink_time = os::elapsedTime();
   uint age_period = 0;
@@ -105,9 +104,9 @@ void ShenandoahControlThread::run_service() {
   // Having a period 10x lower than the delay would mean we hit the
   // shrinking with lag of less than 1/10-th of true delay.
   // ShenandoahUncommitDelay is in msecs, but shrink_period is in seconds.
-  double shrink_period = (double)ShenandoahUncommitDelay / 1000 / 10;
+  const double shrink_period = (double)ShenandoahUncommitDelay / 1000 / 10;
 
-  ShenandoahCollectorPolicy* policy = heap->shenandoah_policy();
+  ShenandoahCollectorPolicy* const policy = heap->shenandoah_policy();
 
   // Heuristics are notified of allocation failures here and other outcomes
   // of the cycle. They're also used here to control whether the Nth consecutive
@@ -116,22 +115,22 @@ void ShenandoahControlThread::run_service() {
   ShenandoahHeuristics* global_heuristics = heap->global_generation()->heuristics();
   while (!in_graceful_shutdown() && !should_terminate()) {
     // Figure out if we have pending requests.
-    bool alloc_failure_pending = _alloc_failure_gc.is_set();
-    bool humongous_alloc_failure_pending = _humongous_alloc_failure_gc.is_set();
-    bool is_gc_requested = _gc_requested.is_set();
-    GCCause::Cause requested_gc_cause = _requested_gc_cause;
-    bool explicit_gc_requested = is_gc_requested && is_explicit_gc(requested_gc_cause);
-    bool implicit_gc_requested = is_gc_requested && is_implicit_gc(requested_gc_cause);
+    const bool alloc_failure_pending = _alloc_failure_gc.is_set();
+    const bool humongous_alloc_failure_pending = _humongous_alloc_failure_gc.is_set();
+
+    GCCause::Cause cause = Atomic::xchg(&_requested_gc_cause, GCCause::_no_gc);
+
+    const bool explicit_gc_requested = is_explicit_gc(cause);
+    const bool implicit_gc_requested = is_implicit_gc(cause);
 
     // This control loop iteration have seen this much allocations.
-    size_t allocs_seen = Atomic::xchg(&_allocs_seen, (size_t)0, memory_order_relaxed);
+    const size_t allocs_seen = Atomic::xchg(&_allocs_seen, (size_t)0, memory_order_relaxed);
 
     // Check if we have seen a new target for soft max heap size.
-    bool soft_max_changed = check_soft_max_changed();
+    const bool soft_max_changed = check_soft_max_changed();
 
     // Choose which GC mode to run in. The block below should select a single mode.
     set_gc_mode(none);
-    GCCause::Cause cause = GCCause::_last_gc_cause;
     ShenandoahGC::ShenandoahDegenPoint degen_point = ShenandoahGC::_degenerated_unset;
 
     if (alloc_failure_pending) {
@@ -175,7 +174,6 @@ void ShenandoahControlThread::run_service() {
         set_gc_mode(stw_full);
       }
     } else if (explicit_gc_requested) {
-      cause = requested_gc_cause;
       generation = select_global_generation();
       log_info(gc)("Trigger: Explicit GC request (%s)", GCCause::to_string(cause));
 
@@ -191,7 +189,6 @@ void ShenandoahControlThread::run_service() {
         set_gc_mode(stw_full);
       }
     } else if (implicit_gc_requested) {
-      cause = requested_gc_cause;
       generation = select_global_generation();
       log_info(gc)("Trigger: Implicit GC request (%s)", GCCause::to_string(cause));
 
@@ -210,7 +207,7 @@ void ShenandoahControlThread::run_service() {
     } else {
       // We should only be here if the regulator requested a cycle or if
       // there is an old generation mark in progress.
-      if (_requested_gc_cause == GCCause::_shenandoah_concurrent_gc) {
+      if (cause == GCCause::_shenandoah_concurrent_gc) {
         if (_requested_generation == OLD && heap->doing_mixed_evacuations()) {
           // If a request to start an old cycle arrived while an old cycle was running, but _before_
           // it chose any regions for evacuation we don't want to start a new old cycle. Rather, we want
@@ -220,8 +217,8 @@ void ShenandoahControlThread::run_service() {
         } else {
           generation = _requested_generation;
         }
+
         // preemption was requested or this is a regular cycle
-        cause = GCCause::_shenandoah_concurrent_gc;
         set_gc_mode(default_mode);
 
         // Don't start a new old marking if there is one already in progress
@@ -234,12 +231,6 @@ void ShenandoahControlThread::run_service() {
         } else {
           heap->set_unload_classes(false);
         }
-
-        // Don't want to spin in this loop and start a cycle every time, so
-        // clear requested gc cause. This creates a race with callers of the
-        // blocking 'request_gc' method, but there it loops and resets the
-        // '_requested_gc_cause' until a full cycle is completed.
-        _requested_gc_cause = GCCause::_no_gc;
       } else if (heap->is_concurrent_old_mark_in_progress() || heap->is_prepare_for_old_mark_in_progress()) {
         // Nobody asked us to do anything, but we have an old-generation mark or old-generation preparation for
         // mixed evacuation in progress, so resume working on that.
@@ -254,16 +245,16 @@ void ShenandoahControlThread::run_service() {
       }
     }
 
-    // Blow all soft references on this cycle, if handling allocation failure,
-    // either implicit or explicit GC request, or we are requested to do so unconditionally.
-    if (generation == select_global_generation() && (alloc_failure_pending || implicit_gc_requested || explicit_gc_requested || ShenandoahAlwaysClearSoftRefs)) {
-      heap->soft_ref_policy()->set_should_clear_all_soft_refs(true);
-    }
-
-    bool gc_requested = (gc_mode() != none);
-    assert (!gc_requested || cause != GCCause::_last_gc_cause, "GC cause should be set");
+    const bool gc_requested = (gc_mode() != none);
+    assert (!gc_requested || cause != GCCause::_no_gc, "GC cause should be set");
 
     if (gc_requested) {
+      // Blow away all soft references on this cycle, if handling allocation failure,
+      // either implicit or explicit GC request, or we are requested to do so unconditionally.
+      if (generation == select_global_generation() && (alloc_failure_pending || implicit_gc_requested || explicit_gc_requested || ShenandoahAlwaysClearSoftRefs)) {
+        heap->soft_ref_policy()->set_should_clear_all_soft_refs(true);
+      }
+
       // GC is starting, bump the internal ID
       update_gc_id();
 
@@ -281,7 +272,7 @@ void ShenandoahControlThread::run_service() {
         heap->free_set()->log_status();
       }
       // In case this is a degenerated cycle, remember whether original cycle was aging.
-      bool was_aging_cycle = heap->is_aging_cycle();
+      const bool was_aging_cycle = heap->is_aging_cycle();
       heap->set_aging_cycle(false);
 
       switch (gc_mode()) {
@@ -369,7 +360,7 @@ void ShenandoahControlThread::run_service() {
         heap->pacer()->setup_for_idle();
       }
     } else {
-      // Allow allocators to know we have seen this much regions
+      // Allow pacer to know we have seen this many allocations
       if (ShenandoahPacing && (allocs_seen > 0)) {
         heap->pacer()->report_alloc(allocs_seen);
       }
@@ -395,8 +386,8 @@ void ShenandoahControlThread::run_service() {
       last_shrink_time = current;
     }
 
-    // Don't wait around if there was an allocation failure - start the next cycle immediately.
-    if (!is_alloc_failure_gc()) {
+    // Wait for ShenandoahControlIntervalMax unless there was an allocation failure or another request was made mid-cycle.
+    if (!is_alloc_failure_gc() && _requested_gc_cause == GCCause::_no_gc) {
       // The timed wait is necessary because this thread has a responsibility to send
       // 'alloc_words' to the pacer when it does not perform a GC.
       MonitorLocker lock(&_control_lock, Mutex::_no_safepoint_check_flag);
@@ -865,17 +856,22 @@ void ShenandoahControlThread::request_gc(GCCause::Cause cause) {
 }
 
 bool ShenandoahControlThread::request_concurrent_gc(ShenandoahGenerationType generation) {
-  if (_preemption_requested.is_set() || _gc_requested.is_set() || ShenandoahHeap::heap()->cancelled_gc()) {
+  if (_preemption_requested.is_set() || _requested_gc_cause != GCCause::_no_gc || ShenandoahHeap::heap()->cancelled_gc()) {
     // Ignore subsequent requests from the heuristics
     log_debug(gc, thread)("Reject request for concurrent gc: preemption_requested: %s, gc_requested: %s, gc_cancelled: %s",
                           BOOL_TO_STR(_preemption_requested.is_set()),
-                          BOOL_TO_STR(_gc_requested.is_set()),
+                          GCCause::to_string(_requested_gc_cause),
                           BOOL_TO_STR(ShenandoahHeap::heap()->cancelled_gc()));
     return false;
   }
 
   if (gc_mode() == none) {
-    _requested_gc_cause = GCCause::_shenandoah_concurrent_gc;
+    GCCause::Cause existing = Atomic::cmpxchg(&_requested_gc_cause, GCCause::_no_gc, GCCause::_shenandoah_concurrent_gc);
+    if (existing != GCCause::_no_gc) {
+      log_debug(gc, thread)("Reject request for concurrent gc because another gc is pending: %s", GCCause::to_string(existing));
+      return false;
+    }
+
     _requested_generation = generation;
     notify_control_thread();
 
@@ -887,10 +883,14 @@ bool ShenandoahControlThread::request_concurrent_gc(ShenandoahGenerationType gen
   }
 
   if (preempt_old_marking(generation)) {
-    log_info(gc)("Preempting old generation mark to allow %s GC", shenandoah_generation_name(generation));
     assert(gc_mode() == servicing_old, "Expected to be servicing old, but was: %s.", gc_mode_name(gc_mode()));
-    _requested_gc_cause = GCCause::_shenandoah_concurrent_gc;
-    _requested_generation = generation;
+    GCCause::Cause existing = Atomic::cmpxchg(&_requested_gc_cause, GCCause::_no_gc, GCCause::_shenandoah_concurrent_gc);
+    if (existing != GCCause::_no_gc) {
+      log_debug(gc, thread)("Reject request to interrupt old gc because another gc is pending: %s", GCCause::to_string(existing));
+      return false;
+    }
+
+    log_info(gc)("Preempting old generation mark to allow %s GC", shenandoah_generation_name(generation));
     _preemption_requested.set();
     ShenandoahHeap::heap()->cancel_gc(GCCause::_shenandoah_concurrent_gc);
     notify_control_thread();
@@ -931,11 +931,14 @@ void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {
   size_t current_gc_id = get_gc_id();
   size_t required_gc_id = current_gc_id + 1;
   while (current_gc_id < required_gc_id) {
-    // Although setting gc request is under _gc_waiters_lock, but read side (run_service())
-    // does not take the lock. We need to enforce following order, so that read side sees
-    // latest requested gc cause when the flag is set.
-    _requested_gc_cause = cause;
-    _gc_requested.set();
+    // This races with the regulator thread to start a concurrent gc and the
+    // control thread to clear it at the start of a cycle. Threads here are
+    // allowed to escalate a heuristic's request for concurrent gc.
+    GCCause::Cause existing = Atomic::xchg(&_requested_gc_cause, cause);
+    if (existing != GCCause::_no_gc) {
+      log_debug(gc, thread)("GC request supersedes existing request: %s", GCCause::to_string(existing));
+    }
+
     notify_control_thread();
     if (cause != GCCause::_wb_breakpoint) {
       ml.wait();
@@ -997,12 +1000,7 @@ bool ShenandoahControlThread::is_alloc_failure_gc() {
   return _alloc_failure_gc.is_set();
 }
 
-bool ShenandoahControlThread::is_humongous_alloc_failure_gc() {
-  return _humongous_alloc_failure_gc.is_set();
-}
-
 void ShenandoahControlThread::notify_gc_waiters() {
-  _gc_requested.unset();
   MonitorLocker ml(&_gc_waiters_lock);
   ml.notify_all();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -86,14 +86,14 @@ public:
 private:
   ShenandoahSharedFlag _allow_old_preemption;
   ShenandoahSharedFlag _preemption_requested;
-  ShenandoahSharedFlag _gc_requested;
   ShenandoahSharedFlag _alloc_failure_gc;
   ShenandoahSharedFlag _humongous_alloc_failure_gc;
   ShenandoahSharedFlag _graceful_shutdown;
   ShenandoahSharedFlag _do_counters_update;
   ShenandoahSharedFlag _force_counters_update;
-  GCCause::Cause       _requested_gc_cause;
-  ShenandoahGenerationType _requested_generation;
+
+  GCCause::Cause  _requested_gc_cause;
+  volatile ShenandoahGenerationType _requested_generation;
   ShenandoahGC::ShenandoahDegenPoint _degen_point;
   ShenandoahGeneration* _degen_generation;
 
@@ -123,9 +123,6 @@ private:
 
   // True if allocation failure flag has been set.
   bool is_alloc_failure_gc();
-
-  // True if humongous allocation failure flag has been set.
-  bool is_humongous_alloc_failure_gc();
 
   void reset_gc_id();
   void update_gc_id();


### PR DESCRIPTION
Testing if bots can help us with shenandoah-21u backports

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323630](https://bugs.openjdk.org/browse/JDK-8323630): GenShen: Control thread may (still) ignore requests to start concurrent GC (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/5.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/5.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/5#issuecomment-1889790871)