### PR TITLE
8323083: [GenShen] Alloca avoidance, const-safety, interface decluttering in promotion budgeting

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -106,6 +106,7 @@ void ShenandoahGenerationalHeuristics::choose_collection_set(ShenandoahCollectio
           // in old gen to hold the evacuated copies of this region's live data.  In both cases, we choose not to
           // place this region into the collection set.
           if (region->get_top_before_promote() != nullptr) {
+            // Region was included for promotion-in-place
             regular_regions_promoted_in_place++;
             regular_regions_promoted_usage += region->used_before_promote();
           }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -47,6 +47,7 @@ ShenandoahCollectionSet::ShenandoahCollectionSet(ShenandoahHeap* heap, ReservedS
   _live(0),
   _region_count(0),
   _old_garbage(0),
+  _preselected_regions(nullptr),
   _current_index(0) {
 
   // The collection set map is reserved to cover the entire heap *and* zero addresses.

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -34,6 +34,14 @@
 
 class ShenandoahCollectionSet : public CHeapObj<mtGC> {
   friend class ShenandoahHeap;
+  friend class ShenandoahCollectionSetPreselector;
+
+  void establish_preselected(bool *preselected) {
+   assert(_preselected_regions == nullptr, "Over-writing");
+   _preselected_regions = preselected;
+  }
+  void abandon_preselected() { _preselected_regions = nullptr; }
+
 private:
   size_t const          _map_size;
   size_t const          _region_size_bytes_shift;
@@ -106,9 +114,15 @@ public:
 
   inline size_t get_old_garbage();
 
-  void establish_preselected(bool *preselected) { _preselected_regions = preselected; }
-  void abandon_preselected() { _preselected_regions = nullptr; }
-  bool is_preselected(size_t region_idx) { return (_preselected_regions != nullptr) && _preselected_regions[region_idx]; }
+  bool is_preselected(size_t region_idx) {
+    assert(_preselected_regions != nullptr, "Missing etsablish after abandon");
+    return _preselected_regions[region_idx];
+  }
+
+  bool* preselected_regions() {
+    assert(_preselected_regions != nullptr, "Null ptr");
+    return _preselected_regions;
+  }
 
   bool has_old_regions() const { return _has_old_regions; }
   size_t used()          const { return _used; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSetPreselector.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSetPreselector.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHCOLLECTIONSETPRESELECTOR_HPP
+#define SHARE_GC_SHENANDOAH_SHENANDOAHCOLLECTIONSETPRESELECTOR_HPP
+
+#include "gc/shenandoah/shenandoahCollectionSet.hpp"
+
+class ShenandoahCollectionSetPreselector : public StackObj {
+  ShenandoahCollectionSet* _cset;
+  bool* _pset;
+public:
+  ShenandoahCollectionSetPreselector(ShenandoahCollectionSet* cset, size_t num_regions):
+    _cset(cset) {
+    _pset = NEW_RESOURCE_ARRAY(bool, num_regions);
+    for (unsigned int i = 0; i < num_regions; i++) {
+        _pset[i] = false;
+    }
+    _cset->establish_preselected(_pset);
+  }
+
+  ~ShenandoahCollectionSetPreselector() {
+    _cset->abandon_preselected();
+  }
+};
+
+#endif // SHARE_GC_SHENANDOAH_SHENANDOAHCOLLECTIONSETPRESELECTOR_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -71,26 +71,28 @@ protected:
 
 private:
   // Compute evacuation budgets prior to choosing collection set.
-  // preselected_regions is an array of indicator bits for regions that will
-  // be preselected for inclusion into the collection set by this method.
-  // collection_set is the set of regions to be collected that is maintained
-  // for the heap as a whole.
-  void compute_evacuation_budgets(ShenandoahHeap* heap,
-                                  bool* preselected_regions,
-                                  ShenandoahCollectionSet* collection_set);
+  void compute_evacuation_budgets(ShenandoahHeap* heap);
 
   // Adjust evacuation budgets after choosing collection set.
   void adjust_evacuation_budgets(ShenandoahHeap* heap,
                                  ShenandoahCollectionSet* collection_set);
 
-  // Preselect for inclusion into the collection set regions whose age is
-  // at or above tenure age and which contain more than ShenandoahOldGarbageThreshold
-  // amounts of garbage.
+  // Preselect for possible inclusion into the collection set exactly the most
+  // garbage-dense regions, including those that satisfy criteria 1 & 2 below,
+  // and whose live bytes will fit within old_available budget:
+  // Criterion 1. region age >= tenuring threshold
+  // Criterion 2. region garbage percentage > ShenandoahOldGarbageThreshold
   //
-  // Returns bytes of old-gen memory consumed by selected aged regions
-  size_t select_aged_regions(size_t old_available,
-                             size_t num_regions, bool
-                             candidate_regions_for_promotion_by_copy[]);
+  // Identifies regions eligible for promotion in place,
+  // being those of at least tenuring_threshold age that have lower garbage
+  // density.
+  //
+  // Updates promotion_potential and pad_for_promote_in_place fields
+  // of the heap. Returns bytes of live object memory in the preselected
+  // regions, which are marked in the preselected_regions() indicator
+  // array of the heap's collection set, which should be initialized
+  // to false.
+  size_t select_aged_regions(size_t old_available);
 
   size_t available(size_t capacity) const;
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323083](https://bugs.openjdk.org/browse/JDK-8323083): [GenShen] Alloca avoidance, const-safety, interface decluttering in promotion budgeting (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/11.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/11.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/11#issuecomment-1890031439)