### PR TITLE
8322219: GenShen: GHA for shenandoah repo should run all shenandoah jtreg tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
           - 'hs/tier1 common'
           - 'hs/tier1 compiler'
           - 'hs/tier1 gc'
+          - 'hs/all shenandoah'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
           - 'lib-test/tier1'
@@ -89,6 +90,10 @@ jobs:
 
           - test-name: 'hs/tier1 gc'
             test-suite: 'test/hotspot/jtreg/:tier1_gc'
+            debug-suffix: -debug
+
+          - test-name: 'hs/all shenandoah'
+            test-suite: 'test/hotspot/jtreg/:hotspot_gc_shenandoah'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 runtime'


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322219](https://bugs.openjdk.org/browse/JDK-8322219): GenShen: GHA for shenandoah repo should run all shenandoah jtreg tests (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/7.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/7.diff</a>

</details>
