### PR TITLE
8321816: GenShen: Provide a minimum amount of time for an old collection to run

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -254,8 +254,7 @@ void ShenandoahHeuristics::record_requested_gc() {
 }
 
 bool ShenandoahHeuristics::can_unload_classes() {
-  if (!ClassUnloading) return false;
-  return true;
+  return ClassUnloading;
 }
 
 bool ShenandoahHeuristics::can_unload_classes_normal() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -550,11 +550,11 @@ bool ShenandoahOldHeuristics::should_start_gc() {
   //
   // Future refinement: under certain circumstances, we might be more sophisticated about this choice.
   // For example, we could choose to abandon the previous old collection before it has completed evacuations.
-  if (!_old_generation->can_start_gc()) {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  if (!_old_generation->can_start_gc() || heap->collection_set()->has_old_regions()) {
     return false;
   }
 
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (_cannot_expand_trigger) {
     size_t old_gen_capacity = _old_generation->max_capacity();
     size_t heap_capacity = heap->capacity();

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -53,30 +53,32 @@ ShenandoahRegulatorThread::ShenandoahRegulatorThread(ShenandoahControlThread* co
 void ShenandoahRegulatorThread::run_service() {
   if (ShenandoahHeap::heap()->mode()->is_generational()) {
     if (ShenandoahAllowOldMarkingPreemption) {
-      regulate_concurrent_cycles();
+      regulate_young_and_old_cycles();
     } else {
-      regulate_interleaved_cycles();
+      regulate_young_and_global_cycles();
     }
   } else {
-    regulate_heap();
+    regulate_global_cycles();
   }
 
   log_info(gc)("%s: Done.", name());
 }
 
-void ShenandoahRegulatorThread::regulate_concurrent_cycles() {
+void ShenandoahRegulatorThread::regulate_young_and_old_cycles() {
   assert(_young_heuristics != nullptr, "Need young heuristics.");
   assert(_old_heuristics != nullptr, "Need old heuristics.");
 
   while (!should_terminate()) {
     ShenandoahControlThread::GCMode mode = _control_thread->gc_mode();
     if (mode == ShenandoahControlThread::none) {
-      if (should_unload_classes()) {
+      if (should_start_metaspace_gc()) {
         if (request_concurrent_gc(ShenandoahControlThread::select_global_generation())) {
           log_info(gc)("Heuristics request for global (unload classes) accepted.");
         }
       } else {
         if (_young_heuristics->should_start_gc()) {
+          // Give the old generation a chance to run. The old generation cycle
+          // begins with a 'bootstrap' cycle that will also collect young.
           if (start_old_cycle()) {
             log_info(gc)("Heuristics request for old collection accepted");
           } else if (request_concurrent_gc(YOUNG)) {
@@ -94,7 +96,8 @@ void ShenandoahRegulatorThread::regulate_concurrent_cycles() {
   }
 }
 
-void ShenandoahRegulatorThread::regulate_interleaved_cycles() {
+
+void ShenandoahRegulatorThread::regulate_young_and_global_cycles() {
   assert(_young_heuristics != nullptr, "Need young heuristics.");
   assert(_global_heuristics != nullptr, "Need global heuristics.");
 
@@ -111,7 +114,7 @@ void ShenandoahRegulatorThread::regulate_interleaved_cycles() {
   }
 }
 
-void ShenandoahRegulatorThread::regulate_heap() {
+void ShenandoahRegulatorThread::regulate_global_cycles() {
   assert(_global_heuristics != nullptr, "Need global heuristics.");
 
   while (!should_terminate()) {
@@ -149,11 +152,15 @@ void ShenandoahRegulatorThread::regulator_sleep() {
 }
 
 bool ShenandoahRegulatorThread::start_old_cycle() {
-  // TODO: These first two checks might be vestigial
-  return !ShenandoahHeap::heap()->doing_mixed_evacuations()
-      && !ShenandoahHeap::heap()->collection_set()->has_old_regions()
-      && _old_heuristics->should_start_gc()
-      && request_concurrent_gc(OLD);
+  return _old_heuristics->should_start_gc() && request_concurrent_gc(OLD);
+}
+
+bool ShenandoahRegulatorThread::start_young_cycle() {
+  return _young_heuristics->should_start_gc() && request_concurrent_gc(YOUNG);
+}
+
+bool ShenandoahRegulatorThread::start_global_cycle() {
+  return _global_heuristics->should_start_gc() && request_concurrent_gc(ShenandoahControlThread::select_global_generation());
 }
 
 bool ShenandoahRegulatorThread::request_concurrent_gc(ShenandoahGenerationType generation) {
@@ -168,21 +175,17 @@ bool ShenandoahRegulatorThread::request_concurrent_gc(ShenandoahGenerationType g
   return accepted;
 }
 
-bool ShenandoahRegulatorThread::start_young_cycle() {
-  return _young_heuristics->should_start_gc() && request_concurrent_gc(YOUNG);
-}
-
-bool ShenandoahRegulatorThread::start_global_cycle() {
-  return _global_heuristics->should_start_gc() && request_concurrent_gc(ShenandoahControlThread::select_global_generation());
-}
-
 void ShenandoahRegulatorThread::stop_service() {
   log_info(gc)("%s: Stop requested.", name());
 }
 
-bool ShenandoahRegulatorThread::should_unload_classes() {
-  // The heuristics delegate this decision to the collector policy, which is based on the number
-  // of cycles started.
-  return _global_heuristics->should_unload_classes();
+bool ShenandoahRegulatorThread::should_start_metaspace_gc() {
+  // The generational mode can, at present, only unload classes during a global
+  // cycle. For this reason, we treat an oom in metaspace as a _trigger_ for a
+  // global cycle. But, we check other prerequisites before starting a gc that won't
+  // unload anything.
+  return ClassUnloadingWithConcurrentMark
+      && _global_heuristics->can_unload_classes()
+      && _global_heuristics->has_metaspace_oom();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -614,6 +614,13 @@
   notproduct(int, ShenandoahCardStatsLogInterval, 50,                       \
           "Log cumulative card stats every so many remembered set or "      \
           "update refs scans")                                              \
+                                                                            \
+  product(uintx, ShenandoahMinimumOldMarkTimeMs, 100, EXPERIMENTAL,         \
+         "Minimum amount of time in milliseconds to run old marking "       \
+         "before a young collection is allowed to run. This is intended "   \
+         "to prevent starvation of the old collector. Setting this to "     \
+         "0 will allow back to back young collections to run during old "   \
+         "marking.")                                                        \
   // end of GC_SHENANDOAH_FLAGS
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAH_GLOBALS_HPP


### PR DESCRIPTION
Resolved conflict with `can_unload_classes_normal`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8321816](https://bugs.openjdk.org/browse/JDK-8321816): GenShen: Provide a minimum amount of time for an old collection to run (**Enhancement** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/14.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/14.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/14#issuecomment-1890182506)