### PR TITLE
8322347: GenShen: Run shenandoah tier2 and tier3 tests separately in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,8 @@ jobs:
           - 'hs/tier1 common'
           - 'hs/tier1 compiler'
           - 'hs/tier1 gc'
-          - 'hs/all shenandoah'
+          - 'hs/tier2_gc_shenandoah shenandoah tier2'
+          - 'hs/tier3_gc_shenandoah shenandoah tier3'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
           - 'lib-test/tier1'
@@ -92,8 +93,12 @@ jobs:
             test-suite: 'test/hotspot/jtreg/:tier1_gc'
             debug-suffix: -debug
 
-          - test-name: 'hs/all shenandoah'
-            test-suite: 'test/hotspot/jtreg/:hotspot_gc_shenandoah'
+          - test-name: 'hs/tier2_gc_shenandoah shenandoah tier2'
+            test-suite: 'test/hotspot/jtreg/:tier2_gc_shenandoah'
+            debug-suffix: -debug
+
+          - test-name: 'hs/tier3_gc_shenandoah shenandoah tier3'
+            test-suite: 'test/hotspot/jtreg/:tier3_gc_shenandoah'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 runtime'


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322347](https://bugs.openjdk.org/browse/JDK-8322347): GenShen: Run shenandoah tier2 and tier3 tests separately in GHA (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/15.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/15.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/15#issuecomment-1890186394)