### PR TITLE
8329342: GenShen: Synchronize shenandoah-jdk21u:master with shenandoah:master

### DIFF
--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -72,12 +72,11 @@ void AgeTable::clear() {
 }
 
 #ifndef PRODUCT
-bool AgeTable::is_clear() {
-  size_t total = 0;
-  for (size_t* p = sizes; p < sizes + table_size; ++p) {
-    total += *p;
+bool AgeTable::is_clear() const {
+  for (const size_t* p = sizes; p < sizes + table_size; ++p) {
+    if (*p != 0) return false;
   }
-  return total == 0;
+  return true;
 }
 #endif // !PRODUCT
 

--- a/src/hotspot/share/gc/shared/ageTable.hpp
+++ b/src/hotspot/share/gc/shared/ageTable.hpp
@@ -53,8 +53,11 @@ class AgeTable: public CHeapObj<mtGC> {
 
   // clear table
   void clear();
+
+#ifndef PRODUCT
   // check whether it's clear
-  bool is_clear() PRODUCT_RETURN0;
+  bool is_clear() const;
+#endif // !PRODUCT
 
   // add entry
   inline void add(oop p, size_t oop_size);

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -386,6 +386,12 @@ void ShenandoahBarrierC2Support::verify(RootNode* root) {
           verify_type t;
         } args[6];
       } calls[] = {
+        "array_partition_stub",
+        { { TypeFunc::Parms, ShenandoahStore }, { TypeFunc::Parms+4, ShenandoahStore },   { -1, ShenandoahNone },
+          { -1, ShenandoahNone },                { -1, ShenandoahNone },                  { -1, ShenandoahNone } },
+        "arraysort_stub",
+        { { TypeFunc::Parms, ShenandoahStore },  { -1, ShenandoahNone },                  { -1, ShenandoahNone },
+          { -1,  ShenandoahNone},                 { -1,  ShenandoahNone},                 { -1,  ShenandoahNone} },
         "aescrypt_encryptBlock",
         { { TypeFunc::Parms, ShenandoahLoad },   { TypeFunc::Parms+1, ShenandoahStore },  { TypeFunc::Parms+2, ShenandoahLoad },
           { -1,  ShenandoahNone},                 { -1,  ShenandoahNone},                 { -1,  ShenandoahNone} },
@@ -2168,7 +2174,7 @@ void MemoryGraphFixer::collect_memory_nodes() {
           assert(m != nullptr || (c->is_Loop() && j == LoopNode::LoopBackControl && iteration == 1) || _phase->C->has_irreducible_loop() || has_never_branch(_phase->C->root()), "expect memory state");
           if (m != nullptr) {
             if (m == prev_region && ((c->is_Loop() && j == LoopNode::LoopBackControl) || (prev_region->is_Phi() && prev_region->in(0) == c))) {
-              assert(c->is_Loop() && j == LoopNode::LoopBackControl || _phase->C->has_irreducible_loop() || has_never_branch(_phase->C->root()), "");
+              assert((c->is_Loop() && j == LoopNode::LoopBackControl) || _phase->C->has_irreducible_loop() || has_never_branch(_phase->C->root()), "");
               // continue
             } else if (unique == nullptr) {
               unique = m;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -28,8 +28,9 @@
 #include "gc/shenandoah/shenandoahCollectionSet.hpp"
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
-#include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
 
 #include "logging/log.hpp"
 
@@ -40,7 +41,7 @@ ShenandoahGenerationalHeuristics::ShenandoahGenerationalHeuristics(ShenandoahGen
 void ShenandoahGenerationalHeuristics::choose_collection_set(ShenandoahCollectionSet* collection_set) {
   assert(collection_set->is_empty(), "Must be empty");
 
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  auto heap = ShenandoahGenerationalHeap::heap();
   size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
 
 
@@ -148,8 +149,8 @@ void ShenandoahGenerationalHeuristics::choose_collection_set(ShenandoahCollectio
       immediate_garbage += garbage;
     }
   }
-  heap->reserve_promotable_humongous_regions(humongous_regions_promoted);
-  heap->reserve_promotable_regular_regions(regular_regions_promoted_in_place);
+  heap->old_generation()->set_expected_humongous_region_promotions(humongous_regions_promoted);
+  heap->old_generation()->set_expected_regular_region_promotions(regular_regions_promoted_in_place);
   log_info(gc, ergo)("Planning to promote in place " SIZE_FORMAT " humongous regions and " SIZE_FORMAT
                      " regular regions, spanning a total of " SIZE_FORMAT " used bytes",
                      humongous_regions_promoted, regular_regions_promoted_in_place,

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGlobalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGlobalHeuristics.cpp
@@ -27,7 +27,7 @@
 #include "gc/shenandoah/heuristics/shenandoahGlobalHeuristics.hpp"
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
 #include "gc/shenandoah/shenandoahGlobalGeneration.hpp"
-#include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
 
 #include "utilities/quickSort.hpp"
@@ -79,16 +79,18 @@ void ShenandoahGlobalHeuristics::choose_global_collection_set(ShenandoahCollecti
                                                               const ShenandoahHeuristics::RegionData* data,
                                                               size_t size, size_t actual_free,
                                                               size_t cur_young_garbage) const {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  auto heap = ShenandoahGenerationalHeap::heap();
   size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
   size_t capacity = heap->young_generation()->max_capacity();
   size_t garbage_threshold = region_size_bytes * ShenandoahGarbageThreshold / 100;
   size_t ignore_threshold = region_size_bytes * ShenandoahIgnoreGarbageThreshold / 100;
   const uint tenuring_threshold = heap->age_census()->tenuring_threshold();
 
-  size_t max_young_cset = (size_t) (heap->get_young_evac_reserve() / ShenandoahEvacWaste);
+  size_t young_evac_reserve = heap->young_generation()->get_evacuation_reserve();
+  size_t old_evac_reserve = heap->old_generation()->get_evacuation_reserve();
+  size_t max_young_cset = (size_t) (young_evac_reserve / ShenandoahEvacWaste);
   size_t young_cur_cset = 0;
-  size_t max_old_cset = (size_t) (heap->get_old_evac_reserve() / ShenandoahOldEvacWaste);
+  size_t max_old_cset = (size_t) (old_evac_reserve / ShenandoahOldEvacWaste);
   size_t old_cur_cset = 0;
 
   // Figure out how many unaffiliated young regions are dedicated to mutator and to evacuator.  Allow the young
@@ -168,7 +170,7 @@ void ShenandoahGlobalHeuristics::choose_global_collection_set(ShenandoahCollecti
 
   if (regions_transferred_to_old > 0) {
     heap->generation_sizer()->force_transfer_to_old(regions_transferred_to_old);
-    heap->set_young_evac_reserve(heap->get_young_evac_reserve() - regions_transferred_to_old * region_size_bytes);
-    heap->set_old_evac_reserve(heap->get_old_evac_reserve() + regions_transferred_to_old * region_size_bytes);
+    heap->young_generation()->set_evacuation_reserve(young_evac_reserve - regions_transferred_to_old * region_size_bytes);
+    heap->old_generation()->set_evacuation_reserve(old_evac_reserve + regions_transferred_to_old * region_size_bytes);
   }
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -154,6 +154,9 @@ public:
   virtual void choose_collection_set(ShenandoahCollectionSet* collection_set);
 
   virtual bool can_unload_classes();
+
+  // This indicates whether or not the current cycle should unload classes.
+  // It does NOT indicate that a cycle should be started.
   virtual bool should_unload_classes();
 
   virtual const char* name() = 0;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
@@ -27,8 +27,9 @@
 #include "gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp"
 #include "gc/shenandoah/heuristics/shenandoahYoungHeuristics.hpp"
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
-#include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 
 #include "utilities/quickSort.hpp"
@@ -78,7 +79,7 @@ void ShenandoahYoungHeuristics::choose_young_collection_set(ShenandoahCollection
                                                             size_t size, size_t actual_free,
                                                             size_t cur_young_garbage) const {
 
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  auto heap = ShenandoahGenerationalHeap::heap();
 
   size_t capacity = heap->young_generation()->max_capacity();
   size_t garbage_threshold = ShenandoahHeapRegion::region_size_bytes() * ShenandoahGarbageThreshold / 100;
@@ -87,7 +88,7 @@ void ShenandoahYoungHeuristics::choose_young_collection_set(ShenandoahCollection
 
   // This is young-gen collection or a mixed evacuation.
   // If this is mixed evacuation, the old-gen candidate regions have already been added.
-  size_t max_cset = (size_t) (heap->get_young_evac_reserve() / ShenandoahEvacWaste);
+  size_t max_cset = (size_t) (heap->young_generation()->get_evacuation_reserve() / ShenandoahEvacWaste);
   size_t cur_cset = 0;
   size_t free_target = (capacity * ShenandoahMinFreeThreshold) / 100 + max_cset;
   size_t min_garbage = (free_target > actual_free) ? (free_target - actual_free) : 0;
@@ -123,11 +124,11 @@ void ShenandoahYoungHeuristics::choose_young_collection_set(ShenandoahCollection
 
 
 bool ShenandoahYoungHeuristics::should_start_gc() {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  auto heap = ShenandoahGenerationalHeap::heap();
   ShenandoahOldHeuristics* old_heuristics = heap->old_heuristics();
 
   // Checks that an old cycle has run for at least ShenandoahMinimumOldMarkTimeMs before allowing a young cycle.
-  if (ShenandoahMinimumOldMarkTimeMs > 0 && ShenandoahHeap::heap()->is_concurrent_old_mark_in_progress()) {
+  if (ShenandoahMinimumOldMarkTimeMs > 0 && heap->is_concurrent_old_mark_in_progress()) {
     size_t old_mark_elapsed = size_t(old_heuristics->elapsed_cycle_time() * 1000);
     if (old_mark_elapsed < ShenandoahMinimumOldMarkTimeMs) {
       return false;
@@ -145,7 +146,7 @@ bool ShenandoahYoungHeuristics::should_start_gc() {
   // be done, we start up the young-gen GC threads so they can do some of this old-gen work.  As implemented, promotion
   // gets priority over old-gen marking.
   size_t promo_expedite_threshold = percent_of(heap->young_generation()->max_capacity(), ShenandoahExpeditePromotionsThreshold);
-  size_t promo_potential = heap->get_promotion_potential();
+  size_t promo_potential = heap->old_generation()->get_promotion_potential();
   if (promo_potential > promo_expedite_threshold) {
     // Detect unsigned arithmetic underflow
     assert(promo_potential < heap->capacity(), "Sanity");
@@ -175,7 +176,7 @@ bool ShenandoahYoungHeuristics::should_start_gc() {
 // generation at the end of the current cycle (as represented by young_regions_to_be_reclaimed) and on the anticipated
 // amount of time required to perform a GC.
 size_t ShenandoahYoungHeuristics::bytes_of_allocation_runway_before_gc_trigger(size_t young_regions_to_be_reclaimed) {
-  size_t capacity = _space_info->soft_max_capacity();
+  size_t capacity = _space_info->max_capacity();
   size_t usage = _space_info->used();
   size_t available = (capacity > usage)? capacity - usage: 0;
   size_t allocated = _space_info->bytes_allocated_since_gc_start();

--- a/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.cpp
@@ -183,6 +183,7 @@ void ShenandoahAgeCensus::reset_local() {
   }
 }
 
+#ifndef PRODUCT
 // Is global census information clear?
 bool ShenandoahAgeCensus::is_clear_global() {
   assert(_epoch < MAX_SNAPSHOTS, "Out of bounds");
@@ -212,6 +213,7 @@ bool ShenandoahAgeCensus::is_clear_local() {
   }
   return true;
 }
+#endif // !PRODUCT
 
 void ShenandoahAgeCensus::update_tenuring_threshold() {
   if (!ShenandoahGenerationalAdaptiveTenuring) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.hpp
@@ -178,9 +178,11 @@ class ShenandoahAgeCensus: public CHeapObj<mtGC> {
   // Reset any partial census information
   void reset_local();
 
+#ifndef PRODUCT
   // Check whether census information is clear
   bool is_clear_global();
   bool is_clear_local();
+#endif // !PRODUCT
 
   // Print the age census information
   void print();

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -123,6 +123,16 @@ void ShenandoahArguments::initialize() {
     }
   }
 
+  // Disable support for dynamic number of GC threads. We do not let the runtime
+  // heuristics to misjudge how many threads we need during the heavy concurrent phase
+  // or a GC pause.
+  if (UseDynamicNumberOfGCThreads) {
+    if (FLAG_IS_CMDLINE(UseDynamicNumberOfGCThreads)) {
+      warning("Shenandoah does not support UseDynamicNumberOfGCThreads, disabling");
+    }
+    FLAG_SET_DEFAULT(UseDynamicNumberOfGCThreads, false);
+  }
+
   if (ShenandoahRegionSampling && FLAG_IS_DEFAULT(PerfDataMemorySize)) {
     // When sampling is enabled, max out the PerfData memory to get more
     // Shenandoah data in, including Matrix.

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -402,7 +402,7 @@ void ShenandoahBarrierSet::arraycopy_work(T* src, size_t count) {
         if (EVAC && obj == fwd) {
           fwd = _heap->evacuate_object(obj, thread);
         }
-        assert(obj != fwd || _heap->cancelled_gc(), "must be forwarded");
+        shenandoah_assert_forwarded_except(elem_ptr, obj, _heap->cancelled_gc());
         ShenandoahHeap::atomic_update_oop(fwd, elem_ptr, o);
         obj = fwd;
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetClone.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetClone.inline.hpp
@@ -53,7 +53,7 @@ private:
         if (EVAC && obj == fwd) {
           fwd = _heap->evacuate_object(obj, _thread);
         }
-        assert(obj != fwd || _heap->cancelled_gc(), "must be forwarded");
+        shenandoah_assert_forwarded_except(p, obj, _heap->cancelled_gc());
         ShenandoahHeap::atomic_update_oop(fwd, p, o);
         obj = fwd;
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCardTable.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCardTable.cpp
@@ -56,10 +56,6 @@ void ShenandoahCardTable::initialize() {
   assert(byte_for(low_bound) == &_byte_map[0], "Checking start of map");
   assert(byte_for(high_bound-1) <= &_byte_map[last_valid_index()], "Checking end of map");
 
-  CardValue* guard_card = &_byte_map[num_cards];
-  assert(is_aligned(guard_card, _page_size), "must be on its own OS page");
-  _guard_region = MemRegion((HeapWord*)guard_card, _page_size);
-
   _write_byte_map = _byte_map;
   _write_byte_map_base = _byte_map_base;
 
@@ -85,10 +81,6 @@ void ShenandoahCardTable::initialize() {
   // because the mutator write barrier hard codes the address of the _write_byte_map_base.  Instead,
   // the current implementation simply copies contents of _write_byte_map onto _read_byte_map and cleans
   // the entirety of _write_byte_map at the init_mark safepoint.
-  //
-  // If we choose to modify the mutator write barrier so that we can swap _read_byte_map_base and
-  // _write_byte_map_base pointers, we may also have to figure out certain details about how the
-  // _guard_region is implemented so that we can replicate the read and write versions of this region.
   //
   // Alternatively, we may switch to a SATB-based write barrier and replace the direct card-marking
   // remembered set with something entirely different.

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
@@ -32,44 +32,28 @@
 
 ShenandoahCollectorPolicy::ShenandoahCollectorPolicy() :
   _success_concurrent_gcs(0),
-  _mixed_gcs(0),
   _abbreviated_concurrent_gcs(0),
+  _success_degenerated_gcs(0),
   _abbreviated_degenerated_gcs(0),
+  _success_full_gcs(0),
+  _consecutive_degenerated_gcs(0),
+  _consecutive_young_gcs(0),
+  _mixed_gcs(0),
   _success_old_gcs(0),
   _interrupted_old_gcs(0),
-  _success_degenerated_gcs(0),
-  _success_full_gcs(0),
-  _consecutive_young_gcs(0),
-  _consecutive_degenerated_gcs(0),
   _alloc_failure_degenerated(0),
   _alloc_failure_degenerated_upgrade_to_full(0),
-  _alloc_failure_full(0),
-  _explicit_concurrent(0),
-  _explicit_full(0),
-  _implicit_concurrent(0),
-  _implicit_full(0),
-  _cycle_counter(0) {
+  _alloc_failure_full(0) {
 
-  Copy::zero_to_bytes(_degen_points, sizeof(size_t) * ShenandoahGC::_DEGENERATED_LIMIT);
+  Copy::zero_to_bytes(_degen_point_counts, sizeof(size_t) * ShenandoahGC::_DEGENERATED_LIMIT);
+  Copy::zero_to_bytes(_collection_cause_counts, sizeof(size_t) * GCCause::_last_gc_cause);
 
   _tracer = new ShenandoahTracer();
-
 }
 
-void ShenandoahCollectorPolicy::record_explicit_to_concurrent() {
-  _explicit_concurrent++;
-}
-
-void ShenandoahCollectorPolicy::record_explicit_to_full() {
-  _explicit_full++;
-}
-
-void ShenandoahCollectorPolicy::record_implicit_to_concurrent() {
-  _implicit_concurrent++;
-}
-
-void ShenandoahCollectorPolicy::record_implicit_to_full() {
-  _implicit_full++;
+void ShenandoahCollectorPolicy::record_collection_cause(GCCause::Cause cause) {
+  assert(cause < GCCause::_last_gc_cause, "Invalid GCCause");
+  _collection_cause_counts[cause]++;
 }
 
 void ShenandoahCollectorPolicy::record_alloc_failure_to_full() {
@@ -79,7 +63,7 @@ void ShenandoahCollectorPolicy::record_alloc_failure_to_full() {
 void ShenandoahCollectorPolicy::record_alloc_failure_to_degenerated(ShenandoahGC::ShenandoahDegenPoint point) {
   assert(point < ShenandoahGC::_DEGENERATED_LIMIT, "sanity");
   _alloc_failure_degenerated++;
-  _degen_points[point]++;
+  _degen_point_counts[point]++;
 }
 
 void ShenandoahCollectorPolicy::record_degenerated_upgrade_to_full() {
@@ -135,20 +119,55 @@ void ShenandoahCollectorPolicy::record_success_full() {
   _success_full_gcs++;
 }
 
-size_t ShenandoahCollectorPolicy::cycle_counter() const {
-  return _cycle_counter;
-}
-
-void ShenandoahCollectorPolicy::record_cycle_start() {
-  _cycle_counter++;
-}
-
 void ShenandoahCollectorPolicy::record_shutdown() {
   _in_shutdown.set();
 }
 
 bool ShenandoahCollectorPolicy::is_at_shutdown() {
   return _in_shutdown.is_set();
+}
+
+bool is_explicit_gc(GCCause::Cause cause) {
+  return GCCause::is_user_requested_gc(cause)
+      || GCCause::is_serviceability_requested_gc(cause);
+}
+
+bool is_implicit_gc(GCCause::Cause cause) {
+  return cause != GCCause::_no_gc
+      && cause != GCCause::_shenandoah_concurrent_gc
+      && cause != GCCause::_allocation_failure
+      && !is_explicit_gc(cause);
+}
+
+#ifdef ASSERT
+bool is_valid_request(GCCause::Cause cause) {
+  return is_explicit_gc(cause)
+      || cause == GCCause::_metadata_GC_clear_soft_refs
+      || cause == GCCause::_codecache_GC_aggressive
+      || cause == GCCause::_codecache_GC_threshold
+      || cause == GCCause::_full_gc_alot
+      || cause == GCCause::_wb_young_gc
+      || cause == GCCause::_wb_full_gc
+      || cause == GCCause::_wb_breakpoint
+      || cause == GCCause::_scavenge_alot;
+}
+#endif
+
+bool ShenandoahCollectorPolicy::is_requested_gc(GCCause::Cause cause) {
+  return is_explicit_gc(cause) || is_implicit_gc(cause);
+}
+
+bool ShenandoahCollectorPolicy::should_run_full_gc(GCCause::Cause cause) {
+  return is_explicit_gc(cause) ? !ExplicitGCInvokesConcurrent : !ShenandoahImplicitGCInvokesConcurrent;
+}
+
+bool ShenandoahCollectorPolicy::should_handle_requested_gc(GCCause::Cause cause) {
+  assert(is_valid_request(cause), "only requested GCs here: %s", GCCause::to_string(cause));
+
+  if (DisableExplicitGC) {
+    return !is_explicit_gc(cause);
+  }
+  return true;
 }
 
 void ShenandoahCollectorPolicy::print_gc_stats(outputStream* out) const {
@@ -161,10 +180,32 @@ void ShenandoahCollectorPolicy::print_gc_stats(outputStream* out) const {
 
   size_t completed_gcs = _success_full_gcs + _success_degenerated_gcs + _success_concurrent_gcs + _success_old_gcs;
   out->print_cr(SIZE_FORMAT_W(5) " Completed GCs", completed_gcs);
-  out->print_cr(SIZE_FORMAT_W(5) " Successful Concurrent GCs (%.2f%%)",  _success_concurrent_gcs, percent_of(_success_concurrent_gcs, completed_gcs));
-  out->print_cr("  " SIZE_FORMAT_W(5) " invoked explicitly (%.2f%%)",    _explicit_concurrent, percent_of(_explicit_concurrent, _success_concurrent_gcs));
-  out->print_cr("  " SIZE_FORMAT_W(5) " invoked implicitly (%.2f%%)",    _implicit_concurrent, percent_of(_implicit_concurrent, _success_concurrent_gcs));
-  out->print_cr("  " SIZE_FORMAT_W(5) " abbreviated (%.2f%%)",           _abbreviated_concurrent_gcs, percent_of(_abbreviated_concurrent_gcs, _success_concurrent_gcs));
+
+  size_t explicit_requests = 0;
+  size_t implicit_requests = 0;
+  for (int c = 0; c < GCCause::_last_gc_cause; c++) {
+    size_t cause_count = _collection_cause_counts[c];
+    if (cause_count > 0) {
+      auto cause = (GCCause::Cause) c;
+      if (is_explicit_gc(cause)) {
+        explicit_requests += cause_count;
+      } else if (is_implicit_gc(cause)) {
+        implicit_requests += cause_count;
+      }
+      const char* desc = GCCause::to_string(cause);
+      out->print_cr("  " SIZE_FORMAT_W(5) " caused by %s (%.2f%%)", cause_count, desc, percent_of(cause_count, completed_gcs));
+    }
+  }
+
+  out->cr();
+  out->print_cr(SIZE_FORMAT_W(5) " Successful Concurrent GCs (%.2f%%)", _success_concurrent_gcs, percent_of(_success_concurrent_gcs, completed_gcs));
+  if (ExplicitGCInvokesConcurrent) {
+    out->print_cr("  " SIZE_FORMAT_W(5) " invoked explicitly (%.2f%%)", explicit_requests, percent_of(explicit_requests, _success_concurrent_gcs));
+  }
+  if (ShenandoahImplicitGCInvokesConcurrent) {
+    out->print_cr("  " SIZE_FORMAT_W(5) " invoked implicitly (%.2f%%)", implicit_requests, percent_of(implicit_requests, _success_concurrent_gcs));
+  }
+  out->print_cr("  " SIZE_FORMAT_W(5) " abbreviated (%.2f%%)",  _abbreviated_concurrent_gcs, percent_of(_abbreviated_concurrent_gcs, _success_concurrent_gcs));
   out->cr();
 
   if (ShenandoahHeap::heap()->mode()->is_generational()) {
@@ -180,16 +221,20 @@ void ShenandoahCollectorPolicy::print_gc_stats(outputStream* out) const {
   out->print_cr("  " SIZE_FORMAT_W(5) " caused by allocation failure (%.2f%%)", _alloc_failure_degenerated, percent_of(_alloc_failure_degenerated, degenerated_gcs));
   out->print_cr("  " SIZE_FORMAT_W(5) " abbreviated (%.2f%%)",                  _abbreviated_degenerated_gcs, percent_of(_abbreviated_degenerated_gcs, degenerated_gcs));
   for (int c = 0; c < ShenandoahGC::_DEGENERATED_LIMIT; c++) {
-    if (_degen_points[c] > 0) {
+    if (_degen_point_counts[c] > 0) {
       const char* desc = ShenandoahGC::degen_point_to_string((ShenandoahGC::ShenandoahDegenPoint)c);
-      out->print_cr("    " SIZE_FORMAT_W(5) " happened at %s",         _degen_points[c], desc);
+      out->print_cr("    " SIZE_FORMAT_W(5) " happened at %s", _degen_point_counts[c], desc);
     }
   }
   out->cr();
 
-  out->print_cr(SIZE_FORMAT_W(5) " Full GCs (%.2f%%)",                          _success_full_gcs, percent_of(_success_full_gcs, completed_gcs));
-  out->print_cr("  " SIZE_FORMAT_W(5) " invoked explicitly (%.2f%%)",           _explicit_full, percent_of(_explicit_full, _success_full_gcs));
-  out->print_cr("  " SIZE_FORMAT_W(5) " invoked implicitly (%.2f%%)",           _implicit_full, percent_of(_implicit_full, _success_full_gcs));
+  out->print_cr(SIZE_FORMAT_W(5) " Full GCs (%.2f%%)", _success_full_gcs, percent_of(_success_full_gcs, completed_gcs));
+  if (!ExplicitGCInvokesConcurrent) {
+    out->print_cr("  " SIZE_FORMAT_W(5) " invoked explicitly (%.2f%%)", explicit_requests, percent_of(explicit_requests, _success_concurrent_gcs));
+  }
+  if (!ShenandoahImplicitGCInvokesConcurrent) {
+    out->print_cr("  " SIZE_FORMAT_W(5) " invoked implicitly (%.2f%%)", implicit_requests, percent_of(implicit_requests, _success_concurrent_gcs));
+  }
   out->print_cr("  " SIZE_FORMAT_W(5) " caused by allocation failure (%.2f%%)", _alloc_failure_full, percent_of(_alloc_failure_full, _success_full_gcs));
   out->print_cr("  " SIZE_FORMAT_W(5) " upgraded from Degenerated GC (%.2f%%)", _alloc_failure_degenerated_upgrade_to_full, percent_of(_alloc_failure_degenerated_upgrade_to_full, _success_full_gcs));
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -40,25 +40,21 @@ public:
 class ShenandoahCollectorPolicy : public CHeapObj<mtGC> {
 private:
   size_t _success_concurrent_gcs;
-  size_t _mixed_gcs;
   size_t _abbreviated_concurrent_gcs;
-  size_t _abbreviated_degenerated_gcs;
-  size_t _success_old_gcs;
-  size_t _interrupted_old_gcs;
   size_t _success_degenerated_gcs;
+  size_t _abbreviated_degenerated_gcs;
   // Written by control thread, read by mutators
   volatile size_t _success_full_gcs;
-  volatile size_t _consecutive_young_gcs;
   uint _consecutive_degenerated_gcs;
+  volatile size_t _consecutive_young_gcs;
+  size_t _mixed_gcs;
+  size_t _success_old_gcs;
+  size_t _interrupted_old_gcs;
   size_t _alloc_failure_degenerated;
   size_t _alloc_failure_degenerated_upgrade_to_full;
   size_t _alloc_failure_full;
-  size_t _explicit_concurrent;
-  size_t _explicit_full;
-  size_t _implicit_concurrent;
-  size_t _implicit_full;
-  size_t _cycle_counter;
-  size_t _degen_points[ShenandoahGC::_DEGENERATED_LIMIT];
+  size_t _collection_cause_counts[GCCause::_last_gc_cause];
+  size_t _degen_point_counts[ShenandoahGC::_DEGENERATED_LIMIT];
 
   ShenandoahSharedFlag _in_shutdown;
   ShenandoahTracer* _tracer;
@@ -67,31 +63,27 @@ private:
 public:
   ShenandoahCollectorPolicy();
 
-  // TODO: This is different from gc_end: that one encompasses one VM operation.
-  // These two encompass the entire cycle.
-  void record_cycle_start();
-
   void record_mixed_cycle();
-
-  void record_success_concurrent(bool is_young, bool is_abbreviated);
   void record_success_old();
   void record_interrupted_old();
+
+  // A collection cycle may be "abbreviated" if Shenandoah finds a sufficient percentage
+  // of regions that contain no live objects (ShenandoahImmediateThreshold). These cycles
+  // end after final mark, skipping the evacuation and reference-updating phases. Such
+  // cycles are very efficient and are worth tracking. Note that both degenerated and
+  // concurrent cycles can be abbreviated.
+  void record_success_concurrent(bool is_young, bool is_abbreviated);
   void record_success_degenerated(bool is_young, bool is_abbreviated);
   void record_success_full();
   void record_alloc_failure_to_degenerated(ShenandoahGC::ShenandoahDegenPoint point);
   void record_alloc_failure_to_full();
   void record_degenerated_upgrade_to_full();
-  void record_explicit_to_concurrent();
-  void record_explicit_to_full();
-  void record_implicit_to_concurrent();
-  void record_implicit_to_full();
+  void record_collection_cause(GCCause::Cause cause);
 
   void record_shutdown();
   bool is_at_shutdown();
 
   ShenandoahTracer* tracer() {return _tracer;}
-
-  size_t cycle_counter() const;
 
   void print_gc_stats(outputStream* out) const;
 
@@ -99,12 +91,19 @@ public:
     return _success_full_gcs + _alloc_failure_degenerated_upgrade_to_full;
   }
 
-  inline size_t consecutive_young_gc_count() const {
-    return _consecutive_young_gcs;
-  }
-
+  // If the heuristics find that the number of consecutive degenerated cycles is above
+  // ShenandoahFullGCThreshold, then they will initiate a Full GC upon an allocation
+  // failure.
   inline size_t consecutive_degenerated_gc_count() const {
     return _consecutive_degenerated_gcs;
+  }
+
+  static bool is_requested_gc(GCCause::Cause cause);
+  static bool should_run_full_gc(GCCause::Cause cause);
+  static bool should_handle_requested_gc(GCCause::Cause cause);
+
+  inline size_t consecutive_young_gc_count() const {
+    return _consecutive_young_gcs;
   }
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -33,6 +33,7 @@
 #include "gc/shenandoah/shenandoahConcurrentGC.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/shenandoahLock.hpp"
@@ -230,47 +231,21 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // We defer generation resizing actions until after cset regions have been recycled.  We do this even following an
   // abbreviated cycle.
   if (heap->mode()->is_generational()) {
-    bool success;
-    size_t region_xfer;
-    const char* region_destination;
-    ShenandoahYoungGeneration* young_gen = heap->young_generation();
-    ShenandoahGeneration* old_gen = heap->old_generation();
-    {
-      ShenandoahHeapLocker locker(heap->lock());
 
-      size_t old_region_surplus = heap->get_old_region_surplus();
-      size_t old_region_deficit = heap->get_old_region_deficit();
-      if (old_region_surplus) {
-        success = heap->generation_sizer()->transfer_to_young(old_region_surplus);
-        region_destination = "young";
-        region_xfer = old_region_surplus;
-      } else if (old_region_deficit) {
-        success = heap->generation_sizer()->transfer_to_old(old_region_deficit);
-        region_destination = "old";
-        region_xfer = old_region_deficit;
-        if (!success) {
-          ((ShenandoahOldHeuristics *) old_gen->heuristics())->trigger_cannot_expand();
-        }
-      } else {
-        region_destination = "none";
-        region_xfer = 0;
-        success = true;
-      }
-      heap->set_old_region_surplus(0);
-      heap->set_old_region_deficit(0);
-      heap->set_young_evac_reserve(0);
-      heap->set_old_evac_reserve(0);
-      heap->set_promoted_reserve(0);
+    ShenandoahGenerationalHeap::TransferResult result;
+    {
+      ShenandoahGenerationalHeap* gen_heap = ShenandoahGenerationalHeap::heap();
+      ShenandoahHeapLocker locker(gen_heap->lock());
+
+      result = gen_heap->balance_generations();
+      gen_heap->reset_generation_reserves();
     }
 
-    // Report outside the heap lock
-    size_t young_available = young_gen->available();
-    size_t old_available = old_gen->available();
-    log_info(gc, ergo)("After cleanup, %s " SIZE_FORMAT " regions to %s to prepare for next gc, old available: "
-                       SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
-                       success? "successfully transferred": "failed to transfer", region_xfer, region_destination,
-                       byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
+    LogTarget(Info, gc, ergo) lt;
+    if (lt.is_enabled()) {
+      LogStream ls(lt);
+      result.print_on("Concurrent GC", &ls);
+    }
   }
   return true;
 }
@@ -765,9 +740,7 @@ void ShenandoahConcurrentGC::op_final_mark() {
     heap->prepare_concurrent_roots();
 
     if (heap->mode()->is_generational()) {
-      size_t humongous_regions_promoted = heap->get_promotable_humongous_regions();
-      size_t regular_regions_promoted_in_place = heap->get_regular_regions_promoted_in_place();
-      if (!heap->collection_set()->is_empty() || (humongous_regions_promoted + regular_regions_promoted_in_place > 0)) {
+      if (!heap->collection_set()->is_empty() || heap->old_generation()->has_in_place_promotions()) {
         // Even if the collection set is empty, we need to do evacuation if there are regions to be promoted in place.
         // Concurrent evacuation takes responsibility for registering objects and setting the remembered set cards to dirty.
 
@@ -819,7 +792,7 @@ void ShenandoahConcurrentGC::op_final_mark() {
     } else {
       // Not is_generational()
       if (!heap->collection_set()->is_empty()) {
-        LogTarget(Info, gc, ergo) lt;
+        LogTarget(Debug, gc, ergo) lt;
         if (lt.is_enabled()) {
           ResourceMark rm;
           LogStream ls(lt);
@@ -959,10 +932,8 @@ void ShenandoahEvacUpdateCleanupOopStorageRootsClosure::do_oop(oop* p) {
       if (resolved == obj) {
         resolved = _heap->evacuate_object(obj, _thread);
       }
+      shenandoah_assert_not_in_cset_except(p, resolved, _heap->cancelled_gc());
       ShenandoahHeap::atomic_update_oop(resolved, p, obj);
-      assert(_heap->cancelled_gc() ||
-             _mark_context->is_marked(resolved) && !_heap->in_collection_set(resolved),
-             "Sanity");
     }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -60,6 +60,8 @@ public:
   ShenandoahConcurrentGC(ShenandoahGeneration* generation, bool do_old_gc_bootstrap);
   bool collect(GCCause::Cause cause);
   ShenandoahDegenPoint degen_point() const;
+
+  // Return true if this cycle found enough immediate garbage to skip evacuation
   bool abbreviated() const { return _abbreviated; }
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_SHENANDOAH_SHENANDOAHCONCURRENTMARK_HPP
 #define SHARE_GC_SHENANDOAH_SHENANDOAHCONCURRENTMARK_HPP
 
+#include "gc/shenandoah/shenandoahGenerationType.hpp"
 #include "gc/shenandoah/shenandoahMark.hpp"
 
 template <ShenandoahGenerationType GENERATION>

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
  * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
- * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,76 +28,36 @@
 #include "gc/shenandoah/shenandoahConcurrentGC.hpp"
 #include "gc/shenandoah/shenandoahControlThread.hpp"
 #include "gc/shenandoah/shenandoahDegeneratedGC.hpp"
-#include "gc/shenandoah/shenandoahEvacTracker.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
 #include "gc/shenandoah/shenandoahFullGC.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
-#include "gc/shenandoah/shenandoahGlobalGeneration.hpp"
-#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
-#include "gc/shenandoah/shenandoahOldGeneration.hpp"
-#include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
-#include "gc/shenandoah/shenandoahMark.inline.hpp"
 #include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
-#include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
-#include "gc/shenandoah/shenandoahOldGC.hpp"
-#include "gc/shenandoah/shenandoahRootProcessor.inline.hpp"
+#include "gc/shenandoah/shenandoahPacer.inline.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
-#include "gc/shenandoah/shenandoahVMOperations.hpp"
-#include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "gc/shenandoah/mode/shenandoahMode.hpp"
 #include "logging/log.hpp"
-#include "memory/iterator.hpp"
 #include "memory/metaspaceUtils.hpp"
 #include "memory/metaspaceStats.hpp"
-#include "memory/universe.hpp"
-#include "runtime/atomic.hpp"
 
 ShenandoahControlThread::ShenandoahControlThread() :
-  ConcurrentGCThread(),
-  _alloc_failure_waiters_lock(Mutex::safepoint - 2, "ShenandoahAllocFailureGC_lock", true),
-  _gc_waiters_lock(Mutex::safepoint - 2, "ShenandoahRequestedGC_lock", true),
-  _control_lock(Mutex::nosafepoint - 2, "ShenandoahControlGC_lock", true),
-  _regulator_lock(Mutex::nosafepoint - 2, "ShenandoahRegulatorGC_lock", true),
-  _periodic_task(this),
-  _requested_gc_cause(GCCause::_no_gc),
-  _requested_generation(select_global_generation()),
-  _degen_point(ShenandoahGC::_degenerated_outside_cycle),
-  _degen_generation(nullptr),
-  _allocs_seen(0),
-  _mode(none) {
+  ShenandoahController(),
+  _requested_gc_cause(GCCause::_no_cause_specified),
+  _degen_point(ShenandoahGC::_degenerated_outside_cycle) {
   set_name("Shenandoah Control Thread");
-  reset_gc_id();
   create_and_start();
-  _periodic_task.enroll();
-  if (ShenandoahPacing) {
-    _periodic_pacer_notify_task.enroll();
-  }
-}
-
-ShenandoahControlThread::~ShenandoahControlThread() {
-  // This is here so that super is called.
-}
-
-void ShenandoahPeriodicTask::task() {
-  _thread->handle_force_counters_update();
-  _thread->handle_counters_update();
-}
-
-void ShenandoahPeriodicPacerNotify::task() {
-  assert(ShenandoahPacing, "Should not be here otherwise");
-  ShenandoahHeap::heap()->pacer()->notify_waiters();
 }
 
 void ShenandoahControlThread::run_service() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
 
   const GCMode default_mode = concurrent_normal;
-  ShenandoahGenerationType generation = select_global_generation();
+  const GCCause::Cause default_cause = GCCause::_shenandoah_concurrent_gc;
+  int sleep = ShenandoahControlIntervalMin;
 
   double last_shrink_time = os::elapsedTime();
-  uint age_period = 0;
+  double last_sleep_adjust_time = os::elapsedTime();
 
   // Shrink period avoids constantly polling regions for shrinking.
   // Having a period 10x lower than the delay would mean we hit the
@@ -107,30 +66,22 @@ void ShenandoahControlThread::run_service() {
   const double shrink_period = (double)ShenandoahUncommitDelay / 1000 / 10;
 
   ShenandoahCollectorPolicy* const policy = heap->shenandoah_policy();
-
-  // Heuristics are notified of allocation failures here and other outcomes
-  // of the cycle. They're also used here to control whether the Nth consecutive
-  // degenerated cycle should be 'promoted' to a full cycle. The decision to
-  // trigger a cycle or not is evaluated on the regulator thread.
-  ShenandoahHeuristics* global_heuristics = heap->global_generation()->heuristics();
+  ShenandoahHeuristics* const heuristics = heap->heuristics();
   while (!in_graceful_shutdown() && !should_terminate()) {
     // Figure out if we have pending requests.
     const bool alloc_failure_pending = _alloc_failure_gc.is_set();
-    const bool humongous_alloc_failure_pending = _humongous_alloc_failure_gc.is_set();
+    const bool is_gc_requested = _gc_requested.is_set();
+    const GCCause::Cause requested_gc_cause = _requested_gc_cause;
 
-    GCCause::Cause cause = Atomic::xchg(&_requested_gc_cause, GCCause::_no_gc);
-
-    const bool explicit_gc_requested = is_explicit_gc(cause);
-    const bool implicit_gc_requested = is_implicit_gc(cause);
-
-    // This control loop iteration have seen this much allocations.
-    const size_t allocs_seen = Atomic::xchg(&_allocs_seen, (size_t)0, memory_order_relaxed);
+    // This control loop iteration has seen this much allocation.
+    const size_t allocs_seen = reset_allocs_seen();
 
     // Check if we have seen a new target for soft max heap size.
-    const bool soft_max_changed = check_soft_max_changed();
+    const bool soft_max_changed = heap->check_soft_max_changed();
 
     // Choose which GC mode to run in. The block below should select a single mode.
-    set_gc_mode(none);
+    GCMode mode = none;
+    GCCause::Cause cause = GCCause::_last_gc_cause;
     ShenandoahGC::ShenandoahDegenPoint degen_point = ShenandoahGC::_degenerated_unset;
 
     if (alloc_failure_pending) {
@@ -143,118 +94,48 @@ void ShenandoahControlThread::run_service() {
       degen_point = _degen_point;
       _degen_point = ShenandoahGC::_degenerated_outside_cycle;
 
-      if (degen_point == ShenandoahGC::_degenerated_outside_cycle) {
-        _degen_generation = heap->mode()->is_generational() ?
-                heap->young_generation() : heap->global_generation();
-      } else {
-        assert(_degen_generation != nullptr, "Need to know which generation to resume");
-      }
-
-      ShenandoahHeuristics* heuristics = _degen_generation->heuristics();
-      generation = _degen_generation->type();
-      bool old_gen_evacuation_failed = heap->clear_old_evacuation_failure();
-
-      // Do not bother with degenerated cycle if old generation evacuation failed or if humongous allocation failed
-      if (ShenandoahDegeneratedGC && heuristics->should_degenerate_cycle() &&
-          !old_gen_evacuation_failed && !humongous_alloc_failure_pending) {
+      if (ShenandoahDegeneratedGC && heuristics->should_degenerate_cycle()) {
         heuristics->record_allocation_failure_gc();
         policy->record_alloc_failure_to_degenerated(degen_point);
-        set_gc_mode(stw_degenerated);
+        mode = stw_degenerated;
       } else {
-        // TODO: if humongous_alloc_failure_pending, there might be value in trying a "compacting" degen before
-        // going all the way to full.  But it's a lot of work to implement this, and it may not provide value.
-        // A compacting degen can move young regions around without doing full old-gen mark (relying upon the
-        // remembered set scan), so it might be faster than a full gc.
-        //
-        // Longer term, think about how to defragment humongous memory concurrently.
-
         heuristics->record_allocation_failure_gc();
         policy->record_alloc_failure_to_full();
-        generation = select_global_generation();
-        set_gc_mode(stw_full);
+        mode = stw_full;
       }
-    } else if (explicit_gc_requested) {
-      generation = select_global_generation();
-      log_info(gc)("Trigger: Explicit GC request (%s)", GCCause::to_string(cause));
+    } else if (is_gc_requested) {
+      cause = requested_gc_cause;
+      log_info(gc)("Trigger: GC request (%s)", GCCause::to_string(cause));
+      heuristics->record_requested_gc();
 
-      global_heuristics->record_requested_gc();
-
-      if (ExplicitGCInvokesConcurrent) {
-        policy->record_explicit_to_concurrent();
-        set_gc_mode(default_mode);
-        // Unload and clean up everything
-        heap->set_unload_classes(global_heuristics->can_unload_classes());
+      if (ShenandoahCollectorPolicy::should_run_full_gc(cause)) {
+        mode = stw_full;
       } else {
-        policy->record_explicit_to_full();
-        set_gc_mode(stw_full);
-      }
-    } else if (implicit_gc_requested) {
-      generation = select_global_generation();
-      log_info(gc)("Trigger: Implicit GC request (%s)", GCCause::to_string(cause));
-
-      global_heuristics->record_requested_gc();
-
-      if (ShenandoahImplicitGCInvokesConcurrent) {
-        policy->record_implicit_to_concurrent();
-        set_gc_mode(default_mode);
-
+        mode = default_mode;
         // Unload and clean up everything
-        heap->set_unload_classes(global_heuristics->can_unload_classes());
-      } else {
-        policy->record_implicit_to_full();
-        set_gc_mode(stw_full);
+        heap->set_unload_classes(heuristics->can_unload_classes());
       }
     } else {
-      // We should only be here if the regulator requested a cycle or if
-      // there is an old generation mark in progress.
-      if (cause == GCCause::_shenandoah_concurrent_gc) {
-        if (_requested_generation == OLD && heap->doing_mixed_evacuations()) {
-          // If a request to start an old cycle arrived while an old cycle was running, but _before_
-          // it chose any regions for evacuation we don't want to start a new old cycle. Rather, we want
-          // the heuristic to run a young collection so that we can evacuate some old regions.
-          assert(!heap->is_concurrent_old_mark_in_progress(), "Should not be running mixed collections and concurrent marking");
-          generation = YOUNG;
-        } else {
-          generation = _requested_generation;
-        }
-
-        // preemption was requested or this is a regular cycle
-        set_gc_mode(default_mode);
-
-        // Don't start a new old marking if there is one already in progress
-        if (generation == OLD && heap->is_concurrent_old_mark_in_progress()) {
-          set_gc_mode(servicing_old);
-        }
-
-        if (generation == select_global_generation()) {
-          heap->set_unload_classes(global_heuristics->should_unload_classes());
-        } else {
-          heap->set_unload_classes(false);
-        }
-      } else if (heap->is_concurrent_old_mark_in_progress() || heap->is_prepare_for_old_mark_in_progress()) {
-        // Nobody asked us to do anything, but we have an old-generation mark or old-generation preparation for
-        // mixed evacuation in progress, so resume working on that.
-        log_info(gc)("Resume old GC: marking is%s in progress, preparing is%s in progress",
-                     heap->is_concurrent_old_mark_in_progress() ? "" : " NOT",
-                     heap->is_prepare_for_old_mark_in_progress() ? "" : " NOT");
-
-        cause = GCCause::_shenandoah_concurrent_gc;
-        generation = OLD;
-        set_gc_mode(servicing_old);
-        heap->set_unload_classes(false);
+      // Potential normal cycle: ask heuristics if it wants to act
+      if (heuristics->should_start_gc()) {
+        mode = default_mode;
+        cause = default_cause;
       }
+
+      // Ask policy if this cycle wants to process references or unload classes
+      heap->set_unload_classes(heuristics->should_unload_classes());
     }
 
-    const bool gc_requested = (gc_mode() != none);
-    assert (!gc_requested || cause != GCCause::_no_gc, "GC cause should be set");
+    // Blow all soft references on this cycle, if handling allocation failure,
+    // either implicit or explicit GC request,  or we are requested to do so unconditionally.
+    if (alloc_failure_pending || is_gc_requested || ShenandoahAlwaysClearSoftRefs) {
+      heap->soft_ref_policy()->set_should_clear_all_soft_refs(true);
+    }
+
+    const bool gc_requested = (mode != none);
+    assert (!gc_requested || cause != GCCause::_last_gc_cause, "GC cause should be set");
 
     if (gc_requested) {
-      // Blow away all soft references on this cycle, if handling allocation failure,
-      // either implicit or explicit GC request, or we are requested to do so unconditionally.
-      if (generation == select_global_generation() && (alloc_failure_pending || implicit_gc_requested || explicit_gc_requested || ShenandoahAlwaysClearSoftRefs)) {
-        heap->soft_ref_policy()->set_should_clear_all_soft_refs(true);
-      }
-
       // GC is starting, bump the internal ID
       update_gc_id();
 
@@ -264,56 +145,30 @@ void ShenandoahControlThread::run_service() {
 
       // If GC was requested, we are sampling the counters even without actual triggers
       // from allocation machinery. This captures GC phases more accurately.
-      set_forced_counters_update(true);
+      heap->set_forced_counters_update(true);
 
       // If GC was requested, we better dump freeset data for performance debugging
       {
         ShenandoahHeapLocker locker(heap->lock());
         heap->free_set()->log_status();
       }
-      // In case this is a degenerated cycle, remember whether original cycle was aging.
-      const bool was_aging_cycle = heap->is_aging_cycle();
-      heap->set_aging_cycle(false);
 
-      switch (gc_mode()) {
-        case concurrent_normal: {
-          // At this point:
-          //  if (generation == YOUNG), this is a normal YOUNG cycle
-          //  if (generation == OLD), this is a bootstrap OLD cycle
-          //  if (generation == GLOBAL), this is a GLOBAL cycle triggered by System.gc()
-          // In all three cases, we want to age old objects if this is an aging cycle
-          if (age_period-- == 0) {
-             heap->set_aging_cycle(true);
-             age_period = ShenandoahAgingCyclePeriod - 1;
-          }
-          service_concurrent_normal_cycle(heap, generation, cause);
+      switch (mode) {
+        case concurrent_normal:
+          service_concurrent_normal_cycle(cause);
           break;
-        }
-        case stw_degenerated: {
-          heap->set_aging_cycle(was_aging_cycle);
+        case stw_degenerated:
           service_stw_degenerated_cycle(cause, degen_point);
           break;
-        }
-        case stw_full: {
-          if (age_period-- == 0) {
-            heap->set_aging_cycle(true);
-            age_period = ShenandoahAgingCyclePeriod - 1;
-          }
+        case stw_full:
           service_stw_full_cycle(cause);
           break;
-        }
-        case servicing_old: {
-          assert(generation == OLD, "Expected old generation here");
-          GCIdMark gc_id_mark;
-          service_concurrent_old_cycle(heap, cause);
-          break;
-        }
         default:
           ShouldNotReachHere();
       }
 
       // If this was the requested GC cycle, notify waiters about it
-      if (explicit_gc_requested || implicit_gc_requested) {
+      if (is_gc_requested) {
         notify_gc_waiters();
       }
 
@@ -331,26 +186,46 @@ void ShenandoahControlThread::run_service() {
         // Notify Universe about new heap usage. This has implications for
         // global soft refs policy, and we better report it every time heap
         // usage goes down.
-        Universe::heap()->update_capacity_and_used_at_gc();
+        heap->update_capacity_and_used_at_gc();
 
         // Signal that we have completed a visit to all live objects.
-        Universe::heap()->record_whole_heap_examined_timestamp();
+        heap->record_whole_heap_examined_timestamp();
       }
 
       // Disable forced counters update, and update counters one more time
       // to capture the state at the end of GC session.
-      handle_force_counters_update();
-      set_forced_counters_update(false);
+      heap->handle_force_counters_update();
+      heap->set_forced_counters_update(false);
 
       // Retract forceful part of soft refs policy
       heap->soft_ref_policy()->set_should_clear_all_soft_refs(false);
 
       // Clear metaspace oom flag, if current cycle unloaded classes
       if (heap->unload_classes()) {
-        global_heuristics->clear_metaspace_oom();
+        heuristics->clear_metaspace_oom();
       }
 
-      process_phase_timings(heap);
+      // Commit worker statistics to cycle data
+      heap->phase_timings()->flush_par_workers_to_cycle();
+      if (ShenandoahPacing) {
+        heap->pacer()->flush_stats_to_cycle();
+      }
+
+      // Print GC stats for current cycle
+      {
+        LogTarget(Info, gc, stats) lt;
+        if (lt.is_enabled()) {
+          ResourceMark rm;
+          LogStream ls(lt);
+          heap->phase_timings()->print_cycle_on(&ls);
+          if (ShenandoahPacing) {
+            heap->pacer()->print_cycle_on(&ls);
+          }
+        }
+      }
+
+      // Commit statistics to globals
+      heap->phase_timings()->flush_cycle_to_global();
 
       // Print Metaspace change following GC (if logging is enabled).
       MetaspaceUtils::print_metaspace_change(meta_sizes);
@@ -360,20 +235,20 @@ void ShenandoahControlThread::run_service() {
         heap->pacer()->setup_for_idle();
       }
     } else {
-      // Allow pacer to know we have seen this many allocations
+      // Report to pacer that we have seen this many words allocated
       if (ShenandoahPacing && (allocs_seen > 0)) {
         heap->pacer()->report_alloc(allocs_seen);
       }
     }
 
-    double current = os::elapsedTime();
+    const double current = os::elapsedTime();
 
-    if (ShenandoahUncommit && (explicit_gc_requested || soft_max_changed || (current - last_shrink_time > shrink_period))) {
+    if (ShenandoahUncommit && (is_gc_requested || soft_max_changed || (current - last_shrink_time > shrink_period))) {
       // Explicit GC tries to uncommit everything down to min capacity.
       // Soft max change tries to uncommit everything down to target capacity.
       // Periodic uncommit tries to uncommit suitable regions down to min capacity.
 
-      double shrink_before = (explicit_gc_requested || soft_max_changed) ?
+      double shrink_before = (is_gc_requested || soft_max_changed) ?
                              current :
                              current - (ShenandoahUncommitDelay / 1000.0);
 
@@ -381,18 +256,21 @@ void ShenandoahControlThread::run_service() {
                              heap->soft_max_capacity() :
                              heap->min_capacity();
 
-      service_uncommit(shrink_before, shrink_until);
+      heap->maybe_uncommit(shrink_before, shrink_until);
       heap->phase_timings()->flush_cycle_to_global();
       last_shrink_time = current;
     }
 
-    // Wait for ShenandoahControlIntervalMax unless there was an allocation failure or another request was made mid-cycle.
-    if (!is_alloc_failure_gc() && _requested_gc_cause == GCCause::_no_gc) {
-      // The timed wait is necessary because this thread has a responsibility to send
-      // 'alloc_words' to the pacer when it does not perform a GC.
-      MonitorLocker lock(&_control_lock, Mutex::_no_safepoint_check_flag);
-      lock.wait(ShenandoahControlIntervalMax);
+    // Wait before performing the next action. If allocation happened during this wait,
+    // we exit sooner, to let heuristics re-evaluate new conditions. If we are at idle,
+    // back off exponentially.
+    if (heap->has_changed()) {
+      sleep = ShenandoahControlIntervalMin;
+    } else if ((current - last_sleep_adjust_time) * 1000 > ShenandoahControlIntervalAdjustPeriod){
+      sleep = MIN2<int>(ShenandoahControlIntervalMax, MAX2(1, sleep * 2));
+      last_sleep_adjust_time = current;
     }
+    os::naked_short_sleep(sleep);
   }
 
   // Wait for the actual stop(), can't leave run_service() earlier.
@@ -401,232 +279,7 @@ void ShenandoahControlThread::run_service() {
   }
 }
 
-void ShenandoahControlThread::process_phase_timings(const ShenandoahHeap* heap) {
-  // Commit worker statistics to cycle data
-  heap->phase_timings()->flush_par_workers_to_cycle();
-  if (ShenandoahPacing) {
-    heap->pacer()->flush_stats_to_cycle();
-  }
-
-  ShenandoahEvacuationTracker* evac_tracker = heap->evac_tracker();
-  ShenandoahCycleStats         evac_stats   = evac_tracker->flush_cycle_to_global();
-
-  // Print GC stats for current cycle
-  {
-    LogTarget(Info, gc, stats) lt;
-    if (lt.is_enabled()) {
-      ResourceMark rm;
-      LogStream ls(lt);
-      heap->phase_timings()->print_cycle_on(&ls);
-      evac_tracker->print_evacuations_on(&ls, &evac_stats.workers,
-                                              &evac_stats.mutators);
-      if (ShenandoahPacing) {
-        heap->pacer()->print_cycle_on(&ls);
-      }
-    }
-  }
-
-  // Commit statistics to globals
-  heap->phase_timings()->flush_cycle_to_global();
-}
-
-// Young and old concurrent cycles are initiated by the regulator. Implicit
-// and explicit GC requests are handled by the controller thread and always
-// run a global cycle (which is concurrent by default, but may be overridden
-// by command line options). Old cycles always degenerate to a global cycle.
-// Young cycles are degenerated to complete the young cycle.  Young
-// and old degen may upgrade to Full GC.  Full GC may also be
-// triggered directly by a System.gc() invocation.
-//
-//
-//      +-----+ Idle +-----+-----------+---------------------+
-//      |         +        |           |                     |
-//      |         |        |           |                     |
-//      |         |        v           |                     |
-//      |         |  Bootstrap Old +-- | ------------+       |
-//      |         |   +                |             |       |
-//      |         |   |                |             |       |
-//      |         v   v                v             v       |
-//      |    Resume Old <----------+ Young +--> Young Degen  |
-//      |     +  +   ^                            +  +       |
-//      v     |  |   |                            |  |       |
-//   Global <-+  |   +----------------------------+  |       |
-//      +        |                                   |       |
-//      |        v                                   v       |
-//      +--->  Global Degen +--------------------> Full <----+
-//
-void ShenandoahControlThread::service_concurrent_normal_cycle(ShenandoahHeap* heap,
-                                                              const ShenandoahGenerationType generation,
-                                                              GCCause::Cause cause) {
-  GCIdMark gc_id_mark;
-  ShenandoahGeneration* the_generation = nullptr;
-  switch (generation) {
-    case YOUNG: {
-      // Run a young cycle. This might or might not, have interrupted an ongoing
-      // concurrent mark in the old generation. We need to think about promotions
-      // in this case. Promoted objects should be above the TAMS in the old regions
-      // they end up in, but we have to be sure we don't promote into any regions
-      // that are in the cset.
-      log_info(gc, ergo)("Start GC cycle (YOUNG)");
-      the_generation = heap->young_generation();
-      service_concurrent_cycle(the_generation, cause, false);
-      break;
-    }
-    case OLD: {
-      log_info(gc, ergo)("Start GC cycle (OLD)");
-      the_generation = heap->old_generation();
-      service_concurrent_old_cycle(heap, cause);
-      break;
-    }
-    case GLOBAL_GEN: {
-      log_info(gc, ergo)("Start GC cycle (GLOBAL)");
-      the_generation = heap->global_generation();
-      service_concurrent_cycle(the_generation, cause, false);
-      break;
-    }
-    case GLOBAL_NON_GEN: {
-      log_info(gc, ergo)("Start GC cycle");
-      the_generation = heap->global_generation();
-      service_concurrent_cycle(the_generation, cause, false);
-      break;
-    }
-    default:
-      ShouldNotReachHere();
-  }
-}
-
-void ShenandoahControlThread::service_concurrent_old_cycle(ShenandoahHeap* heap, GCCause::Cause &cause) {
-  ShenandoahOldGeneration* old_generation = heap->old_generation();
-  ShenandoahYoungGeneration* young_generation = heap->young_generation();
-  ShenandoahOldGeneration::State original_state = old_generation->state();
-
-  TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
-
-  switch (original_state) {
-    case ShenandoahOldGeneration::FILLING: {
-      _allow_old_preemption.set();
-      old_generation->entry_coalesce_and_fill();
-      _allow_old_preemption.unset();
-
-      // Before bootstrapping begins, we must acknowledge any cancellation request.
-      // If the gc has not been cancelled, this does nothing. If it has been cancelled,
-      // this will clear the cancellation request and exit before starting the bootstrap
-      // phase. This will allow the young GC cycle to proceed normally. If we do not
-      // acknowledge the cancellation request, the subsequent young cycle will observe
-      // the request and essentially cancel itself.
-      if (check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle)) {
-        log_info(gc)("Preparation for old generation cycle was cancelled");
-        return;
-      }
-
-      // Coalescing threads completed and nothing was cancelled. it is safe to transition from this state.
-      old_generation->transition_to(ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP);
-      return;
-    }
-    case ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP:
-      old_generation->transition_to(ShenandoahOldGeneration::BOOTSTRAPPING);
-    case ShenandoahOldGeneration::BOOTSTRAPPING: {
-      // Configure the young generation's concurrent mark to put objects in
-      // old regions into the concurrent mark queues associated with the old
-      // generation. The young cycle will run as normal except that rather than
-      // ignore old references it will mark and enqueue them in the old concurrent
-      // task queues but it will not traverse them.
-      set_gc_mode(bootstrapping_old);
-      young_generation->set_old_gen_task_queues(old_generation->task_queues());
-      ShenandoahGCSession session(cause, young_generation);
-      service_concurrent_cycle(heap, young_generation, cause, true);
-      process_phase_timings(heap);
-      if (heap->cancelled_gc()) {
-        // Young generation bootstrap cycle has failed. Concurrent mark for old generation
-        // is going to resume after degenerated bootstrap cycle completes.
-        log_info(gc)("Bootstrap cycle for old generation was cancelled");
-        return;
-      }
-
-      // Reset the degenerated point. Normally this would happen at the top
-      // of the control loop, but here we have just completed a young cycle
-      // which has bootstrapped the old concurrent marking.
-      _degen_point = ShenandoahGC::_degenerated_outside_cycle;
-
-      // From here we will 'resume' the old concurrent mark. This will skip reset
-      // and init mark for the concurrent mark. All of that work will have been
-      // done by the bootstrapping young cycle.
-      set_gc_mode(servicing_old);
-      old_generation->transition_to(ShenandoahOldGeneration::MARKING);
-    }
-    case ShenandoahOldGeneration::MARKING: {
-      ShenandoahGCSession session(cause, old_generation);
-      bool marking_complete = resume_concurrent_old_cycle(old_generation, cause);
-      if (marking_complete) {
-        assert(old_generation->state() != ShenandoahOldGeneration::MARKING, "Should not still be marking");
-        if (original_state == ShenandoahOldGeneration::MARKING) {
-          heap->mmu_tracker()->record_old_marking_increment(true);
-          heap->log_heap_status("At end of Concurrent Old Marking finishing increment");
-        }
-      } else if (original_state == ShenandoahOldGeneration::MARKING) {
-        heap->mmu_tracker()->record_old_marking_increment(false);
-        heap->log_heap_status("At end of Concurrent Old Marking increment");
-      }
-      break;
-    }
-    default:
-      fatal("Unexpected state for old GC: %s", ShenandoahOldGeneration::state_name(old_generation->state()));
-  }
-}
-
-bool ShenandoahControlThread::resume_concurrent_old_cycle(ShenandoahGeneration* generation, GCCause::Cause cause) {
-  assert(ShenandoahHeap::heap()->is_concurrent_old_mark_in_progress(), "Old mark should be in progress");
-  log_debug(gc)("Resuming old generation with " UINT32_FORMAT " marking tasks queued", generation->task_queues()->tasks());
-
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-
-  // We can only tolerate being cancelled during concurrent marking or during preparation for mixed
-  // evacuation. This flag here (passed by reference) is used to control precisely where the regulator
-  // is allowed to cancel a GC.
-  ShenandoahOldGC gc(generation, _allow_old_preemption);
-  if (gc.collect(cause)) {
-    generation->record_success_concurrent(false);
-  }
-
-  if (heap->cancelled_gc()) {
-    // It's possible the gc cycle was cancelled after the last time
-    // the collection checked for cancellation. In which case, the
-    // old gc cycle is still completed, and we have to deal with this
-    // cancellation. We set the degeneration point to be outside
-    // the cycle because if this is an allocation failure, that is
-    // what must be done (there is no degenerated old cycle). If the
-    // cancellation was due to a heuristic wanting to start a young
-    // cycle, then we are not actually going to a degenerated cycle,
-    // so the degenerated point doesn't matter here.
-    check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle);
-    if (_requested_gc_cause == GCCause::_shenandoah_concurrent_gc) {
-      heap->shenandoah_policy()->record_interrupted_old();
-    }
-    return false;
-  }
-  return true;
-}
-
-bool ShenandoahControlThread::check_soft_max_changed() const {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  size_t new_soft_max = Atomic::load(&SoftMaxHeapSize);
-  size_t old_soft_max = heap->soft_max_capacity();
-  if (new_soft_max != old_soft_max) {
-    new_soft_max = MAX2(heap->min_capacity(), new_soft_max);
-    new_soft_max = MIN2(heap->max_capacity(), new_soft_max);
-    if (new_soft_max != old_soft_max) {
-      log_info(gc)("Soft Max Heap Size: " SIZE_FORMAT "%s -> " SIZE_FORMAT "%s",
-                   byte_size_in_proper_unit(old_soft_max), proper_unit_for_byte_size(old_soft_max),
-                   byte_size_in_proper_unit(new_soft_max), proper_unit_for_byte_size(new_soft_max)
-      );
-      heap->set_soft_max_capacity(new_soft_max);
-      return true;
-    }
-  }
-  return false;
-}
-
-void ShenandoahControlThread::service_concurrent_cycle(ShenandoahGeneration* generation, GCCause::Cause cause, bool do_old_gc_bootstrap) {
+void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cause) {
   // Normal cycle goes via all concurrent phases. If allocation failure (af) happens during
   // any of the concurrent phases, it first degrades to Degenerated GC and completes GC there.
   // If second allocation failure happens during Degenerated GC cycle (for example, when GC
@@ -662,102 +315,38 @@ void ShenandoahControlThread::service_concurrent_cycle(ShenandoahGeneration* gen
   //                                        v                                |
   //                                      Full GC  --------------------------/
   //
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle)) return;
 
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  ShenandoahGCSession session(cause, generation);
+  GCIdMark gc_id_mark;
+  ShenandoahGCSession session(cause, heap->global_generation());
+
   TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
 
-  service_concurrent_cycle(heap, generation, cause, do_old_gc_bootstrap);
-}
-
-void ShenandoahControlThread::service_concurrent_cycle(ShenandoahHeap* heap,
-                                                       ShenandoahGeneration* generation,
-                                                       GCCause::Cause& cause,
-                                                       bool do_old_gc_bootstrap) {
-  ShenandoahConcurrentGC gc(generation, do_old_gc_bootstrap);
+  ShenandoahConcurrentGC gc(heap->global_generation(), false);
   if (gc.collect(cause)) {
     // Cycle is complete
-    generation->record_success_concurrent(gc.abbreviated());
+    heap->global_generation()->heuristics()->record_success_concurrent(gc.abbreviated());
+    heap->shenandoah_policy()->record_success_concurrent(false, gc.abbreviated());
+    heap->log_heap_status("At end of GC");
   } else {
     assert(heap->cancelled_gc(), "Must have been cancelled");
     check_cancellation_or_degen(gc.degen_point());
-    assert(!generation->is_old(), "Old GC takes a different control path");
-    // Concurrent young-gen collection degenerates to young
-    // collection.  Same for global collections.
-    _degen_generation = generation;
+    heap->log_heap_status("At end of cancelled GC");
   }
-  const char* msg;
-  if (heap->mode()->is_generational()) {
-    ShenandoahMmuTracker* mmu_tracker = heap->mmu_tracker();
-    if (generation->is_young()) {
-      if (heap->cancelled_gc()) {
-        msg = (do_old_gc_bootstrap) ? "At end of Interrupted Concurrent Bootstrap GC":
-                                      "At end of Interrupted Concurrent Young GC";
-      } else {
-        // We only record GC results if GC was successful
-        msg = (do_old_gc_bootstrap) ? "At end of Concurrent Bootstrap GC":
-                                      "At end of Concurrent Young GC";
-        if (heap->collection_set()->has_old_regions()) {
-          mmu_tracker->record_mixed(get_gc_id());
-        } else if (do_old_gc_bootstrap) {
-          mmu_tracker->record_bootstrap(get_gc_id());
-        } else {
-          mmu_tracker->record_young(get_gc_id());
-        }
-      }
-    } else {
-      assert(generation->is_global(), "If not young, must be GLOBAL");
-      assert(!do_old_gc_bootstrap, "Do not bootstrap with GLOBAL GC");
-      if (heap->cancelled_gc()) {
-        msg = "At end of Interrupted Concurrent GLOBAL GC";
-      } else {
-        // We only record GC results if GC was successful
-        msg = "At end of Concurrent Global GC";
-        mmu_tracker->record_global(get_gc_id());
-      }
-    }
-  } else {
-    msg = heap->cancelled_gc() ? "At end of cancelled GC" :
-                                 "At end of GC";
-  }
-  heap->log_heap_status(msg);
 }
 
 bool ShenandoahControlThread::check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint point) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (!heap->cancelled_gc()) {
-    return false;
-  }
-
-  if (in_graceful_shutdown()) {
+  if (heap->cancelled_gc()) {
+    assert (is_alloc_failure_gc() || in_graceful_shutdown(), "Cancel GC either for alloc failure GC, or gracefully exiting");
+    if (!in_graceful_shutdown()) {
+      assert (_degen_point == ShenandoahGC::_degenerated_outside_cycle,
+              "Should not be set yet: %s", ShenandoahGC::degen_point_to_string(_degen_point));
+      _degen_point = point;
+    }
     return true;
   }
-
-  assert(_degen_point == ShenandoahGC::_degenerated_outside_cycle,
-         "Should not be set yet: %s", ShenandoahGC::degen_point_to_string(_degen_point));
-
-  if (is_alloc_failure_gc()) {
-    _degen_point = point;
-    _preemption_requested.unset();
-    return true;
-  }
-
-  if (_preemption_requested.is_set()) {
-    assert(_requested_generation == YOUNG, "Only young GCs may preempt old.");
-    _preemption_requested.unset();
-
-    // Old generation marking is only cancellable during concurrent marking.
-    // Once final mark is complete, the code does not check again for cancellation.
-    // If old generation was cancelled for an allocation failure, we wouldn't
-    // make it to this case. The calling code is responsible for forcing a
-    // cancellation due to allocation failure into a degenerated cycle.
-    _degen_point = point;
-    heap->clear_cancelled_gc(false /* clear oom handler */);
-    return true;
-  }
-
-  fatal("Cancel GC either for alloc failure GC, or gracefully exiting, or to pause old generation marking");
   return false;
 }
 
@@ -767,7 +356,6 @@ void ShenandoahControlThread::stop_service() {
 
 void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-
   GCIdMark gc_id_mark;
   ShenandoahGCSession session(cause, heap->global_generation());
 
@@ -775,147 +363,20 @@ void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   gc.collect(cause);
 }
 
-void ShenandoahControlThread::service_stw_degenerated_cycle(GCCause::Cause cause,
-                                                            ShenandoahGC::ShenandoahDegenPoint point) {
-  assert(point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
+void ShenandoahControlThread::service_stw_degenerated_cycle(GCCause::Cause cause, ShenandoahGC::ShenandoahDegenPoint point) {
+  assert (point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-
   GCIdMark gc_id_mark;
-  ShenandoahGCSession session(cause, _degen_generation);
+  ShenandoahGCSession session(cause, heap->global_generation());
 
-  ShenandoahDegenGC gc(point, _degen_generation);
+  ShenandoahDegenGC gc(point, heap->global_generation());
   gc.collect(cause);
-
-  assert(heap->young_generation()->task_queues()->is_empty(), "Unexpected young generation marking tasks");
-  if (_degen_generation->is_global()) {
-    assert(heap->old_generation()->task_queues()->is_empty(), "Unexpected old generation marking tasks");
-    assert(heap->global_generation()->task_queues()->is_empty(), "Unexpected global generation marking tasks");
-  } else {
-    assert(_degen_generation->is_young(), "Expected degenerated young cycle, if not global.");
-    ShenandoahOldGeneration* old = heap->old_generation();
-    if (old->state() == ShenandoahOldGeneration::BOOTSTRAPPING) {
-      old->transition_to(ShenandoahOldGeneration::MARKING);
-    }
-  }
-}
-
-void ShenandoahControlThread::service_uncommit(double shrink_before, size_t shrink_until) {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-
-  // Determine if there is work to do. This avoids taking heap lock if there is
-  // no work available, avoids spamming logs with superfluous logging messages,
-  // and minimises the amount of work while locks are taken.
-
-  if (heap->committed() <= shrink_until) return;
-
-  bool has_work = false;
-  for (size_t i = 0; i < heap->num_regions(); i++) {
-    ShenandoahHeapRegion *r = heap->get_region(i);
-    if (r->is_empty_committed() && (r->empty_time() < shrink_before)) {
-      has_work = true;
-      break;
-    }
-  }
-
-  if (has_work) {
-    heap->entry_uncommit(shrink_before, shrink_until);
-  }
-}
-
-bool ShenandoahControlThread::is_explicit_gc(GCCause::Cause cause) const {
-  return GCCause::is_user_requested_gc(cause) ||
-         GCCause::is_serviceability_requested_gc(cause);
-}
-
-bool ShenandoahControlThread::is_implicit_gc(GCCause::Cause cause) const {
-  return !is_explicit_gc(cause)
-      && cause != GCCause::_shenandoah_concurrent_gc
-      && cause != GCCause::_no_gc;
 }
 
 void ShenandoahControlThread::request_gc(GCCause::Cause cause) {
-  assert(GCCause::is_user_requested_gc(cause) ||
-         GCCause::is_serviceability_requested_gc(cause) ||
-         cause == GCCause::_metadata_GC_clear_soft_refs ||
-         cause == GCCause::_codecache_GC_aggressive ||
-         cause == GCCause::_codecache_GC_threshold ||
-         cause == GCCause::_full_gc_alot ||
-         cause == GCCause::_wb_young_gc ||
-         cause == GCCause::_wb_full_gc ||
-         cause == GCCause::_wb_breakpoint ||
-         cause == GCCause::_scavenge_alot,
-         "only requested GCs here: %s", GCCause::to_string(cause));
-
-  if (is_explicit_gc(cause)) {
-    if (!DisableExplicitGC) {
-      handle_requested_gc(cause);
-    }
-  } else {
+  if (ShenandoahCollectorPolicy::should_handle_requested_gc(cause)) {
     handle_requested_gc(cause);
   }
-}
-
-bool ShenandoahControlThread::request_concurrent_gc(ShenandoahGenerationType generation) {
-  if (_preemption_requested.is_set() || _requested_gc_cause != GCCause::_no_gc || ShenandoahHeap::heap()->cancelled_gc()) {
-    // Ignore subsequent requests from the heuristics
-    log_debug(gc, thread)("Reject request for concurrent gc: preemption_requested: %s, gc_requested: %s, gc_cancelled: %s",
-                          BOOL_TO_STR(_preemption_requested.is_set()),
-                          GCCause::to_string(_requested_gc_cause),
-                          BOOL_TO_STR(ShenandoahHeap::heap()->cancelled_gc()));
-    return false;
-  }
-
-  if (gc_mode() == none) {
-    GCCause::Cause existing = Atomic::cmpxchg(&_requested_gc_cause, GCCause::_no_gc, GCCause::_shenandoah_concurrent_gc);
-    if (existing != GCCause::_no_gc) {
-      log_debug(gc, thread)("Reject request for concurrent gc because another gc is pending: %s", GCCause::to_string(existing));
-      return false;
-    }
-
-    _requested_generation = generation;
-    notify_control_thread();
-
-    MonitorLocker ml(&_regulator_lock, Mutex::_no_safepoint_check_flag);
-    while (gc_mode() == none) {
-      ml.wait();
-    }
-    return true;
-  }
-
-  if (preempt_old_marking(generation)) {
-    assert(gc_mode() == servicing_old, "Expected to be servicing old, but was: %s.", gc_mode_name(gc_mode()));
-    GCCause::Cause existing = Atomic::cmpxchg(&_requested_gc_cause, GCCause::_no_gc, GCCause::_shenandoah_concurrent_gc);
-    if (existing != GCCause::_no_gc) {
-      log_debug(gc, thread)("Reject request to interrupt old gc because another gc is pending: %s", GCCause::to_string(existing));
-      return false;
-    }
-
-    log_info(gc)("Preempting old generation mark to allow %s GC", shenandoah_generation_name(generation));
-    _requested_generation = generation;
-    _preemption_requested.set();
-    ShenandoahHeap::heap()->cancel_gc(GCCause::_shenandoah_concurrent_gc);
-    notify_control_thread();
-
-    MonitorLocker ml(&_regulator_lock, Mutex::_no_safepoint_check_flag);
-    while (gc_mode() == servicing_old) {
-      ml.wait();
-    }
-    return true;
-  }
-
-  log_debug(gc, thread)("Reject request for concurrent gc: mode: %s, allow_old_preemption: %s",
-                        gc_mode_name(gc_mode()),
-                        BOOL_TO_STR(_allow_old_preemption.is_set()));
-  return false;
-}
-
-void ShenandoahControlThread::notify_control_thread() {
-  MonitorLocker locker(&_control_lock, Mutex::_no_safepoint_check_flag);
-  _control_lock.notify();
-}
-
-bool ShenandoahControlThread::preempt_old_marking(ShenandoahGenerationType generation) {
-  return (generation == YOUNG) && _allow_old_preemption.try_unset();
 }
 
 void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {
@@ -932,15 +393,12 @@ void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {
   size_t current_gc_id = get_gc_id();
   size_t required_gc_id = current_gc_id + 1;
   while (current_gc_id < required_gc_id) {
-    // This races with the regulator thread to start a concurrent gc and the
-    // control thread to clear it at the start of a cycle. Threads here are
-    // allowed to escalate a heuristic's request for concurrent gc.
-    GCCause::Cause existing = Atomic::xchg(&_requested_gc_cause, cause);
-    if (existing != GCCause::_no_gc) {
-      log_debug(gc, thread)("GC request supersedes existing request: %s", GCCause::to_string(existing));
-    }
+    // Although setting gc request is under _gc_waiters_lock, but read side (run_service())
+    // does not take the lock. We need to enforce following order, so that read side sees
+    // latest requested gc cause when the flag is set.
+    _requested_gc_cause = cause;
+    _gc_requested.set();
 
-    notify_control_thread();
     if (cause != GCCause::_wb_breakpoint) {
       ml.wait();
     }
@@ -948,146 +406,8 @@ void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {
   }
 }
 
-void ShenandoahControlThread::handle_alloc_failure(ShenandoahAllocRequest& req) {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-
-  assert(current()->is_Java_thread(), "expect Java thread here");
-  bool is_humongous = req.size() > ShenandoahHeapRegion::region_size_words();
-
-  if (try_set_alloc_failure_gc(is_humongous)) {
-    // Only report the first allocation failure
-    log_info(gc)("Failed to allocate %s, " SIZE_FORMAT "%s",
-                 req.type_string(),
-                 byte_size_in_proper_unit(req.size() * HeapWordSize), proper_unit_for_byte_size(req.size() * HeapWordSize));
-    // Now that alloc failure GC is scheduled, we can abort everything else
-    heap->cancel_gc(GCCause::_allocation_failure);
-  }
-
-  MonitorLocker ml(&_alloc_failure_waiters_lock);
-  while (is_alloc_failure_gc()) {
-    ml.wait();
-  }
-}
-
-void ShenandoahControlThread::handle_alloc_failure_evac(size_t words) {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  bool is_humongous = (words > ShenandoahHeapRegion::region_size_words());
-
-  if (try_set_alloc_failure_gc(is_humongous)) {
-    // Only report the first allocation failure
-    log_info(gc)("Failed to allocate " SIZE_FORMAT "%s for evacuation",
-                 byte_size_in_proper_unit(words * HeapWordSize), proper_unit_for_byte_size(words * HeapWordSize));
-  }
-
-  // Forcefully report allocation failure
-  heap->cancel_gc(GCCause::_shenandoah_allocation_failure_evac);
-}
-
-void ShenandoahControlThread::notify_alloc_failure_waiters() {
-  _alloc_failure_gc.unset();
-  _humongous_alloc_failure_gc.unset();
-  MonitorLocker ml(&_alloc_failure_waiters_lock);
-  ml.notify_all();
-}
-
-bool ShenandoahControlThread::try_set_alloc_failure_gc(bool is_humongous) {
-  if (is_humongous) {
-    _humongous_alloc_failure_gc.try_set();
-  }
-  return _alloc_failure_gc.try_set();
-}
-
-bool ShenandoahControlThread::is_alloc_failure_gc() {
-  return _alloc_failure_gc.is_set();
-}
-
 void ShenandoahControlThread::notify_gc_waiters() {
+  _gc_requested.unset();
   MonitorLocker ml(&_gc_waiters_lock);
   ml.notify_all();
-}
-
-void ShenandoahControlThread::handle_counters_update() {
-  if (_do_counters_update.is_set()) {
-    _do_counters_update.unset();
-    ShenandoahHeap::heap()->monitoring_support()->update_counters();
-  }
-}
-
-void ShenandoahControlThread::handle_force_counters_update() {
-  if (_force_counters_update.is_set()) {
-    _do_counters_update.unset(); // reset these too, we do update now!
-    ShenandoahHeap::heap()->monitoring_support()->update_counters();
-  }
-}
-
-void ShenandoahControlThread::notify_heap_changed() {
-  // This is called from allocation path, and thus should be fast.
-
-  // Update monitoring counters when we took a new region. This amortizes the
-  // update costs on slow path.
-  if (_do_counters_update.is_unset()) {
-    _do_counters_update.set();
-  }
-}
-
-void ShenandoahControlThread::pacing_notify_alloc(size_t words) {
-  assert(ShenandoahPacing, "should only call when pacing is enabled");
-  Atomic::add(&_allocs_seen, words, memory_order_relaxed);
-}
-
-void ShenandoahControlThread::set_forced_counters_update(bool value) {
-  _force_counters_update.set_cond(value);
-}
-
-void ShenandoahControlThread::reset_gc_id() {
-  Atomic::store(&_gc_id, (size_t)0);
-}
-
-void ShenandoahControlThread::update_gc_id() {
-  Atomic::inc(&_gc_id);
-}
-
-size_t ShenandoahControlThread::get_gc_id() {
-  return Atomic::load(&_gc_id);
-}
-
-void ShenandoahControlThread::start() {
-  create_and_start();
-}
-
-void ShenandoahControlThread::prepare_for_graceful_shutdown() {
-  _graceful_shutdown.set();
-}
-
-bool ShenandoahControlThread::in_graceful_shutdown() {
-  return _graceful_shutdown.is_set();
-}
-
-const char* ShenandoahControlThread::gc_mode_name(ShenandoahControlThread::GCMode mode) {
-  switch (mode) {
-    case none:              return "idle";
-    case concurrent_normal: return "normal";
-    case stw_degenerated:   return "degenerated";
-    case stw_full:          return "full";
-    case servicing_old:     return "old";
-    case bootstrapping_old: return "bootstrap";
-    default:                return "unknown";
-  }
-}
-
-void ShenandoahControlThread::set_gc_mode(ShenandoahControlThread::GCMode new_mode) {
-  if (_mode != new_mode) {
-    log_info(gc)("Transition from: %s to: %s", gc_mode_name(_mode), gc_mode_name(new_mode));
-    MonitorLocker ml(&_regulator_lock, Mutex::_no_safepoint_check_flag);
-    _mode = new_mode;
-    ml.notify_all();
-  }
-}
-
-ShenandoahGenerationType ShenandoahControlThread::select_global_generation() {
-  if (ShenandoahHeap::heap()->mode()->is_generational()) {
-    return GLOBAL_GEN;
-  } else {
-    return GLOBAL_NON_GEN;
-  }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
- * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,173 +28,46 @@
 #include "gc/shared/gcCause.hpp"
 #include "gc/shared/concurrentGCThread.hpp"
 #include "gc/shenandoah/shenandoahGC.hpp"
+#include "gc/shenandoah/shenandoahGenerationType.hpp"
 #include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahPadding.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
-#include "runtime/task.hpp"
-#include "utilities/ostream.hpp"
 
-// Periodic task is useful for doing asynchronous things that do not require (heap) locks,
-// or synchronization with other parts of collector. These could run even when ShenandoahConcurrentThread
-// is busy driving the GC cycle.
-class ShenandoahPeriodicTask : public PeriodicTask {
-private:
-  ShenandoahControlThread* _thread;
-public:
-  ShenandoahPeriodicTask(ShenandoahControlThread* thread) :
-          PeriodicTask(100), _thread(thread) {}
-  virtual void task();
-};
-
-// Periodic task to notify blocked paced waiters.
-class ShenandoahPeriodicPacerNotify : public PeriodicTask {
-public:
-  ShenandoahPeriodicPacerNotify() : PeriodicTask(PeriodicTask::min_interval) {}
-  virtual void task();
-};
-
-class ShenandoahControlThread: public ConcurrentGCThread {
+class ShenandoahControlThread: public ShenandoahController {
   friend class VMStructs;
 
 private:
-  // While we could have a single lock for these, it may risk unblocking
-  // GC waiters when alloc failure GC cycle finishes. We want instead
-  // to make complete explicit cycle for demanding customers.
-  Monitor _alloc_failure_waiters_lock;
-  Monitor _gc_waiters_lock;
-  Monitor _control_lock;
-  Monitor _regulator_lock;
-  ShenandoahPeriodicTask _periodic_task;
-  ShenandoahPeriodicPacerNotify _periodic_pacer_notify_task;
-
-public:
   typedef enum {
     none,
     concurrent_normal,
     stw_degenerated,
-    stw_full,
-    bootstrapping_old,
-    servicing_old
+    stw_full
   } GCMode;
 
-  void run_service();
-  void stop_service();
+  ShenandoahSharedFlag _gc_requested;
+  GCCause::Cause       _requested_gc_cause;
+  ShenandoahGC::ShenandoahDegenPoint _degen_point;
 
-  size_t get_gc_id();
+public:
+  ShenandoahControlThread();
+
+  void run_service() override;
+  void stop_service() override;
+
+  void request_gc(GCCause::Cause cause) override;
 
 private:
-  ShenandoahSharedFlag _allow_old_preemption;
-  ShenandoahSharedFlag _preemption_requested;
-  ShenandoahSharedFlag _alloc_failure_gc;
-  ShenandoahSharedFlag _humongous_alloc_failure_gc;
-  ShenandoahSharedFlag _graceful_shutdown;
-  ShenandoahSharedFlag _do_counters_update;
-  ShenandoahSharedFlag _force_counters_update;
 
-  GCCause::Cause  _requested_gc_cause;
-  volatile ShenandoahGenerationType _requested_generation;
-  ShenandoahGC::ShenandoahDegenPoint _degen_point;
-  ShenandoahGeneration* _degen_generation;
-
-  shenandoah_padding(0);
-  volatile size_t _allocs_seen;
-  shenandoah_padding(1);
-  volatile size_t _gc_id;
-  shenandoah_padding(2);
-  volatile GCMode _mode;
-  shenandoah_padding(3);
-
-  // Returns true if the cycle has been cancelled or degenerated.
   bool check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint point);
-
-  // Returns true if the old generation marking completed (i.e., final mark executed for old generation).
-  bool resume_concurrent_old_cycle(ShenandoahGeneration* generation, GCCause::Cause cause);
-  void service_concurrent_cycle(ShenandoahGeneration* generation, GCCause::Cause cause, bool reset_old_bitmap_specially);
+  void service_concurrent_normal_cycle(GCCause::Cause cause);
   void service_stw_full_cycle(GCCause::Cause cause);
   void service_stw_degenerated_cycle(GCCause::Cause cause, ShenandoahGC::ShenandoahDegenPoint point);
-  void service_uncommit(double shrink_before, size_t shrink_until);
-
-  // Return true if setting the flag which indicates allocation failure succeeds.
-  bool try_set_alloc_failure_gc(bool is_humongous);
-
-  // Notify threads waiting for GC to complete.
-  void notify_alloc_failure_waiters();
-
-  // True if allocation failure flag has been set.
-  bool is_alloc_failure_gc();
-
-  void reset_gc_id();
-  void update_gc_id();
 
   void notify_gc_waiters();
 
   // Handle GC request.
   // Blocks until GC is over.
   void handle_requested_gc(GCCause::Cause cause);
-
-  bool is_explicit_gc(GCCause::Cause cause) const;
-  bool is_implicit_gc(GCCause::Cause cause) const;
-
-  // Returns true if the old generation marking was interrupted to allow a young cycle.
-  bool preempt_old_marking(ShenandoahGenerationType generation);
-
-  // Returns true if the soft maximum heap has been changed using management APIs.
-  bool check_soft_max_changed() const;
-
-  void process_phase_timings(const ShenandoahHeap* heap);
-
-public:
-  // Constructor
-  ShenandoahControlThread();
-  ~ShenandoahControlThread();
-
-  // Handle allocation failure from normal allocation.
-  // Blocks until memory is available.
-  void handle_alloc_failure(ShenandoahAllocRequest& req);
-
-  // Handle allocation failure from evacuation path.
-  // Optionally blocks while collector is handling the failure.
-  void handle_alloc_failure_evac(size_t words);
-
-  void request_gc(GCCause::Cause cause);
-  // Return true if the request to start a concurrent GC for the given generation succeeded.
-  bool request_concurrent_gc(ShenandoahGenerationType generation);
-
-  void handle_counters_update();
-  void handle_force_counters_update();
-  void set_forced_counters_update(bool value);
-
-  void notify_heap_changed();
-
-  void pacing_notify_alloc(size_t words);
-
-  void start();
-  void prepare_for_graceful_shutdown();
-  bool in_graceful_shutdown();
-
-  void service_concurrent_normal_cycle(ShenandoahHeap* heap,
-                                       const ShenandoahGenerationType generation,
-                                       GCCause::Cause cause);
-
-  void service_concurrent_old_cycle(ShenandoahHeap* heap,
-                                    GCCause::Cause &cause);
-
-  void set_gc_mode(GCMode new_mode);
-  GCMode gc_mode() {
-    return _mode;
-  }
-
-  static ShenandoahGenerationType select_global_generation();
-
- private:
-  static const char* gc_mode_name(GCMode mode);
-  void notify_control_thread();
-
-  void service_concurrent_cycle(ShenandoahHeap* heap,
-                                ShenandoahGeneration* generation,
-                                GCCause::Cause &cause,
-                                bool do_old_gc_bootstrap);
-
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCONTROLTHREAD_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahController.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahController.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+#include "precompiled.hpp"
+
+#include "gc/shared/gc_globals.hpp"
+#include "gc/shenandoah/shenandoahController.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
+
+void ShenandoahController::pacing_notify_alloc(size_t words) {
+  assert(ShenandoahPacing, "should only call when pacing is enabled");
+  Atomic::add(&_allocs_seen, words, memory_order_relaxed);
+}
+
+size_t ShenandoahController::reset_allocs_seen() {
+  return Atomic::xchg(&_allocs_seen, (size_t)0, memory_order_relaxed);
+}
+
+void ShenandoahController::prepare_for_graceful_shutdown() {
+  _graceful_shutdown.set();
+}
+
+bool ShenandoahController::in_graceful_shutdown() {
+  return _graceful_shutdown.is_set();
+}
+
+void ShenandoahController::update_gc_id() {
+  Atomic::inc(&_gc_id);
+}
+
+size_t ShenandoahController::get_gc_id() {
+  return Atomic::load(&_gc_id);
+}
+
+void ShenandoahController::handle_alloc_failure(ShenandoahAllocRequest& req, bool block) {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+
+  assert(current()->is_Java_thread(), "expect Java thread here");
+  bool is_humongous = req.size() > ShenandoahHeapRegion::humongous_threshold_words();
+
+  if (try_set_alloc_failure_gc(is_humongous)) {
+    // Only report the first allocation failure
+    log_info(gc)("Failed to allocate %s, " SIZE_FORMAT "%s",
+                 req.type_string(),
+                 byte_size_in_proper_unit(req.size() * HeapWordSize), proper_unit_for_byte_size(req.size() * HeapWordSize));
+
+    // Now that alloc failure GC is scheduled, we can abort everything else
+    heap->cancel_gc(GCCause::_allocation_failure);
+  }
+
+
+  if (block) {
+    MonitorLocker ml(&_alloc_failure_waiters_lock);
+    while (is_alloc_failure_gc()) {
+      ml.wait();
+    }
+  }
+}
+
+void ShenandoahController::handle_alloc_failure_evac(size_t words) {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  bool is_humongous = (words > ShenandoahHeapRegion::region_size_words());
+
+  if (try_set_alloc_failure_gc(is_humongous)) {
+    // Only report the first allocation failure
+    log_info(gc)("Failed to allocate " SIZE_FORMAT "%s for evacuation",
+                 byte_size_in_proper_unit(words * HeapWordSize), proper_unit_for_byte_size(words * HeapWordSize));
+  }
+
+  // Forcefully report allocation failure
+  heap->cancel_gc(GCCause::_shenandoah_allocation_failure_evac);
+}
+
+void ShenandoahController::notify_alloc_failure_waiters() {
+  _alloc_failure_gc.unset();
+  _humongous_alloc_failure_gc.unset();
+  MonitorLocker ml(&_alloc_failure_waiters_lock);
+  ml.notify_all();
+}
+
+bool ShenandoahController::try_set_alloc_failure_gc(bool is_humongous) {
+  if (is_humongous) {
+    _humongous_alloc_failure_gc.try_set();
+  }
+  return _alloc_failure_gc.try_set();
+}
+
+bool ShenandoahController::is_alloc_failure_gc() {
+  return _alloc_failure_gc.is_set();
+}
+

--- a/src/hotspot/share/gc/shenandoah/shenandoahController.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahController.hpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef LINUX_X86_64_SERVER_SLOWDEBUG_SHENANDOAHCONTROLLER_HPP
+#define LINUX_X86_64_SERVER_SLOWDEBUG_SHENANDOAHCONTROLLER_HPP
+
+#include "gc/shared/gcCause.hpp"
+#include "gc/shared/concurrentGCThread.hpp"
+#include "gc/shenandoah/shenandoahAllocRequest.hpp"
+#include "gc/shenandoah/shenandoahSharedVariables.hpp"
+
+/**
+ * This interface exposes methods necessary for the heap to interact
+ * with the threads responsible for driving the collection cycle.
+ */
+class ShenandoahController: public ConcurrentGCThread {
+private:
+  ShenandoahSharedFlag _graceful_shutdown;
+
+  shenandoah_padding(0);
+  volatile size_t _allocs_seen;
+  shenandoah_padding(1);
+  volatile size_t _gc_id;
+  shenandoah_padding(2);
+
+protected:
+  ShenandoahSharedFlag _alloc_failure_gc;
+  ShenandoahSharedFlag _humongous_alloc_failure_gc;
+
+  // While we could have a single lock for these, it may risk unblocking
+  // GC waiters when alloc failure GC cycle finishes. We want instead
+  // to make complete explicit cycle for demanding customers.
+  Monitor _alloc_failure_waiters_lock;
+  Monitor _gc_waiters_lock;
+
+public:
+  ShenandoahController():
+    ConcurrentGCThread(),
+    _allocs_seen(0),
+    _gc_id(0),
+    _alloc_failure_waiters_lock(Mutex::safepoint-2, "ShenandoahAllocFailureGC_lock", true),
+    _gc_waiters_lock(Mutex::safepoint-2, "ShenandoahRequestedGC_lock", true)
+  { }
+
+  // Request a collection cycle. This handles "explicit" gc requests
+  // like System.gc and "implicit" gc requests, like metaspace oom.
+  virtual void request_gc(GCCause::Cause cause) = 0;
+
+  // This cancels the collection cycle and has an option to block
+  // until another cycle runs and clears the alloc failure gc flag.
+  void handle_alloc_failure(ShenandoahAllocRequest& req, bool block);
+
+  // Invoked for allocation failures during evacuation. This cancels
+  // the collection cycle without blocking.
+  void handle_alloc_failure_evac(size_t words);
+
+  // Return true if setting the flag which indicates allocation failure succeeds.
+  bool try_set_alloc_failure_gc(bool is_humongous);
+
+  // Notify threads waiting for GC to complete.
+  void notify_alloc_failure_waiters();
+
+  // True if allocation failure flag has been set.
+  bool is_alloc_failure_gc();
+
+  // This is called for every allocation. The control thread accumulates
+  // this value when idle. During the gc cycle, the control resets it
+  // and reports it to the pacer.
+  void pacing_notify_alloc(size_t words);
+  size_t reset_allocs_seen();
+
+  // These essentially allows to cancel a collection cycle for the
+  // purpose of shutting down the JVM, without trying to start a degenerated
+  // cycle.
+  void prepare_for_graceful_shutdown();
+  bool in_graceful_shutdown();
+
+
+  // Returns the internal gc count used by the control thread. Probably
+  // doesn't need to be exposed.
+  size_t get_gc_id();
+  void update_gc_id();
+};
+#endif //LINUX_X86_64_SERVER_SLOWDEBUG_SHENANDOAHCONTROLLER_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -31,6 +31,7 @@
 #include "gc/shenandoah/shenandoahDegeneratedGC.hpp"
 #include "gc/shenandoah/shenandoahFullGC.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahMetrics.hpp"
 #include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
@@ -290,38 +291,12 @@ void ShenandoahDegenGC::op_degenerated() {
       op_cleanup_complete();
       // We defer generation resizing actions until after cset regions have been recycled.
       if (heap->mode()->is_generational()) {
-        size_t old_region_surplus = heap->get_old_region_surplus();
-        size_t old_region_deficit = heap->get_old_region_deficit();
-        bool success;
-        size_t region_xfer;
-        const char* region_destination;
-        if (old_region_surplus) {
-          region_xfer = old_region_surplus;
-          region_destination = "young";
-          success = heap->generation_sizer()->transfer_to_young(old_region_surplus);
-        } else if (old_region_deficit) {
-          region_xfer = old_region_surplus;
-          region_destination = "old";
-          success = heap->generation_sizer()->transfer_to_old(old_region_deficit);
-          if (!success) {
-            heap->old_heuristics()->trigger_cannot_expand();
-          }
-        } else {
-          region_destination = "none";
-          region_xfer = 0;
-          success = true;
+        auto result = ShenandoahGenerationalHeap::heap()->balance_generations();
+        LogTarget(Info, gc, ergo) lt;
+        if (lt.is_enabled()) {
+          LogStream ls(lt);
+          result.print_on("Degenerated GC", &ls);
         }
-
-        size_t young_available = heap->young_generation()->available();
-        size_t old_available = heap->old_generation()->available();
-        log_info(gc, ergo)("After cleanup, %s " SIZE_FORMAT " regions to %s to prepare for next gc, old available: "
-                           SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
-                           success? "successfully transferred": "failed to transfer", region_xfer, region_destination,
-                           byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                           byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
-
-        heap->set_old_region_surplus(0);
-        heap->set_old_region_deficit(0);
       }
       break;
     default:
@@ -331,9 +306,7 @@ void ShenandoahDegenGC::op_degenerated() {
   if (heap->mode()->is_generational()) {
     // In case degeneration interrupted concurrent evacuation or update references, we need to clean up transient state.
     // Otherwise, these actions have no effect.
-    heap->set_young_evac_reserve(0);
-    heap->set_old_evac_reserve(0);
-    heap->set_promoted_reserve(0);
+    ShenandoahGenerationalHeap::heap()->reset_generation_reserves();
   }
 
   if (ShenandoahVerify) {
@@ -397,9 +370,7 @@ void ShenandoahDegenGC::op_prepare_evacuation() {
     heap->tlabs_retire(false);
   }
 
-  size_t humongous_regions_promoted = heap->get_promotable_humongous_regions();
-  size_t regular_regions_promoted_in_place = heap->get_regular_regions_promoted_in_place();
-  if (!heap->collection_set()->is_empty() || (humongous_regions_promoted + regular_regions_promoted_in_place > 0)) {
+  if (!heap->collection_set()->is_empty() || heap->old_generation()->has_in_place_promotions()) {
     // Even if the collection set is empty, we need to do evacuation if there are regions to be promoted in place.
     // Degenerated evacuation takes responsibility for registering objects and setting the remembered set cards to dirty.
 
@@ -503,7 +474,7 @@ const char* ShenandoahDegenGC::degen_event_message(ShenandoahDegenPoint point) c
 }
 
 void ShenandoahDegenGC::upgrade_to_full() {
-  log_info(gc)("Degenerate GC upgrading to Full GC");
+  log_info(gc)("Degenerated GC upgrading to Full GC");
   ShenandoahHeap::heap()->shenandoah_policy()->record_degenerated_upgrade_to_full();
   ShenandoahFullGC full_gc;
   full_gc.op_full(GCCause::_shenandoah_upgrade_to_full_gc);

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -62,6 +62,7 @@ private:
   void op_degenerated_futile();
   void op_degenerated_fail();
 
+  // Turns this degenerated cycle into a full gc without leaving the safepoint
   void upgrade_to_full();
 
   const char* degen_event_message(ShenandoahDegenPoint point) const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -164,13 +164,9 @@ void ShenandoahSetsOfFree::move_to_set(size_t idx, ShenandoahFreeMemoryType new_
   // At start of update refs:
   //                  Collector => Mutator
   //                  OldCollector Empty => Mutator
-  assert (((region_capacity <= _region_size_bytes) &&
-           ((orig_set == Mutator) && (new_set == Collector)) ||
-           ((orig_set == Collector) && (new_set == Mutator))) ||
-          ((region_capacity == _region_size_bytes) &&
-           ((orig_set == Mutator) && (new_set == Collector)) ||
-           ((orig_set == OldCollector) && (new_set == Mutator)) ||
-           (new_set == OldCollector)), "Unexpected movement between sets");
+  assert((region_capacity <= _region_size_bytes && ((orig_set == Mutator && new_set == Collector) || (orig_set == Collector && new_set == Mutator)))
+      || (region_capacity == _region_size_bytes && ((orig_set == Mutator && new_set == Collector) || (orig_set == OldCollector && new_set == Mutator) || new_set == OldCollector)),
+      "Unexpected movement between sets");
 
   _membership[idx] = new_set;
   _capacity_of[orig_set] -= region_capacity;
@@ -468,7 +464,7 @@ void ShenandoahFreeSet::add_old_collector_free_region(ShenandoahHeapRegion* regi
   assert(_free_sets.membership(idx) == NotFree, "Regions promoted in place should not be in any free set");
   if (capacity >= PLAB::min_size() * HeapWordSize) {
     _free_sets.make_free(idx, OldCollector, capacity);
-    _heap->augment_promo_reserve(capacity);
+    _heap->old_generation()->augment_promoted_reserve(capacity);
   }
 }
 
@@ -1003,7 +999,7 @@ void ShenandoahFreeSet::flip_to_old_gc(ShenandoahHeapRegion* r) {
   size_t region_capacity = alloc_capacity(r);
   _free_sets.move_to_set(idx, OldCollector, region_capacity);
   _free_sets.assert_bounds();
-  _heap->augment_old_evac_reserve(region_capacity);
+  _heap->old_generation()->augment_evacuation_reserve(region_capacity);
   bool transferred = _heap->generation_sizer()->transfer_to_old(1);
   if (!transferred) {
     log_warning(gc, free)("Forcing transfer of " SIZE_FORMAT " to old reserve.", idx);
@@ -1165,17 +1161,19 @@ void ShenandoahFreeSet::prepare_to_rebuild(size_t &young_cset_regions, size_t &o
   find_regions_with_alloc_capacity(young_cset_regions, old_cset_regions, first_old_region, last_old_region, old_region_count);
 }
 
-void ShenandoahFreeSet::rebuild(size_t young_cset_regions, size_t old_cset_regions) {
+void ShenandoahFreeSet::rebuild(size_t young_cset_regions, size_t old_cset_regions, bool have_evacuation_reserves) {
   shenandoah_assert_heaplocked();
   size_t young_reserve, old_reserve;
   size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
 
-  size_t old_capacity = _heap->old_generation()->max_capacity();
-  size_t old_available = _heap->old_generation()->available();
-  size_t old_unaffiliated_regions = _heap->old_generation()->free_unaffiliated_regions();
-  size_t young_capacity = _heap->young_generation()->max_capacity();
-  size_t young_available = _heap->young_generation()->available();
-  size_t young_unaffiliated_regions = _heap->young_generation()->free_unaffiliated_regions();
+  ShenandoahOldGeneration* old_generation = _heap->old_generation();
+  size_t old_capacity = old_generation->max_capacity();
+  size_t old_available = old_generation->available();
+  size_t old_unaffiliated_regions = old_generation->free_unaffiliated_regions();
+  ShenandoahYoungGeneration* young_generation = _heap->young_generation();
+  size_t young_capacity = young_generation->max_capacity();
+  size_t young_available = young_generation->available();
+  size_t young_unaffiliated_regions = young_generation->free_unaffiliated_regions();
 
   old_unaffiliated_regions += old_cset_regions;
   old_available += old_cset_regions * region_size_bytes;
@@ -1184,8 +1182,8 @@ void ShenandoahFreeSet::rebuild(size_t young_cset_regions, size_t old_cset_regio
 
   // Consult old-region surplus and deficit to make adjustments to current generation capacities and availability.
   // The generation region transfers take place after we rebuild.
-  size_t old_region_surplus = _heap->get_old_region_surplus();
-  size_t old_region_deficit = _heap->get_old_region_deficit();
+  size_t old_region_surplus = old_generation->get_region_surplus();
+  size_t old_region_deficit = old_generation->get_region_deficit();
 
   if (old_region_surplus > 0) {
     size_t xfer_bytes = old_region_surplus * region_size_bytes;
@@ -1217,13 +1215,16 @@ void ShenandoahFreeSet::rebuild(size_t young_cset_regions, size_t old_cset_regio
     // promotions and evacuations.  The partition between which old memory is reserved for evacuation and
     // which is reserved for promotion is enforced using thread-local variables that prescribe intentons for
     // each PLAB's available memory.
-    if (_heap->has_evacuation_reserve_quantities()) {
+    if (have_evacuation_reserves) {
       // We are rebuilding at the end of final mark, having already established evacuation budgets for this GC pass.
-      young_reserve = _heap->get_young_evac_reserve();
-      old_reserve = _heap->get_promoted_reserve() + _heap->get_old_evac_reserve();
+
+      size_t promoted_reserve = old_generation->get_promoted_reserve();
+      size_t old_evac_reserve = old_generation->get_evacuation_reserve();
+      young_reserve = young_generation->get_evacuation_reserve();
+      old_reserve = promoted_reserve + old_evac_reserve;
       assert(old_reserve <= old_available,
              "Cannot reserve (" SIZE_FORMAT " + " SIZE_FORMAT") more OLD than is available: " SIZE_FORMAT,
-             _heap->get_promoted_reserve(), _heap->get_old_evac_reserve(), old_available);
+             promoted_reserve, old_evac_reserve, old_available);
     } else {
       // We are rebuilding at end of GC, so we set aside budgets specified on command line (or defaults)
       young_reserve = (young_capacity * ShenandoahEvacReserve) / 100;

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -192,7 +192,21 @@ public:
   void clear();
   void prepare_to_rebuild(size_t &young_cset_regions, size_t &old_cset_regions,
                           size_t &first_old_region, size_t &last_old_region, size_t &old_region_count);
-  void rebuild(size_t young_cset_regions, size_t old_cset_regions);
+
+  // At the end of final mark, but before we begin evacuating, heuristics calculate how much memory is required to
+  // hold the results of evacuating to young-gen and to old-gen.  These quantities, stored in reserves for their,
+  // respective generations, are consulted prior to rebuilding the free set (ShenandoahFreeSet) in preparation for
+  // evacuation.  When the free set is rebuilt, we make sure to reserve sufficient memory in the collector and
+  // old_collector sets to hold evacuations, if have_evacuation_reserves is true.  The other time we rebuild the free
+  // set is at the end of GC, as we prepare to idle GC until the next trigger.  In this case, have_evacuation_reserves
+  // is false because we don't yet know how much memory will need to be evacuated in the next GC cycle.  When
+  // have_evacuation_reserves is false, the free set rebuild operation reserves for the collector and old_collector sets
+  // based on alternative mechanisms, such as ShenandoahEvacReserve, ShenandoahOldEvacReserve, and
+  // ShenandoahOldCompactionReserve.  In a future planned enhancement, the reserve for old_collector set when the
+  // evacuation reserves are unknown, is based in part on anticipated promotion as determined by analysis of live data
+  // found during the previous GC pass which is one less than the current tenure age.
+  void rebuild(size_t young_cset_regions, size_t old_cset_regions, bool have_evacuation_reserves = false);
+
   void move_collector_sets_to_mutator(size_t cset_regions);
 
   void add_old_collector_free_region(ShenandoahHeapRegion* region);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -32,11 +32,13 @@
 #include "gc/shared/tlab_globals.hpp"
 #include "gc/shared/workerThread.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
+#include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
 #include "gc/shenandoah/shenandoahConcurrentGC.hpp"
 #include "gc/shenandoah/shenandoahCollectionSet.hpp"
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
 #include "gc/shenandoah/shenandoahFullGC.hpp"
+#include "gc/shenandoah/shenandoahGenerationalFullGC.hpp"
 #include "gc/shenandoah/shenandoahGlobalGeneration.hpp"
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "gc/shenandoah/shenandoahMark.inline.hpp"
@@ -46,7 +48,6 @@
 #include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
 #include "gc/shenandoah/shenandoahMarkingContext.inline.hpp"
 #include "gc/shenandoah/shenandoahMetrics.hpp"
-#include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
 #include "gc/shenandoah/shenandoahRootProcessor.inline.hpp"
@@ -55,80 +56,15 @@
 #include "gc/shenandoah/shenandoahVerifier.hpp"
 #include "gc/shenandoah/shenandoahVMOperations.hpp"
 #include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
-#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "memory/metaspaceUtils.hpp"
 #include "memory/universe.hpp"
 #include "oops/compressedOops.inline.hpp"
 #include "oops/oop.inline.hpp"
-#include "runtime/javaThread.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/vmThread.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/events.hpp"
 #include "utilities/growableArray.hpp"
-
-// After Full GC is done, reconstruct the remembered set by iterating over OLD regions,
-// registering all objects between bottom() and top(), and setting remembered set cards to
-// DIRTY if they hold interesting pointers.
-class ShenandoahReconstructRememberedSetTask : public WorkerTask {
-private:
-  ShenandoahRegionIterator _regions;
-
-public:
-  ShenandoahReconstructRememberedSetTask() :
-    WorkerTask("Shenandoah Reset Bitmap") { }
-
-  void work(uint worker_id) {
-    ShenandoahParallelWorkerSession worker_session(worker_id);
-    ShenandoahHeapRegion* r = _regions.next();
-    ShenandoahHeap* heap = ShenandoahHeap::heap();
-    RememberedScanner* scanner = heap->card_scan();
-    ShenandoahSetRememberedCardsToDirtyClosure dirty_cards_for_interesting_pointers;
-
-    while (r != nullptr) {
-      if (r->is_old() && r->is_active()) {
-        HeapWord* obj_addr = r->bottom();
-        if (r->is_humongous_start()) {
-          // First, clear the remembered set
-          oop obj = cast_to_oop(obj_addr);
-          size_t size = obj->size();
-
-          // First, clear the remembered set for all spanned humongous regions
-          size_t num_regions = ShenandoahHeapRegion::required_regions(size * HeapWordSize);
-          size_t region_span = num_regions * ShenandoahHeapRegion::region_size_words();
-          scanner->reset_remset(r->bottom(), region_span);
-          size_t region_index = r->index();
-          ShenandoahHeapRegion* humongous_region = heap->get_region(region_index);
-          while (num_regions-- != 0) {
-            scanner->reset_object_range(humongous_region->bottom(), humongous_region->end());
-            region_index++;
-            humongous_region = heap->get_region(region_index);
-          }
-
-          // Then register the humongous object and DIRTY relevant remembered set cards
-          scanner->register_object_without_lock(obj_addr);
-          obj->oop_iterate(&dirty_cards_for_interesting_pointers);
-        } else if (!r->is_humongous()) {
-          // First, clear the remembered set
-          scanner->reset_remset(r->bottom(), ShenandoahHeapRegion::region_size_words());
-          scanner->reset_object_range(r->bottom(), r->end());
-
-          // Then iterate over all objects, registering object and DIRTYing relevant remembered set cards
-          HeapWord* t = r->top();
-          while (obj_addr < t) {
-            oop obj = cast_to_oop(obj_addr);
-            size_t size = obj->size();
-            scanner->register_object_without_lock(obj_addr);
-            obj_addr += obj->oop_iterate_size(&dirty_cards_for_interesting_pointers);
-          }
-        } // else, ignore humongous continuation region
-      }
-      // else, this region is FREE or YOUNG or inactive and we can ignore it.
-      // TODO: Assert this.
-      r = _regions.next();
-    }
-  }
-};
 
 ShenandoahFullGC::ShenandoahFullGC() :
   _gc_timer(ShenandoahHeap::heap()->gc_timer()),
@@ -167,47 +103,26 @@ void ShenandoahFullGC::entry_full(GCCause::Cause cause) {
 }
 
 void ShenandoahFullGC::op_full(GCCause::Cause cause) {
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
   ShenandoahMetricsSnapshot metrics;
   metrics.snap_before();
 
   // Perform full GC
   do_it(cause);
 
-  metrics.snap_after();
+  ShenandoahHeap* const heap = ShenandoahHeap::heap();
+
   if (heap->mode()->is_generational()) {
-    // Full GC should reset time since last gc for young and old heuristics
-    heap->young_generation()->heuristics()->record_cycle_end();
-    heap->old_generation()->heuristics()->record_cycle_end();
-
-    heap->mmu_tracker()->record_full(GCId::current());
-    heap->log_heap_status("At end of Full GC");
-
-    assert(heap->old_generation()->state() == ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP,
-           "After full GC, old generation should be waiting for bootstrap.");
-
-    // Since we allow temporary violation of these constraints during Full GC, we want to enforce that the assertions are
-    // made valid by the time Full GC completes.
-    assert(heap->old_generation()->used_regions_size() <= heap->old_generation()->max_capacity(),
-           "Old generation affiliated regions must be less than capacity");
-    assert(heap->young_generation()->used_regions_size() <= heap->young_generation()->max_capacity(),
-           "Young generation affiliated regions must be less than capacity");
-
-    assert((heap->young_generation()->used() + heap->young_generation()->get_humongous_waste())
-           <= heap->young_generation()->used_regions_size(), "Young consumed can be no larger than span of affiliated regions");
-    assert((heap->old_generation()->used() + heap->old_generation()->get_humongous_waste())
-           <= heap->old_generation()->used_regions_size(), "Old consumed can be no larger than span of affiliated regions");
-
-    // Establish baseline for next old-has-grown trigger.
-    heap->old_generation()->set_live_bytes_after_last_mark(heap->old_generation()->used() +
-                                                           heap->old_generation()->get_humongous_waste());
+    ShenandoahGenerationalFullGC::handle_completion(heap);
   }
+
+  metrics.snap_after();
+
   if (metrics.is_good_progress()) {
-    ShenandoahHeap::heap()->notify_gc_progress();
+    heap->notify_gc_progress();
   } else {
     // Nothing to do. Tell the allocation path that we have failed to make
     // progress, and it can finally fail.
-    ShenandoahHeap::heap()->notify_gc_no_progress();
+    heap->notify_gc_no_progress();
   }
 
   // Regardless if progress was made, we record that we completed a "successful" full GC.
@@ -217,17 +132,9 @@ void ShenandoahFullGC::op_full(GCCause::Cause cause) {
 
 void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  // Since we may arrive here from degenerated GC failure of either young or old, establish generation as GLOBAL.
-  heap->set_gc_generation(heap->global_generation());
 
   if (heap->mode()->is_generational()) {
-    // No need for old_gen->increase_used() as this was done when plabs were allocated.
-    heap->set_young_evac_reserve(0);
-    heap->set_old_evac_reserve(0);
-    heap->set_promoted_reserve(0);
-
-    // Full GC supersedes any marking or coalescing in old generation.
-    heap->cancel_old_gc();
+    ShenandoahGenerationalFullGC::prepare();
   }
 
   if (ShenandoahVerify) {
@@ -274,6 +181,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
 
     // b. Cancel all concurrent marks, if in progress
     if (heap->is_concurrent_mark_in_progress()) {
+      // TODO: Send cancel_concurrent_mark upstream? Does it really not have it already?
       heap->cancel_concurrent_mark();
     }
     assert(!heap->is_concurrent_mark_in_progress(), "sanity");
@@ -296,12 +204,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     heap->sync_pinned_region_status();
 
     if (heap->mode()->is_generational()) {
-      for (size_t i = 0; i < heap->num_regions(); i++) {
-        ShenandoahHeapRegion* r = heap->get_region(i);
-        if (r->get_top_before_promote() != nullptr) {
-          r->restore_top_before_promote();
-        }
-      }
+      ShenandoahGenerationalFullGC::restore_top_before_promote(heap);
     }
 
     // The rest of prologue:
@@ -352,19 +255,6 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     phase5_epilog();
   }
 
-  {
-    // Epilogue
-    // TODO: Merge with phase5_epilog?
-    _preserved_marks->restore(heap->workers());
-    _preserved_marks->reclaim();
-
-    if (heap->mode()->is_generational()) {
-      ShenandoahGCPhase phase(ShenandoahPhaseTimings::full_gc_reconstruct_remembered_set);
-      ShenandoahReconstructRememberedSetTask task;
-      heap->workers()->run_task(&task);
-    }
-  }
-
   // Resize metaspace
   MetaspaceGC::compute_new_size();
 
@@ -400,6 +290,7 @@ public:
   ShenandoahPrepareForMarkClosure() : _ctx(ShenandoahHeap::heap()->marking_context()) {}
 
   void heap_region_do(ShenandoahHeapRegion *r) {
+    // TODO: Add API to heap to skip free regions
     if (r->affiliation() != FREE) {
       _ctx->capture_top_at_mark_start(r);
       r->clear_live_data();
@@ -428,250 +319,10 @@ void ShenandoahFullGC::phase1_mark_heap() {
   mark.mark();
   heap->parallel_cleaning(true /* full_gc */);
 
-  size_t live_bytes_in_old = 0;
-  for (size_t i = 0; i < heap->num_regions(); i++) {
-    ShenandoahHeapRegion* r = heap->get_region(i);
-    if (r->is_old()) {
-      live_bytes_in_old += r->get_live_data_bytes();
-    }
+  if (ShenandoahHeap::heap()->mode()->is_generational()) {
+    ShenandoahGenerationalFullGC::log_live_in_old(heap);
   }
-  log_info(gc)("Live bytes in old after STW mark: " PROPERFMT, PROPERFMTARGS(live_bytes_in_old));
 }
-
-class ShenandoahPrepareForCompactionTask : public WorkerTask {
-private:
-  PreservedMarksSet*        const _preserved_marks;
-  ShenandoahHeap*           const _heap;
-  ShenandoahHeapRegionSet** const _worker_slices;
-  size_t                    const _num_workers;
-
-public:
-  ShenandoahPrepareForCompactionTask(PreservedMarksSet *preserved_marks,
-                                     ShenandoahHeapRegionSet **worker_slices,
-                                     size_t num_workers);
-
-  static bool is_candidate_region(ShenandoahHeapRegion* r) {
-    // Empty region: get it into the slice to defragment the slice itself.
-    // We could have skipped this without violating correctness, but we really
-    // want to compact all live regions to the start of the heap, which sometimes
-    // means moving them into the fully empty regions.
-    if (r->is_empty()) return true;
-
-    // Can move the region, and this is not the humongous region. Humongous
-    // moves are special cased here, because their moves are handled separately.
-    return r->is_stw_move_allowed() && !r->is_humongous();
-  }
-
-  void work(uint worker_id);
-};
-
-class ShenandoahPrepareForGenerationalCompactionObjectClosure : public ObjectClosure {
-private:
-  PreservedMarks*          const _preserved_marks;
-  ShenandoahHeap*          const _heap;
-  uint                           _tenuring_threshold;
-
-  // _empty_regions is a thread-local list of heap regions that have been completely emptied by this worker thread's
-  // compaction efforts.  The worker thread that drives these efforts adds compacted regions to this list if the
-  // region has not been compacted onto itself.
-  GrowableArray<ShenandoahHeapRegion*>& _empty_regions;
-  int _empty_regions_pos;
-  ShenandoahHeapRegion*          _old_to_region;
-  ShenandoahHeapRegion*          _young_to_region;
-  ShenandoahHeapRegion*          _from_region;
-  ShenandoahAffiliation          _from_affiliation;
-  HeapWord*                      _old_compact_point;
-  HeapWord*                      _young_compact_point;
-  uint                           _worker_id;
-
-public:
-  ShenandoahPrepareForGenerationalCompactionObjectClosure(PreservedMarks* preserved_marks,
-                                                          GrowableArray<ShenandoahHeapRegion*>& empty_regions,
-                                                          ShenandoahHeapRegion* old_to_region,
-                                                          ShenandoahHeapRegion* young_to_region, uint worker_id) :
-      _preserved_marks(preserved_marks),
-      _heap(ShenandoahHeap::heap()),
-      _tenuring_threshold(0),
-      _empty_regions(empty_regions),
-      _empty_regions_pos(0),
-      _old_to_region(old_to_region),
-      _young_to_region(young_to_region),
-      _from_region(nullptr),
-      _old_compact_point((old_to_region != nullptr)? old_to_region->bottom(): nullptr),
-      _young_compact_point((young_to_region != nullptr)? young_to_region->bottom(): nullptr),
-      _worker_id(worker_id) {
-    if (_heap->mode()->is_generational()) {
-      _tenuring_threshold = _heap->age_census()->tenuring_threshold();
-    }
-  }
-
-  void set_from_region(ShenandoahHeapRegion* from_region) {
-    _from_region = from_region;
-    _from_affiliation = from_region->affiliation();
-    if (_from_region->has_live()) {
-      if (_from_affiliation == ShenandoahAffiliation::OLD_GENERATION) {
-        if (_old_to_region == nullptr) {
-          _old_to_region = from_region;
-          _old_compact_point = from_region->bottom();
-        }
-      } else {
-        assert(_from_affiliation == ShenandoahAffiliation::YOUNG_GENERATION, "from_region must be OLD or YOUNG");
-        if (_young_to_region == nullptr) {
-          _young_to_region = from_region;
-          _young_compact_point = from_region->bottom();
-        }
-      }
-    } // else, we won't iterate over this _from_region so we don't need to set up to region to hold copies
-  }
-
-  void finish() {
-    finish_old_region();
-    finish_young_region();
-  }
-
-  void finish_old_region() {
-    if (_old_to_region != nullptr) {
-      log_debug(gc)("Planned compaction into Old Region " SIZE_FORMAT ", used: " SIZE_FORMAT " tabulated by worker %u",
-                    _old_to_region->index(), _old_compact_point - _old_to_region->bottom(), _worker_id);
-      _old_to_region->set_new_top(_old_compact_point);
-      _old_to_region = nullptr;
-    }
-  }
-
-  void finish_young_region() {
-    if (_young_to_region != nullptr) {
-      log_debug(gc)("Worker %u planned compaction into Young Region " SIZE_FORMAT ", used: " SIZE_FORMAT,
-                    _worker_id, _young_to_region->index(), _young_compact_point - _young_to_region->bottom());
-      _young_to_region->set_new_top(_young_compact_point);
-      _young_to_region = nullptr;
-    }
-  }
-
-  bool is_compact_same_region() {
-    return (_from_region == _old_to_region) || (_from_region == _young_to_region);
-  }
-
-  int empty_regions_pos() {
-    return _empty_regions_pos;
-  }
-
-  void do_object(oop p) {
-    assert(_from_region != nullptr, "must set before work");
-    assert((_from_region->bottom() <= cast_from_oop<HeapWord*>(p)) && (cast_from_oop<HeapWord*>(p) < _from_region->top()),
-           "Object must reside in _from_region");
-    assert(_heap->complete_marking_context()->is_marked(p), "must be marked");
-    assert(!_heap->complete_marking_context()->allocated_after_mark_start(p), "must be truly marked");
-
-    size_t obj_size = p->size();
-    uint from_region_age = _from_region->age();
-    uint object_age = p->age();
-
-    bool promote_object = false;
-    if ((_from_affiliation == ShenandoahAffiliation::YOUNG_GENERATION) &&
-        (from_region_age + object_age >= _tenuring_threshold)) {
-      if ((_old_to_region != nullptr) && (_old_compact_point + obj_size > _old_to_region->end())) {
-        finish_old_region();
-        _old_to_region = nullptr;
-      }
-      if (_old_to_region == nullptr) {
-        if (_empty_regions_pos < _empty_regions.length()) {
-          ShenandoahHeapRegion* new_to_region = _empty_regions.at(_empty_regions_pos);
-          _empty_regions_pos++;
-          new_to_region->set_affiliation(OLD_GENERATION);
-          _old_to_region = new_to_region;
-          _old_compact_point = _old_to_region->bottom();
-          promote_object = true;
-        }
-        // Else this worker thread does not yet have any empty regions into which this aged object can be promoted so
-        // we leave promote_object as false, deferring the promotion.
-      } else {
-        promote_object = true;
-      }
-    }
-
-    if (promote_object || (_from_affiliation == ShenandoahAffiliation::OLD_GENERATION)) {
-      assert(_old_to_region != nullptr, "_old_to_region should not be nullptr when evacuating to OLD region");
-      if (_old_compact_point + obj_size > _old_to_region->end()) {
-        ShenandoahHeapRegion* new_to_region;
-
-        log_debug(gc)("Worker %u finishing old region " SIZE_FORMAT ", compact_point: " PTR_FORMAT ", obj_size: " SIZE_FORMAT
-                      ", &compact_point[obj_size]: " PTR_FORMAT ", region end: " PTR_FORMAT,  _worker_id, _old_to_region->index(),
-                      p2i(_old_compact_point), obj_size, p2i(_old_compact_point + obj_size), p2i(_old_to_region->end()));
-
-        // Object does not fit.  Get a new _old_to_region.
-        finish_old_region();
-        if (_empty_regions_pos < _empty_regions.length()) {
-          new_to_region = _empty_regions.at(_empty_regions_pos);
-          _empty_regions_pos++;
-          new_to_region->set_affiliation(OLD_GENERATION);
-        } else {
-          // If we've exhausted the previously selected _old_to_region, we know that the _old_to_region is distinct
-          // from _from_region.  That's because there is always room for _from_region to be compacted into itself.
-          // Since we're out of empty regions, let's use _from_region to hold the results of its own compaction.
-          new_to_region = _from_region;
-        }
-
-        assert(new_to_region != _old_to_region, "must not reuse same OLD to-region");
-        assert(new_to_region != nullptr, "must not be nullptr");
-        _old_to_region = new_to_region;
-        _old_compact_point = _old_to_region->bottom();
-      }
-
-      // Object fits into current region, record new location:
-      assert(_old_compact_point + obj_size <= _old_to_region->end(), "must fit");
-      shenandoah_assert_not_forwarded(nullptr, p);
-      _preserved_marks->push_if_necessary(p, p->mark());
-      p->forward_to(cast_to_oop(_old_compact_point));
-      _old_compact_point += obj_size;
-    } else {
-      assert(_from_affiliation == ShenandoahAffiliation::YOUNG_GENERATION,
-             "_from_region must be OLD_GENERATION or YOUNG_GENERATION");
-      assert(_young_to_region != nullptr, "_young_to_region should not be nullptr when compacting YOUNG _from_region");
-
-      // After full gc compaction, all regions have age 0.  Embed the region's age into the object's age in order to preserve
-      // tenuring progress.
-      if (_heap->is_aging_cycle()) {
-        _heap->increase_object_age(p, from_region_age + 1);
-      } else {
-        _heap->increase_object_age(p, from_region_age);
-      }
-
-      if (_young_compact_point + obj_size > _young_to_region->end()) {
-        ShenandoahHeapRegion* new_to_region;
-
-        log_debug(gc)("Worker %u finishing young region " SIZE_FORMAT ", compact_point: " PTR_FORMAT ", obj_size: " SIZE_FORMAT
-                      ", &compact_point[obj_size]: " PTR_FORMAT ", region end: " PTR_FORMAT,  _worker_id, _young_to_region->index(),
-                      p2i(_young_compact_point), obj_size, p2i(_young_compact_point + obj_size), p2i(_young_to_region->end()));
-
-        // Object does not fit.  Get a new _young_to_region.
-        finish_young_region();
-        if (_empty_regions_pos < _empty_regions.length()) {
-          new_to_region = _empty_regions.at(_empty_regions_pos);
-          _empty_regions_pos++;
-          new_to_region->set_affiliation(YOUNG_GENERATION);
-        } else {
-          // If we've exhausted the previously selected _young_to_region, we know that the _young_to_region is distinct
-          // from _from_region.  That's because there is always room for _from_region to be compacted into itself.
-          // Since we're out of empty regions, let's use _from_region to hold the results of its own compaction.
-          new_to_region = _from_region;
-        }
-
-        assert(new_to_region != _young_to_region, "must not reuse same OLD to-region");
-        assert(new_to_region != nullptr, "must not be nullptr");
-        _young_to_region = new_to_region;
-        _young_compact_point = _young_to_region->bottom();
-      }
-
-      // Object fits into current region, record new location:
-      assert(_young_compact_point + obj_size <= _young_to_region->end(), "must fit");
-      shenandoah_assert_not_forwarded(nullptr, p);
-      _preserved_marks->push_if_necessary(p, p->mark());
-      p->forward_to(cast_to_oop(_young_compact_point));
-      _young_compact_point += obj_size;
-    }
-  }
-};
-
 
 class ShenandoahPrepareForCompactionObjectClosure : public ObjectClosure {
 private:
@@ -699,9 +350,8 @@ public:
     _from_region = from_region;
   }
 
-  void finish_region() {
+  void finish() {
     assert(_to_region != nullptr, "should not happen");
-    assert(!_heap->mode()->is_generational(), "Generational GC should use different Closure");
     _to_region->set_new_top(_compact_point);
   }
 
@@ -720,7 +370,7 @@ public:
 
     size_t obj_size = p->size();
     if (_compact_point + obj_size > _to_region->end()) {
-      finish_region();
+      finish();
 
       // Object doesn't fit. Pick next empty region and start compacting there.
       ShenandoahHeapRegion* new_to_region;
@@ -738,23 +388,50 @@ public:
       _compact_point = _to_region->bottom();
     }
 
-    // Object fits into current region, record new location:
+    // Object fits into current region, record new location, if object does not move:
     assert(_compact_point + obj_size <= _to_region->end(), "must fit");
     shenandoah_assert_not_forwarded(nullptr, p);
-    _preserved_marks->push_if_necessary(p, p->mark());
-    p->forward_to(cast_to_oop(_compact_point));
+    if (_compact_point != cast_from_oop<HeapWord*>(p)) {
+      _preserved_marks->push_if_necessary(p, p->mark());
+      p->forward_to(cast_to_oop(_compact_point));
+    }
     _compact_point += obj_size;
   }
 };
 
+class ShenandoahPrepareForCompactionTask : public WorkerTask {
+private:
+  PreservedMarksSet*        const _preserved_marks;
+  ShenandoahHeap*           const _heap;
+  ShenandoahHeapRegionSet** const _worker_slices;
 
-ShenandoahPrepareForCompactionTask::ShenandoahPrepareForCompactionTask(PreservedMarksSet *preserved_marks,
-                                                                       ShenandoahHeapRegionSet **worker_slices,
-                                                                       size_t num_workers) :
+public:
+  ShenandoahPrepareForCompactionTask(PreservedMarksSet *preserved_marks, ShenandoahHeapRegionSet **worker_slices) :
     WorkerTask("Shenandoah Prepare For Compaction"),
-    _preserved_marks(preserved_marks), _heap(ShenandoahHeap::heap()),
-    _worker_slices(worker_slices), _num_workers(num_workers) { }
+    _preserved_marks(preserved_marks),
+    _heap(ShenandoahHeap::heap()), _worker_slices(worker_slices) {
+  }
 
+  static bool is_candidate_region(ShenandoahHeapRegion* r) {
+    // Empty region: get it into the slice to defragment the slice itself.
+    // We could have skipped this without violating correctness, but we really
+    // want to compact all live regions to the start of the heap, which sometimes
+    // means moving them into the fully empty regions.
+    if (r->is_empty()) return true;
+
+    // Can move the region, and this is not the humongous region. Humongous
+    // moves are special cased here, because their moves are handled separately.
+    return r->is_stw_move_allowed() && !r->is_humongous();
+  }
+
+  void work(uint worker_id) override;
+private:
+  template<typename ClosureType>
+  void prepare_for_compaction(ClosureType& cl,
+                              GrowableArray<ShenandoahHeapRegion*>& empty_regions,
+                              ShenandoahHeapRegionSetIterator& it,
+                              ShenandoahHeapRegion* from_region);
+};
 
 void ShenandoahPrepareForCompactionTask::work(uint worker_id) {
   ShenandoahParallelWorkerSession worker_session(worker_id);
@@ -773,56 +450,39 @@ void ShenandoahPrepareForCompactionTask::work(uint worker_id) {
   GrowableArray<ShenandoahHeapRegion*> empty_regions((int)_heap->num_regions());
 
   if (_heap->mode()->is_generational()) {
-    ShenandoahHeapRegion* old_to_region = (from_region->is_old())? from_region: nullptr;
-    ShenandoahHeapRegion* young_to_region = (from_region->is_young())? from_region: nullptr;
     ShenandoahPrepareForGenerationalCompactionObjectClosure cl(_preserved_marks->get(worker_id),
-                                                               empty_regions,
-                                                               old_to_region, young_to_region,
-                                                               worker_id);
-    while (from_region != nullptr) {
-      assert(is_candidate_region(from_region), "Sanity");
-      log_debug(gc)("Worker %u compacting %s Region " SIZE_FORMAT " which had used " SIZE_FORMAT " and %s live",
-                    worker_id, from_region->affiliation_name(),
-                    from_region->index(), from_region->used(), from_region->has_live()? "has": "does not have");
-      cl.set_from_region(from_region);
-      if (from_region->has_live()) {
-        _heap->marked_object_iterate(from_region, &cl);
-      }
-      // Compacted the region to somewhere else? From-region is empty then.
-      if (!cl.is_compact_same_region()) {
-        empty_regions.append(from_region);
-      }
-      from_region = it.next();
-    }
-    cl.finish();
-
-    // Mark all remaining regions as empty
-    for (int pos = cl.empty_regions_pos(); pos < empty_regions.length(); ++pos) {
-      ShenandoahHeapRegion* r = empty_regions.at(pos);
-      r->set_new_top(r->bottom());
-    }
+                                                               empty_regions, from_region, worker_id);
+    prepare_for_compaction(cl, empty_regions, it, from_region);
   } else {
     ShenandoahPrepareForCompactionObjectClosure cl(_preserved_marks->get(worker_id), empty_regions, from_region);
-    while (from_region != nullptr) {
-      assert(is_candidate_region(from_region), "Sanity");
-      cl.set_from_region(from_region);
-      if (from_region->has_live()) {
-        _heap->marked_object_iterate(from_region, &cl);
-      }
+    prepare_for_compaction(cl, empty_regions, it, from_region);
+  }
+}
 
-      // Compacted the region to somewhere else? From-region is empty then.
-      if (!cl.is_compact_same_region()) {
-        empty_regions.append(from_region);
-      }
-      from_region = it.next();
+template<typename ClosureType>
+void ShenandoahPrepareForCompactionTask::prepare_for_compaction(ClosureType& cl,
+                                                                GrowableArray<ShenandoahHeapRegion*>& empty_regions,
+                                                                ShenandoahHeapRegionSetIterator& it,
+                                                                ShenandoahHeapRegion* from_region) {
+  while (from_region != nullptr) {
+    assert(is_candidate_region(from_region), "Sanity");
+    cl.set_from_region(from_region);
+    if (from_region->has_live()) {
+      _heap->marked_object_iterate(from_region, &cl);
     }
-    cl.finish_region();
 
-    // Mark all remaining regions as empty
-    for (int pos = cl.empty_regions_pos(); pos < empty_regions.length(); ++pos) {
-      ShenandoahHeapRegion* r = empty_regions.at(pos);
-      r->set_new_top(r->bottom());
+    // Compacted the region to somewhere else? From-region is empty then.
+    if (!cl.is_compact_same_region()) {
+      empty_regions.append(from_region);
     }
+    from_region = it.next();
+  }
+  cl.finish();
+
+  // Mark all remaining regions as empty
+  for (int pos = cl.empty_regions_pos(); pos < empty_regions.length(); ++pos) {
+    ShenandoahHeapRegion* r = empty_regions.at(pos);
+    r->set_new_top(r->bottom());
   }
 }
 
@@ -921,21 +581,18 @@ public:
       oop humongous_obj = cast_to_oop(r->bottom());
       if (!_ctx->is_marked(humongous_obj)) {
         assert(!r->has_live(),
-               "Humongous Start %s Region " SIZE_FORMAT " is not marked, should not have live",
-               r->affiliation_name(),  r->index());
-        log_debug(gc)("Trashing immediate humongous region " SIZE_FORMAT " because not marked", r->index());
+               "Region " SIZE_FORMAT " is not marked, should not have live", r->index());
         _heap->trash_humongous_region_at(r);
       } else {
         assert(r->has_live(),
-               "Humongous Start %s Region " SIZE_FORMAT " should have live", r->affiliation_name(),  r->index());
+               "Region " SIZE_FORMAT " should have live", r->index());
       }
     } else if (r->is_humongous_continuation()) {
       // If we hit continuation, the non-live humongous starts should have been trashed already
       assert(r->humongous_start_region()->has_live(),
-             "Humongous Continuation %s Region " SIZE_FORMAT " should have live", r->affiliation_name(),  r->index());
+             "Region " SIZE_FORMAT " should have live", r->index());
     } else if (r->is_regular()) {
       if (!r->has_live()) {
-        log_debug(gc)("Trashing immediate regular region " SIZE_FORMAT " because has no live", r->index());
         r->make_trash_immediate();
       }
     }
@@ -1116,10 +773,9 @@ void ShenandoahFullGC::phase2_calculate_target_addresses(ShenandoahHeapRegionSet
 
     distribute_slices(worker_slices);
 
-    size_t num_workers = heap->max_workers();
-
+    // TODO: This is ResourceMark is missing upstream.
     ResourceMark rm;
-    ShenandoahPrepareForCompactionTask task(_preserved_marks, worker_slices, num_workers);
+    ShenandoahPrepareForCompactionTask task(_preserved_marks, worker_slices);
     heap->workers()->run_task(&task);
   }
 
@@ -1193,12 +849,8 @@ public:
       if (!r->is_humongous_continuation() && r->has_live()) {
         _heap->marked_object_iterate(r, &obj_cl);
       }
-      if (r->is_pinned() && r->is_old() && r->is_active() && !r->is_humongous()) {
-        // Pinned regions are not compacted so they may still hold unmarked objects with
-        // reference to reclaimed memory. Remembered set scanning will crash if it attempts
-        // to iterate the oops in these objects.
-        r->begin_preemptible_coalesce_and_fill();
-        r->oop_fill_and_coalesce_without_cancel();
+      if (_heap->mode()->is_generational()) {
+        ShenandoahGenerationalFullGC::maybe_coalesce_and_fill_region(r);
       }
       r = _regions.next();
     }
@@ -1262,6 +914,7 @@ public:
     if (p->is_forwarded()) {
       HeapWord* compact_from = cast_from_oop<HeapWord*>(p);
       HeapWord* compact_to = cast_from_oop<HeapWord*>(p->forwardee());
+      assert(compact_from != compact_to, "Forwarded object should move");
       Copy::aligned_conjoint_words(compact_from, compact_to, size);
       oop new_obj = cast_to_oop(compact_to);
 
@@ -1299,23 +952,6 @@ public:
     }
   }
 };
-
-static void account_for_region(ShenandoahHeapRegion* r, size_t &region_count, size_t &region_usage, size_t &humongous_waste) {
-  region_count++;
-  region_usage += r->used();
-  if (r->is_humongous_start()) {
-    // For each humongous object, we take this path once regardless of how many regions it spans.
-    HeapWord* obj_addr = r->bottom();
-    oop obj = cast_to_oop(obj_addr);
-    size_t word_size = obj->size();
-    size_t region_size_words = ShenandoahHeapRegion::region_size_words();
-    size_t overreach = word_size % region_size_words;
-    if (overreach != 0) {
-      humongous_waste += (region_size_words - overreach) * HeapWordSize;
-    }
-    // else, this humongous object aligns exactly on region size, so no waste.
-  }
-}
 
 class ShenandoahPostCompactClosure : public ShenandoahHeapRegionClosure {
 private:
@@ -1374,9 +1010,9 @@ public:
       r->recycle();
     } else {
       if (r->is_old()) {
-        account_for_region(r, _old_regions, _old_usage, _old_humongous_waste);
+        ShenandoahGenerationalFullGC::account_for_region(r, _old_regions, _old_usage, _old_humongous_waste);
       } else if (r->is_young()) {
-        account_for_region(r, _young_regions, _young_usage, _young_humongous_waste);
+        ShenandoahGenerationalFullGC::account_for_region(r, _young_regions, _young_usage, _young_humongous_waste);
       }
     }
     r->set_live_data(live);
@@ -1428,13 +1064,9 @@ void ShenandoahFullGC::compact_humongous_objects() {
       assert(old_start != new_start, "must be real move");
       assert(r->is_stw_move_allowed(), "Region " SIZE_FORMAT " should be movable", r->index());
 
-      ContinuationGCSupport::relativize_stack_chunk(cast_to_oop<HeapWord*>(heap->get_region(old_start)->bottom()));
-      log_debug(gc)("Full GC compaction moves humongous object from region " SIZE_FORMAT " to region " SIZE_FORMAT,
-                    old_start, new_start);
-
-      Copy::aligned_conjoint_words(heap->get_region(old_start)->bottom(),
-                                   heap->get_region(new_start)->bottom(),
-                                   words_size);
+      log_debug(gc)("Full GC compaction moves humongous object from region " SIZE_FORMAT " to region " SIZE_FORMAT, old_start, new_start);
+      Copy::aligned_conjoint_words(r->bottom(), heap->get_region(new_start)->bottom(), words_size);
+      ContinuationGCSupport::relativize_stack_chunk(cast_to_oop<HeapWord*>(r->bottom()));
 
       oop new_obj = cast_to_oop(heap->get_region(new_start)->bottom());
       new_obj->init_mark();
@@ -1539,25 +1171,11 @@ void ShenandoahFullGC::phase5_epilog() {
     ShenandoahPostCompactClosure post_compact;
     heap->heap_region_iterate(&post_compact);
     post_compact.update_generation_usage();
+
     if (heap->mode()->is_generational()) {
-      size_t old_usage = heap->old_generation()->used_regions_size();
-      size_t old_capacity = heap->old_generation()->max_capacity();
-
-      assert(old_usage % ShenandoahHeapRegion::region_size_bytes() == 0, "Old usage must aligh with region size");
-      assert(old_capacity % ShenandoahHeapRegion::region_size_bytes() == 0, "Old capacity must aligh with region size");
-
-      if (old_capacity > old_usage) {
-        size_t excess_old_regions = (old_capacity - old_usage) / ShenandoahHeapRegion::region_size_bytes();
-        heap->generation_sizer()->transfer_to_young(excess_old_regions);
-      } else if (old_capacity < old_usage) {
-        size_t old_regions_deficit = (old_usage - old_capacity) / ShenandoahHeapRegion::region_size_bytes();
-        heap->generation_sizer()->force_transfer_to_old(old_regions_deficit);
-      }
-
-      log_info(gc)("FullGC done: young usage: " SIZE_FORMAT "%s, old usage: " SIZE_FORMAT "%s",
-                   byte_size_in_proper_unit(heap->young_generation()->used()), proper_unit_for_byte_size(heap->young_generation()->used()),
-                   byte_size_in_proper_unit(heap->old_generation()->used()),   proper_unit_for_byte_size(heap->old_generation()->used()));
+      ShenandoahGenerationalFullGC::balance_generations_after_gc(heap);
     }
+
     heap->collection_set()->clear();
     size_t young_cset_regions, old_cset_regions;
     size_t first_old, last_old, num_old;
@@ -1571,52 +1189,22 @@ void ShenandoahFullGC::phase5_epilog() {
     //       this is probably suboptimal, because most of these objects will not reside in a region that will be
     //       selected for the next evacuation phase.
 
-    // In case this Full GC resulted from degeneration, clear the tally on anticipated promotion.
-    heap->clear_promotion_potential();
 
     if (heap->mode()->is_generational()) {
-      // Invoke this in case we are able to transfer memory from OLD to YOUNG.
-      heap->adjust_generation_sizes_for_next_cycle(0, 0, 0);
+      ShenandoahGenerationalFullGC::compute_balances();
     }
+
     heap->free_set()->rebuild(young_cset_regions, old_cset_regions);
 
     // We defer generation resizing actions until after cset regions have been recycled.  We do this even following an
     // abbreviated cycle.
     if (heap->mode()->is_generational()) {
-      bool success;
-      size_t region_xfer;
-      const char* region_destination;
-      ShenandoahYoungGeneration* young_gen = heap->young_generation();
-      ShenandoahGeneration* old_gen = heap->old_generation();
-
-      size_t old_region_surplus = heap->get_old_region_surplus();
-      size_t old_region_deficit = heap->get_old_region_deficit();
-      if (old_region_surplus) {
-        success = heap->generation_sizer()->transfer_to_young(old_region_surplus);
-        region_destination = "young";
-        region_xfer = old_region_surplus;
-      } else if (old_region_deficit) {
-        success = heap->generation_sizer()->transfer_to_old(old_region_deficit);
-        region_destination = "old";
-        region_xfer = old_region_deficit;
-        if (!success) {
-          ((ShenandoahOldHeuristics *) old_gen->heuristics())->trigger_cannot_expand();
-        }
-      } else {
-        region_destination = "none";
-        region_xfer = 0;
-        success = true;
-      }
-      heap->set_old_region_surplus(0);
-      heap->set_old_region_deficit(0);
-      size_t young_available = young_gen->available();
-      size_t old_available = old_gen->available();
-      log_info(gc, ergo)("After cleanup, %s " SIZE_FORMAT " regions to %s to prepare for next gc, old available: "
-                         SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
-                         success? "successfully transferred": "failed to transfer", region_xfer, region_destination,
-                         byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                         byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
+      ShenandoahGenerationalFullGC::balance_generations_after_rebuilding_free_set();
+      ShenandoahGenerationalFullGC::rebuild_remembered_set(heap);
     }
     heap->clear_cancelled_gc(true /* clear oom handler */);
   }
+
+  _preserved_marks->restore(heap->workers());
+  _preserved_marks->reclaim();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -59,6 +59,9 @@ private:
   // heap lock.
   size_t _humongous_waste;
 
+  // Bytes reserved within this generation to hold evacuated objects from the collection set
+  size_t _evacuation_reserve;
+
 protected:
   // Usage
 
@@ -105,7 +108,12 @@ private:
 
   bool is_young() const  { return _type == YOUNG; }
   bool is_old() const    { return _type == OLD; }
-  bool is_global() const { return _type == GLOBAL_GEN || _type == GLOBAL_NON_GEN; }
+  bool is_global() const { return _type == GLOBAL || _type == NON_GEN; }
+
+  // see description in field declaration
+  void set_evacuation_reserve(size_t new_val);
+  size_t get_evacuation_reserve() const;
+  void augment_evacuation_reserve(size_t increment);
 
   inline ShenandoahGenerationType type() const { return _type; }
 
@@ -123,6 +131,9 @@ private:
   size_t used() const override { return _used; }
   size_t available() const override;
   size_t available_with_reserve() const;
+  size_t used_including_humongous_waste() const {
+    return used() + get_humongous_waste();
+  }
 
   // Returns the memory available based on the _soft_ max heap capacity (soft_max_heap - used).
   // The soft max heap size may be adjusted lower than the max heap size to cause the trigger

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationType.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationType.hpp
@@ -26,17 +26,17 @@
 #define SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONTYPE_HPP
 
 enum ShenandoahGenerationType {
-    GLOBAL_NON_GEN,  // Global, non-generational
-    GLOBAL_GEN,      // Global, generational
-    YOUNG,           // Young,  generational
-    OLD              // Old,    generational
+    NON_GEN,         // non-generational
+    GLOBAL,          // generational: Global
+    YOUNG,           // generational: Young
+    OLD              // generational: Old
 };
 
 inline const char* shenandoah_generation_name(ShenandoahGenerationType mode) {
   switch (mode) {
-    case GLOBAL_NON_GEN:
-      return "";
-    case GLOBAL_GEN:
+    case NON_GEN:
+      return "Non-Generational";
+    case GLOBAL:
       return "Global";
     case OLD:
       return "Old";
@@ -44,7 +44,7 @@ inline const char* shenandoah_generation_name(ShenandoahGenerationType mode) {
       return "Young";
     default:
       ShouldNotReachHere();
-      return "?";
+      return "Unknown";
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -1,0 +1,841 @@
+/*
+ * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "gc/shenandoah/mode/shenandoahMode.hpp"
+#include "gc/shenandoah/shenandoahAsserts.hpp"
+#include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
+#include "gc/shenandoah/shenandoahConcurrentGC.hpp"
+#include "gc/shenandoah/shenandoahGenerationalControlThread.hpp"
+#include "gc/shenandoah/shenandoahDegeneratedGC.hpp"
+#include "gc/shenandoah/shenandoahFreeSet.hpp"
+#include "gc/shenandoah/shenandoahFullGC.hpp"
+#include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahOldGC.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
+#include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
+#include "gc/shenandoah/shenandoahPacer.inline.hpp"
+#include "gc/shenandoah/shenandoahUtils.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
+#include "logging/log.hpp"
+#include "memory/metaspaceUtils.hpp"
+#include "memory/metaspaceStats.hpp"
+#include "runtime/atomic.hpp"
+
+ShenandoahGenerationalControlThread::ShenandoahGenerationalControlThread() :
+  ShenandoahController(),
+  _control_lock(Mutex::nosafepoint - 2, "ShenandoahControlGC_lock", true),
+  _regulator_lock(Mutex::nosafepoint - 2, "ShenandoahRegulatorGC_lock", true),
+  _requested_gc_cause(GCCause::_no_gc),
+  _requested_generation(GLOBAL),
+  _degen_point(ShenandoahGC::_degenerated_outside_cycle),
+  _degen_generation(nullptr),
+  _mode(none) {
+  shenandoah_assert_generational();
+  set_name("Shenandoah Control Thread");
+  create_and_start();
+}
+
+void ShenandoahGenerationalControlThread::run_service() {
+  ShenandoahHeap* const heap = ShenandoahHeap::heap();
+
+  const GCMode default_mode = concurrent_normal;
+  ShenandoahGenerationType generation = GLOBAL;
+
+  double last_shrink_time = os::elapsedTime();
+  uint age_period = 0;
+
+  // Shrink period avoids constantly polling regions for shrinking.
+  // Having a period 10x lower than the delay would mean we hit the
+  // shrinking with lag of less than 1/10-th of true delay.
+  // ShenandoahUncommitDelay is in msecs, but shrink_period is in seconds.
+  const double shrink_period = (double)ShenandoahUncommitDelay / 1000 / 10;
+
+  ShenandoahCollectorPolicy* const policy = heap->shenandoah_policy();
+
+  // Heuristics are notified of allocation failures here and other outcomes
+  // of the cycle. They're also used here to control whether the Nth consecutive
+  // degenerated cycle should be 'promoted' to a full cycle. The decision to
+  // trigger a cycle or not is evaluated on the regulator thread.
+  ShenandoahHeuristics* global_heuristics = heap->global_generation()->heuristics();
+  while (!in_graceful_shutdown() && !should_terminate()) {
+    // Figure out if we have pending requests.
+    const bool alloc_failure_pending = _alloc_failure_gc.is_set();
+    const bool humongous_alloc_failure_pending = _humongous_alloc_failure_gc.is_set();
+
+    GCCause::Cause cause = Atomic::xchg(&_requested_gc_cause, GCCause::_no_gc);
+
+    const bool is_gc_requested = ShenandoahCollectorPolicy::is_requested_gc(cause);
+
+    // This control loop iteration has seen this much allocation.
+    const size_t allocs_seen = reset_allocs_seen();
+
+    // Check if we have seen a new target for soft max heap size.
+    const bool soft_max_changed = heap->check_soft_max_changed();
+
+    // Choose which GC mode to run in. The block below should select a single mode.
+    set_gc_mode(none);
+    ShenandoahGC::ShenandoahDegenPoint degen_point = ShenandoahGC::_degenerated_unset;
+
+    if (alloc_failure_pending) {
+      // Allocation failure takes precedence: we have to deal with it first thing
+      log_info(gc)("Trigger: Handle Allocation Failure");
+
+      cause = GCCause::_allocation_failure;
+
+      // Consume the degen point, and seed it with default value
+      degen_point = _degen_point;
+      _degen_point = ShenandoahGC::_degenerated_outside_cycle;
+
+      if (degen_point == ShenandoahGC::_degenerated_outside_cycle) {
+        _degen_generation = heap->young_generation();
+      } else {
+        assert(_degen_generation != nullptr, "Need to know which generation to resume");
+      }
+
+      ShenandoahHeuristics* heuristics = _degen_generation->heuristics();
+      generation = _degen_generation->type();
+      bool old_gen_evacuation_failed = heap->old_generation()->clear_failed_evacuation();
+
+      // Do not bother with degenerated cycle if old generation evacuation failed or if humongous allocation failed
+      if (ShenandoahDegeneratedGC && heuristics->should_degenerate_cycle() &&
+          !old_gen_evacuation_failed && !humongous_alloc_failure_pending) {
+        heuristics->record_allocation_failure_gc();
+        policy->record_alloc_failure_to_degenerated(degen_point);
+        set_gc_mode(stw_degenerated);
+      } else {
+        // TODO: if humongous_alloc_failure_pending, there might be value in trying a "compacting" degen before
+        // going all the way to full.  But it's a lot of work to implement this, and it may not provide value.
+        // A compacting degen can move young regions around without doing full old-gen mark (relying upon the
+        // remembered set scan), so it might be faster than a full gc.
+        //
+        // Longer term, think about how to defragment humongous memory concurrently.
+
+        heuristics->record_allocation_failure_gc();
+        policy->record_alloc_failure_to_full();
+        generation = GLOBAL;
+        set_gc_mode(stw_full);
+      }
+    } else if (is_gc_requested) {
+      generation = GLOBAL;
+      log_info(gc)("Trigger: GC request (%s)", GCCause::to_string(cause));
+      global_heuristics->record_requested_gc();
+
+      if (ShenandoahCollectorPolicy::should_run_full_gc(cause)) {
+        set_gc_mode(stw_full);
+      } else {
+        set_gc_mode(default_mode);
+        // Unload and clean up everything
+        heap->set_unload_classes(global_heuristics->can_unload_classes());
+      }
+    } else {
+      // We should only be here if the regulator requested a cycle or if
+      // there is an old generation mark in progress.
+      if (cause == GCCause::_shenandoah_concurrent_gc) {
+        if (_requested_generation == OLD && heap->doing_mixed_evacuations()) {
+          // If a request to start an old cycle arrived while an old cycle was running, but _before_
+          // it chose any regions for evacuation we don't want to start a new old cycle. Rather, we want
+          // the heuristic to run a young collection so that we can evacuate some old regions.
+          assert(!heap->is_concurrent_old_mark_in_progress(), "Should not be running mixed collections and concurrent marking");
+          generation = YOUNG;
+        } else {
+          generation = _requested_generation;
+        }
+
+        // preemption was requested or this is a regular cycle
+        set_gc_mode(default_mode);
+
+        // Don't start a new old marking if there is one already in progress
+        if (generation == OLD && heap->is_concurrent_old_mark_in_progress()) {
+          set_gc_mode(servicing_old);
+        }
+
+        if (generation == GLOBAL) {
+          heap->set_unload_classes(global_heuristics->should_unload_classes());
+        } else {
+          heap->set_unload_classes(false);
+        }
+      } else if (heap->is_concurrent_old_mark_in_progress() || heap->is_prepare_for_old_mark_in_progress()) {
+        // Nobody asked us to do anything, but we have an old-generation mark or old-generation preparation for
+        // mixed evacuation in progress, so resume working on that.
+        log_info(gc)("Resume old GC: marking is%s in progress, preparing is%s in progress",
+                     heap->is_concurrent_old_mark_in_progress() ? "" : " NOT",
+                     heap->is_prepare_for_old_mark_in_progress() ? "" : " NOT");
+
+        cause = GCCause::_shenandoah_concurrent_gc;
+        generation = OLD;
+        set_gc_mode(servicing_old);
+        heap->set_unload_classes(false);
+      }
+    }
+
+    const bool gc_requested = (gc_mode() != none);
+    assert (!gc_requested || cause != GCCause::_no_gc, "GC cause should be set");
+
+    if (gc_requested) {
+      // Blow away all soft references on this cycle, if handling allocation failure,
+      // either implicit or explicit GC request, or we are requested to do so unconditionally.
+      if (generation == GLOBAL && (alloc_failure_pending || is_gc_requested || ShenandoahAlwaysClearSoftRefs)) {
+        heap->soft_ref_policy()->set_should_clear_all_soft_refs(true);
+      }
+
+      // GC is starting, bump the internal ID
+      update_gc_id();
+
+      heap->reset_bytes_allocated_since_gc_start();
+
+      MetaspaceCombinedStats meta_sizes = MetaspaceUtils::get_combined_statistics();
+
+      // If GC was requested, we are sampling the counters even without actual triggers
+      // from allocation machinery. This captures GC phases more accurately.
+      heap->set_forced_counters_update(true);
+
+      // If GC was requested, we better dump freeset data for performance debugging
+      {
+        ShenandoahHeapLocker locker(heap->lock());
+        heap->free_set()->log_status();
+      }
+      // In case this is a degenerated cycle, remember whether original cycle was aging.
+      const bool was_aging_cycle = heap->is_aging_cycle();
+      heap->set_aging_cycle(false);
+
+      switch (gc_mode()) {
+        case concurrent_normal: {
+          // At this point:
+          //  if (generation == YOUNG), this is a normal YOUNG cycle
+          //  if (generation == OLD), this is a bootstrap OLD cycle
+          //  if (generation == GLOBAL), this is a GLOBAL cycle triggered by System.gc()
+          // In all three cases, we want to age old objects if this is an aging cycle
+          if (age_period-- == 0) {
+             heap->set_aging_cycle(true);
+             age_period = ShenandoahAgingCyclePeriod - 1;
+          }
+          service_concurrent_normal_cycle(heap, generation, cause);
+          break;
+        }
+        case stw_degenerated: {
+          heap->set_aging_cycle(was_aging_cycle);
+          service_stw_degenerated_cycle(cause, degen_point);
+          break;
+        }
+        case stw_full: {
+          if (age_period-- == 0) {
+            heap->set_aging_cycle(true);
+            age_period = ShenandoahAgingCyclePeriod - 1;
+          }
+          service_stw_full_cycle(cause);
+          break;
+        }
+        case servicing_old: {
+          assert(generation == OLD, "Expected old generation here");
+          GCIdMark gc_id_mark;
+          service_concurrent_old_cycle(heap, cause);
+          break;
+        }
+        default:
+          ShouldNotReachHere();
+      }
+
+      // If this was the requested GC cycle, notify waiters about it
+      if (is_gc_requested) {
+        notify_gc_waiters();
+      }
+
+      // If this was the allocation failure GC cycle, notify waiters about it
+      if (alloc_failure_pending) {
+        notify_alloc_failure_waiters();
+      }
+
+      // Report current free set state at the end of cycle, whether
+      // it is a normal completion, or the abort.
+      {
+        ShenandoahHeapLocker locker(heap->lock());
+        heap->free_set()->log_status();
+
+        // Notify Universe about new heap usage. This has implications for
+        // global soft refs policy, and we better report it every time heap
+        // usage goes down.
+        heap->update_capacity_and_used_at_gc();
+
+        // Signal that we have completed a visit to all live objects.
+        heap->record_whole_heap_examined_timestamp();
+      }
+
+      // Disable forced counters update, and update counters one more time
+      // to capture the state at the end of GC session.
+      heap->handle_force_counters_update();
+      heap->set_forced_counters_update(false);
+
+      // Retract forceful part of soft refs policy
+      heap->soft_ref_policy()->set_should_clear_all_soft_refs(false);
+
+      // Clear metaspace oom flag, if current cycle unloaded classes
+      if (heap->unload_classes()) {
+        global_heuristics->clear_metaspace_oom();
+      }
+
+      process_phase_timings(heap);
+
+      // Print Metaspace change following GC (if logging is enabled).
+      MetaspaceUtils::print_metaspace_change(meta_sizes);
+
+      // GC is over, we are at idle now
+      if (ShenandoahPacing) {
+        heap->pacer()->setup_for_idle();
+      }
+    } else {
+      // Report to pacer that we have seen this many words allocated
+      if (ShenandoahPacing && (allocs_seen > 0)) {
+        heap->pacer()->report_alloc(allocs_seen);
+      }
+    }
+
+    const double current = os::elapsedTime();
+
+    if (ShenandoahUncommit && (is_gc_requested || soft_max_changed || (current - last_shrink_time > shrink_period))) {
+      // Explicit GC tries to uncommit everything down to min capacity.
+      // Soft max change tries to uncommit everything down to target capacity.
+      // Periodic uncommit tries to uncommit suitable regions down to min capacity.
+
+      double shrink_before = (is_gc_requested || soft_max_changed) ?
+                             current :
+                             current - (ShenandoahUncommitDelay / 1000.0);
+
+      size_t shrink_until = soft_max_changed ?
+                             heap->soft_max_capacity() :
+                             heap->min_capacity();
+
+      heap->maybe_uncommit(shrink_before, shrink_until);
+      heap->phase_timings()->flush_cycle_to_global();
+      last_shrink_time = current;
+    }
+
+    // Wait for ShenandoahControlIntervalMax unless there was an allocation failure or another request was made mid-cycle.
+    if (!is_alloc_failure_gc() && _requested_gc_cause == GCCause::_no_gc) {
+      // The timed wait is necessary because this thread has a responsibility to send
+      // 'alloc_words' to the pacer when it does not perform a GC.
+      MonitorLocker lock(&_control_lock, Mutex::_no_safepoint_check_flag);
+      lock.wait(ShenandoahControlIntervalMax);
+    }
+  }
+
+  // Wait for the actual stop(), can't leave run_service() earlier.
+  while (!should_terminate()) {
+    os::naked_short_sleep(ShenandoahControlIntervalMin);
+  }
+}
+
+void ShenandoahGenerationalControlThread::process_phase_timings(const ShenandoahHeap* heap) {
+  // Commit worker statistics to cycle data
+  heap->phase_timings()->flush_par_workers_to_cycle();
+  if (ShenandoahPacing) {
+    heap->pacer()->flush_stats_to_cycle();
+  }
+
+  ShenandoahEvacuationTracker* evac_tracker = heap->evac_tracker();
+  ShenandoahCycleStats         evac_stats   = evac_tracker->flush_cycle_to_global();
+
+  // Print GC stats for current cycle
+  {
+    LogTarget(Info, gc, stats) lt;
+    if (lt.is_enabled()) {
+      ResourceMark rm;
+      LogStream ls(lt);
+      heap->phase_timings()->print_cycle_on(&ls);
+      evac_tracker->print_evacuations_on(&ls, &evac_stats.workers,
+                                              &evac_stats.mutators);
+      if (ShenandoahPacing) {
+        heap->pacer()->print_cycle_on(&ls);
+      }
+    }
+  }
+
+  // Commit statistics to globals
+  heap->phase_timings()->flush_cycle_to_global();
+}
+
+// Young and old concurrent cycles are initiated by the regulator. Implicit
+// and explicit GC requests are handled by the controller thread and always
+// run a global cycle (which is concurrent by default, but may be overridden
+// by command line options). Old cycles always degenerate to a global cycle.
+// Young cycles are degenerated to complete the young cycle.  Young
+// and old degen may upgrade to Full GC.  Full GC may also be
+// triggered directly by a System.gc() invocation.
+//
+//
+//      +-----+ Idle +-----+-----------+---------------------+
+//      |         +        |           |                     |
+//      |         |        |           |                     |
+//      |         |        v           |                     |
+//      |         |  Bootstrap Old +-- | ------------+       |
+//      |         |   +                |             |       |
+//      |         |   |                |             |       |
+//      |         v   v                v             v       |
+//      |    Resume Old <----------+ Young +--> Young Degen  |
+//      |     +  +   ^                            +  +       |
+//      v     |  |   |                            |  |       |
+//   Global <-+  |   +----------------------------+  |       |
+//      +        |                                   |       |
+//      |        v                                   v       |
+//      +--->  Global Degen +--------------------> Full <----+
+//
+void ShenandoahGenerationalControlThread::service_concurrent_normal_cycle(ShenandoahHeap* heap,
+                                                              const ShenandoahGenerationType generation,
+                                                              GCCause::Cause cause) {
+  GCIdMark gc_id_mark;
+  switch (generation) {
+    case YOUNG: {
+      // Run a young cycle. This might or might not, have interrupted an ongoing
+      // concurrent mark in the old generation. We need to think about promotions
+      // in this case. Promoted objects should be above the TAMS in the old regions
+      // they end up in, but we have to be sure we don't promote into any regions
+      // that are in the cset.
+      log_info(gc, ergo)("Start GC cycle (YOUNG)");
+      service_concurrent_cycle(heap->young_generation(), cause, false);
+      break;
+    }
+    case OLD: {
+      log_info(gc, ergo)("Start GC cycle (OLD)");
+      service_concurrent_old_cycle(heap, cause);
+      break;
+    }
+    case GLOBAL: {
+      log_info(gc, ergo)("Start GC cycle (GLOBAL)");
+      service_concurrent_cycle(heap->global_generation(), cause, false);
+      break;
+    }
+    default:
+      ShouldNotReachHere();
+  }
+}
+
+void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(ShenandoahHeap* heap, GCCause::Cause &cause) {
+  ShenandoahOldGeneration* old_generation = heap->old_generation();
+  ShenandoahYoungGeneration* young_generation = heap->young_generation();
+  ShenandoahOldGeneration::State original_state = old_generation->state();
+
+  TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
+
+  switch (original_state) {
+    case ShenandoahOldGeneration::FILLING: {
+      _allow_old_preemption.set();
+      old_generation->entry_coalesce_and_fill();
+      _allow_old_preemption.unset();
+
+      // Before bootstrapping begins, we must acknowledge any cancellation request.
+      // If the gc has not been cancelled, this does nothing. If it has been cancelled,
+      // this will clear the cancellation request and exit before starting the bootstrap
+      // phase. This will allow the young GC cycle to proceed normally. If we do not
+      // acknowledge the cancellation request, the subsequent young cycle will observe
+      // the request and essentially cancel itself.
+      if (check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle)) {
+        log_info(gc)("Preparation for old generation cycle was cancelled");
+        return;
+      }
+
+      // Coalescing threads completed and nothing was cancelled. it is safe to transition from this state.
+      old_generation->transition_to(ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP);
+      return;
+    }
+    case ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP:
+      old_generation->transition_to(ShenandoahOldGeneration::BOOTSTRAPPING);
+    case ShenandoahOldGeneration::BOOTSTRAPPING: {
+      // Configure the young generation's concurrent mark to put objects in
+      // old regions into the concurrent mark queues associated with the old
+      // generation. The young cycle will run as normal except that rather than
+      // ignore old references it will mark and enqueue them in the old concurrent
+      // task queues but it will not traverse them.
+      set_gc_mode(bootstrapping_old);
+      young_generation->set_old_gen_task_queues(old_generation->task_queues());
+      ShenandoahGCSession session(cause, young_generation);
+      service_concurrent_cycle(heap, young_generation, cause, true);
+      process_phase_timings(heap);
+      if (heap->cancelled_gc()) {
+        // Young generation bootstrap cycle has failed. Concurrent mark for old generation
+        // is going to resume after degenerated bootstrap cycle completes.
+        log_info(gc)("Bootstrap cycle for old generation was cancelled");
+        return;
+      }
+
+      // Reset the degenerated point. Normally this would happen at the top
+      // of the control loop, but here we have just completed a young cycle
+      // which has bootstrapped the old concurrent marking.
+      _degen_point = ShenandoahGC::_degenerated_outside_cycle;
+
+      // From here we will 'resume' the old concurrent mark. This will skip reset
+      // and init mark for the concurrent mark. All of that work will have been
+      // done by the bootstrapping young cycle.
+      set_gc_mode(servicing_old);
+      old_generation->transition_to(ShenandoahOldGeneration::MARKING);
+    }
+    case ShenandoahOldGeneration::MARKING: {
+      ShenandoahGCSession session(cause, old_generation);
+      bool marking_complete = resume_concurrent_old_cycle(old_generation, cause);
+      if (marking_complete) {
+        assert(old_generation->state() != ShenandoahOldGeneration::MARKING, "Should not still be marking");
+        if (original_state == ShenandoahOldGeneration::MARKING) {
+          heap->mmu_tracker()->record_old_marking_increment(true);
+          heap->log_heap_status("At end of Concurrent Old Marking finishing increment");
+        }
+      } else if (original_state == ShenandoahOldGeneration::MARKING) {
+        heap->mmu_tracker()->record_old_marking_increment(false);
+        heap->log_heap_status("At end of Concurrent Old Marking increment");
+      }
+      break;
+    }
+    default:
+      fatal("Unexpected state for old GC: %s", ShenandoahOldGeneration::state_name(old_generation->state()));
+  }
+}
+
+bool ShenandoahGenerationalControlThread::resume_concurrent_old_cycle(ShenandoahGeneration* generation, GCCause::Cause cause) {
+  assert(ShenandoahHeap::heap()->is_concurrent_old_mark_in_progress(), "Old mark should be in progress");
+  log_debug(gc)("Resuming old generation with " UINT32_FORMAT " marking tasks queued", generation->task_queues()->tasks());
+
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+
+  // We can only tolerate being cancelled during concurrent marking or during preparation for mixed
+  // evacuation. This flag here (passed by reference) is used to control precisely where the regulator
+  // is allowed to cancel a GC.
+  ShenandoahOldGC gc(generation, _allow_old_preemption);
+  if (gc.collect(cause)) {
+    generation->record_success_concurrent(false);
+  }
+
+  if (heap->cancelled_gc()) {
+    // It's possible the gc cycle was cancelled after the last time
+    // the collection checked for cancellation. In which case, the
+    // old gc cycle is still completed, and we have to deal with this
+    // cancellation. We set the degeneration point to be outside
+    // the cycle because if this is an allocation failure, that is
+    // what must be done (there is no degenerated old cycle). If the
+    // cancellation was due to a heuristic wanting to start a young
+    // cycle, then we are not actually going to a degenerated cycle,
+    // so the degenerated point doesn't matter here.
+    check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle);
+    if (_requested_gc_cause == GCCause::_shenandoah_concurrent_gc) {
+      heap->shenandoah_policy()->record_interrupted_old();
+    }
+    return false;
+  }
+  return true;
+}
+
+void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahGeneration* generation, GCCause::Cause cause, bool do_old_gc_bootstrap) {
+  // Normal cycle goes via all concurrent phases. If allocation failure (af) happens during
+  // any of the concurrent phases, it first degrades to Degenerated GC and completes GC there.
+  // If second allocation failure happens during Degenerated GC cycle (for example, when GC
+  // tries to evac something and no memory is available), cycle degrades to Full GC.
+  //
+  // There are also a shortcut through the normal cycle: immediate garbage shortcut, when
+  // heuristics says there are no regions to compact, and all the collection comes from immediately
+  // reclaimable regions.
+  //
+  // ................................................................................................
+  //
+  //                                    (immediate garbage shortcut)                Concurrent GC
+  //                             /-------------------------------------------\
+  //                             |                                           |
+  //                             |                                           |
+  //                             |                                           |
+  //                             |                                           v
+  // [START] ----> Conc Mark ----o----> Conc Evac --o--> Conc Update-Refs ---o----> [END]
+  //                   |                    |                 |              ^
+  //                   | (af)               | (af)            | (af)         |
+  // ..................|....................|.................|..............|.......................
+  //                   |                    |                 |              |
+  //                   |                    |                 |              |      Degenerated GC
+  //                   v                    v                 v              |
+  //               STW Mark ----------> STW Evac ----> STW Update-Refs ----->o
+  //                   |                    |                 |              ^
+  //                   | (af)               | (af)            | (af)         |
+  // ..................|....................|.................|..............|.......................
+  //                   |                    |                 |              |
+  //                   |                    v                 |              |      Full GC
+  //                   \------------------->o<----------------/              |
+  //                                        |                                |
+  //                                        v                                |
+  //                                      Full GC  --------------------------/
+  //
+  if (check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle)) return;
+
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  ShenandoahGCSession session(cause, generation);
+  TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
+
+  service_concurrent_cycle(heap, generation, cause, do_old_gc_bootstrap);
+}
+
+void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahHeap* heap,
+                                                       ShenandoahGeneration* generation,
+                                                       GCCause::Cause& cause,
+                                                       bool do_old_gc_bootstrap) {
+  assert(!generation->is_old(), "Old GC takes a different control path");
+
+  ShenandoahConcurrentGC gc(generation, do_old_gc_bootstrap);
+  if (gc.collect(cause)) {
+    // Cycle is complete
+    generation->record_success_concurrent(gc.abbreviated());
+  } else {
+    assert(heap->cancelled_gc(), "Must have been cancelled");
+    check_cancellation_or_degen(gc.degen_point());
+
+    // Concurrent young-gen collection degenerates to young
+    // collection.  Same for global collections.
+    _degen_generation = generation;
+  }
+  const char* msg;
+  ShenandoahMmuTracker* mmu_tracker = heap->mmu_tracker();
+  if (generation->is_young()) {
+    if (heap->cancelled_gc()) {
+      msg = (do_old_gc_bootstrap) ? "At end of Interrupted Concurrent Bootstrap GC" :
+            "At end of Interrupted Concurrent Young GC";
+    } else {
+      // We only record GC results if GC was successful
+      msg = (do_old_gc_bootstrap) ? "At end of Concurrent Bootstrap GC" :
+            "At end of Concurrent Young GC";
+      if (heap->collection_set()->has_old_regions()) {
+        mmu_tracker->record_mixed(get_gc_id());
+      } else if (do_old_gc_bootstrap) {
+        mmu_tracker->record_bootstrap(get_gc_id());
+      } else {
+        mmu_tracker->record_young(get_gc_id());
+      }
+    }
+  } else {
+    assert(generation->is_global(), "If not young, must be GLOBAL");
+    assert(!do_old_gc_bootstrap, "Do not bootstrap with GLOBAL GC");
+    if (heap->cancelled_gc()) {
+      msg = "At end of Interrupted Concurrent GLOBAL GC";
+    } else {
+      // We only record GC results if GC was successful
+      msg = "At end of Concurrent Global GC";
+      mmu_tracker->record_global(get_gc_id());
+    }
+  }
+  heap->log_heap_status(msg);
+}
+
+bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint point) {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  if (!heap->cancelled_gc()) {
+    return false;
+  }
+
+  if (in_graceful_shutdown()) {
+    return true;
+  }
+
+  assert(_degen_point == ShenandoahGC::_degenerated_outside_cycle,
+         "Should not be set yet: %s", ShenandoahGC::degen_point_to_string(_degen_point));
+
+  if (is_alloc_failure_gc()) {
+    _degen_point = point;
+    _preemption_requested.unset();
+    return true;
+  }
+
+  if (_preemption_requested.is_set()) {
+    assert(_requested_generation == YOUNG, "Only young GCs may preempt old.");
+    _preemption_requested.unset();
+
+    // Old generation marking is only cancellable during concurrent marking.
+    // Once final mark is complete, the code does not check again for cancellation.
+    // If old generation was cancelled for an allocation failure, we wouldn't
+    // make it to this case. The calling code is responsible for forcing a
+    // cancellation due to allocation failure into a degenerated cycle.
+    _degen_point = point;
+    heap->clear_cancelled_gc(false /* clear oom handler */);
+    return true;
+  }
+
+  fatal("Cancel GC either for alloc failure GC, or gracefully exiting, or to pause old generation marking");
+  return false;
+}
+
+void ShenandoahGenerationalControlThread::stop_service() {
+  // Nothing to do here.
+}
+
+void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause cause) {
+  ShenandoahHeap* const heap = ShenandoahHeap::heap();
+
+  GCIdMark gc_id_mark;
+  ShenandoahGCSession session(cause, heap->global_generation());
+
+  ShenandoahFullGC gc;
+  gc.collect(cause);
+}
+
+void ShenandoahGenerationalControlThread::service_stw_degenerated_cycle(GCCause::Cause cause,
+                                                            ShenandoahGC::ShenandoahDegenPoint point) {
+  assert(point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
+  ShenandoahHeap* const heap = ShenandoahHeap::heap();
+
+  GCIdMark gc_id_mark;
+  ShenandoahGCSession session(cause, _degen_generation);
+
+  ShenandoahDegenGC gc(point, _degen_generation);
+  gc.collect(cause);
+
+  assert(heap->young_generation()->task_queues()->is_empty(), "Unexpected young generation marking tasks");
+  if (_degen_generation->is_global()) {
+    assert(heap->old_generation()->task_queues()->is_empty(), "Unexpected old generation marking tasks");
+    assert(heap->global_generation()->task_queues()->is_empty(), "Unexpected global generation marking tasks");
+  } else {
+    assert(_degen_generation->is_young(), "Expected degenerated young cycle, if not global.");
+    ShenandoahOldGeneration* old = heap->old_generation();
+    if (old->state() == ShenandoahOldGeneration::BOOTSTRAPPING) {
+      old->transition_to(ShenandoahOldGeneration::MARKING);
+    }
+  }
+}
+
+void ShenandoahGenerationalControlThread::request_gc(GCCause::Cause cause) {
+  if (ShenandoahCollectorPolicy::should_handle_requested_gc(cause)) {
+    handle_requested_gc(cause);
+  }
+}
+
+bool ShenandoahGenerationalControlThread::request_concurrent_gc(ShenandoahGenerationType generation) {
+  if (_preemption_requested.is_set() || _requested_gc_cause != GCCause::_no_gc || ShenandoahHeap::heap()->cancelled_gc()) {
+    // Ignore subsequent requests from the heuristics
+    log_debug(gc, thread)("Reject request for concurrent gc: preemption_requested: %s, gc_requested: %s, gc_cancelled: %s",
+                          BOOL_TO_STR(_preemption_requested.is_set()),
+                          GCCause::to_string(_requested_gc_cause),
+                          BOOL_TO_STR(ShenandoahHeap::heap()->cancelled_gc()));
+    return false;
+  }
+
+  if (gc_mode() == none) {
+    GCCause::Cause existing = Atomic::cmpxchg(&_requested_gc_cause, GCCause::_no_gc, GCCause::_shenandoah_concurrent_gc);
+    if (existing != GCCause::_no_gc) {
+      log_debug(gc, thread)("Reject request for concurrent gc because another gc is pending: %s", GCCause::to_string(existing));
+      return false;
+    }
+
+    _requested_generation = generation;
+    notify_control_thread();
+
+    MonitorLocker ml(&_regulator_lock, Mutex::_no_safepoint_check_flag);
+    while (gc_mode() == none) {
+      ml.wait();
+    }
+    return true;
+  }
+
+  if (preempt_old_marking(generation)) {
+    assert(gc_mode() == servicing_old, "Expected to be servicing old, but was: %s.", gc_mode_name(gc_mode()));
+    GCCause::Cause existing = Atomic::cmpxchg(&_requested_gc_cause, GCCause::_no_gc, GCCause::_shenandoah_concurrent_gc);
+    if (existing != GCCause::_no_gc) {
+      log_debug(gc, thread)("Reject request to interrupt old gc because another gc is pending: %s", GCCause::to_string(existing));
+      return false;
+    }
+
+    log_info(gc)("Preempting old generation mark to allow %s GC", shenandoah_generation_name(generation));
+    _requested_generation = generation;
+    _preemption_requested.set();
+    ShenandoahHeap::heap()->cancel_gc(GCCause::_shenandoah_concurrent_gc);
+    notify_control_thread();
+
+    MonitorLocker ml(&_regulator_lock, Mutex::_no_safepoint_check_flag);
+    while (gc_mode() == servicing_old) {
+      ml.wait();
+    }
+    return true;
+  }
+
+  log_debug(gc, thread)("Reject request for concurrent gc: mode: %s, allow_old_preemption: %s",
+                        gc_mode_name(gc_mode()),
+                        BOOL_TO_STR(_allow_old_preemption.is_set()));
+  return false;
+}
+
+void ShenandoahGenerationalControlThread::notify_control_thread() {
+  MonitorLocker locker(&_control_lock, Mutex::_no_safepoint_check_flag);
+  _control_lock.notify();
+}
+
+bool ShenandoahGenerationalControlThread::preempt_old_marking(ShenandoahGenerationType generation) {
+  return (generation == YOUNG) && _allow_old_preemption.try_unset();
+}
+
+void ShenandoahGenerationalControlThread::handle_requested_gc(GCCause::Cause cause) {
+  // Make sure we have at least one complete GC cycle before unblocking
+  // from the explicit GC request.
+  //
+  // This is especially important for weak references cleanup and/or native
+  // resources (e.g. DirectByteBuffers) machinery: when explicit GC request
+  // comes very late in the already running cycle, it would miss lots of new
+  // opportunities for cleanup that were made available before the caller
+  // requested the GC.
+
+  MonitorLocker ml(&_gc_waiters_lock);
+  size_t current_gc_id = get_gc_id();
+  size_t required_gc_id = current_gc_id + 1;
+  while (current_gc_id < required_gc_id) {
+    // This races with the regulator thread to start a concurrent gc and the
+    // control thread to clear it at the start of a cycle. Threads here are
+    // allowed to escalate a heuristic's request for concurrent gc.
+    GCCause::Cause existing = Atomic::xchg(&_requested_gc_cause, cause);
+    if (existing != GCCause::_no_gc) {
+      log_debug(gc, thread)("GC request supersedes existing request: %s", GCCause::to_string(existing));
+    }
+
+    notify_control_thread();
+    if (cause != GCCause::_wb_breakpoint) {
+      ml.wait();
+    }
+    current_gc_id = get_gc_id();
+  }
+}
+
+void ShenandoahGenerationalControlThread::notify_gc_waiters() {
+  MonitorLocker ml(&_gc_waiters_lock);
+  ml.notify_all();
+}
+
+const char* ShenandoahGenerationalControlThread::gc_mode_name(ShenandoahGenerationalControlThread::GCMode mode) {
+  switch (mode) {
+    case none:              return "idle";
+    case concurrent_normal: return "normal";
+    case stw_degenerated:   return "degenerated";
+    case stw_full:          return "full";
+    case servicing_old:     return "old";
+    case bootstrapping_old: return "bootstrap";
+    default:                return "unknown";
+  }
+}
+
+void ShenandoahGenerationalControlThread::set_gc_mode(ShenandoahGenerationalControlThread::GCMode new_mode) {
+  if (_mode != new_mode) {
+    log_info(gc)("Transition from: %s to: %s", gc_mode_name(_mode), gc_mode_name(new_mode));
+    MonitorLocker ml(&_regulator_lock, Mutex::_no_safepoint_check_flag);
+    _mode = new_mode;
+    ml.notify_all();
+  }
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALCONTROLTHREAD_HPP
+#define SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALCONTROLTHREAD_HPP
+
+#include "gc/shared/gcCause.hpp"
+#include "gc/shenandoah/shenandoahController.hpp"
+#include "gc/shenandoah/shenandoahGC.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
+#include "gc/shenandoah/shenandoahPadding.hpp"
+#include "gc/shenandoah/shenandoahSharedVariables.hpp"
+
+class ShenandoahGenerationalControlThread: public ShenandoahController {
+  friend class VMStructs;
+
+public:
+  typedef enum {
+    none,
+    concurrent_normal,
+    stw_degenerated,
+    stw_full,
+    bootstrapping_old,
+    servicing_old
+  } GCMode;
+
+private:
+  Monitor _control_lock;
+  Monitor _regulator_lock;
+
+  ShenandoahSharedFlag _allow_old_preemption;
+  ShenandoahSharedFlag _preemption_requested;
+
+  GCCause::Cause  _requested_gc_cause;
+  volatile ShenandoahGenerationType _requested_generation;
+  ShenandoahGC::ShenandoahDegenPoint _degen_point;
+  ShenandoahGeneration* _degen_generation;
+
+  shenandoah_padding(0);
+  volatile GCMode _mode;
+  shenandoah_padding(1);
+
+public:
+  ShenandoahGenerationalControlThread();
+
+  void run_service() override;
+  void stop_service() override;
+
+  void request_gc(GCCause::Cause cause) override;
+
+  // Return true if the request to start a concurrent GC for the given generation succeeded.
+  bool request_concurrent_gc(ShenandoahGenerationType generation);
+
+  GCMode gc_mode() {
+    return _mode;
+  }
+private:
+
+  // Returns true if the cycle has been cancelled or degenerated.
+  bool check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint point);
+
+  // Returns true if the old generation marking completed (i.e., final mark executed for old generation).
+  bool resume_concurrent_old_cycle(ShenandoahGeneration* generation, GCCause::Cause cause);
+  void service_concurrent_cycle(ShenandoahGeneration* generation, GCCause::Cause cause, bool reset_old_bitmap_specially);
+  void service_stw_full_cycle(GCCause::Cause cause);
+  void service_stw_degenerated_cycle(GCCause::Cause cause, ShenandoahGC::ShenandoahDegenPoint point);
+
+  void notify_gc_waiters();
+
+  // Handle GC request.
+  // Blocks until GC is over.
+  void handle_requested_gc(GCCause::Cause cause);
+
+  bool is_explicit_gc(GCCause::Cause cause) const;
+  bool is_implicit_gc(GCCause::Cause cause) const;
+
+  // Returns true if the old generation marking was interrupted to allow a young cycle.
+  bool preempt_old_marking(ShenandoahGenerationType generation);
+
+  void process_phase_timings(const ShenandoahHeap* heap);
+
+  void service_concurrent_normal_cycle(ShenandoahHeap* heap,
+                                       ShenandoahGenerationType generation,
+                                       GCCause::Cause cause);
+
+  void service_concurrent_old_cycle(ShenandoahHeap* heap,
+                                    GCCause::Cause &cause);
+
+  void set_gc_mode(GCMode new_mode);
+
+  static const char* gc_mode_name(GCMode mode);
+
+  void notify_control_thread();
+
+  void service_concurrent_cycle(ShenandoahHeap* heap,
+                                ShenandoahGeneration* generation,
+                                GCCause::Cause &cause,
+                                bool do_old_gc_bootstrap);
+
+};
+
+#endif // SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALCONTROLTHREAD_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
@@ -1,0 +1,378 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "gc/shared/preservedMarks.inline.hpp"
+#include "gc/shenandoah/shenandoahGenerationalFullGC.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
+#include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
+#include "gc/shenandoah/shenandoahUtils.hpp"
+
+#ifdef ASSERT
+void assert_regions_used_not_more_than_capacity(ShenandoahGeneration* generation) {
+  assert(generation->used_regions_size() <= generation->max_capacity(),
+         "%s generation affiliated regions must be less than capacity", generation->name());
+}
+
+void assert_usage_not_more_than_regions_used(ShenandoahGeneration* generation) {
+  assert(generation->used_including_humongous_waste() <= generation->used_regions_size(),
+         "%s consumed can be no larger than span of affiliated regions", generation->name());
+}
+#else
+void assert_regions_used_not_more_than_capacity(ShenandoahGeneration* generation) {}
+void assert_usage_not_more_than_regions_used(ShenandoahGeneration* generation) {}
+#endif
+
+
+void ShenandoahGenerationalFullGC::prepare() {
+  auto heap = ShenandoahGenerationalHeap::heap();
+  // Since we may arrive here from degenerated GC failure of either young or old, establish generation as GLOBAL.
+  heap->set_gc_generation(heap->global_generation());
+
+  // No need for old_gen->increase_used() as this was done when plabs were allocated.
+  heap->reset_generation_reserves();
+
+  // Full GC supersedes any marking or coalescing in old generation.
+  heap->cancel_old_gc();
+}
+
+void ShenandoahGenerationalFullGC::handle_completion(ShenandoahHeap* heap) {
+  // Full GC should reset time since last gc for young and old heuristics
+  ShenandoahYoungGeneration* young = heap->young_generation();
+  ShenandoahOldGeneration* old = heap->old_generation();
+  young->heuristics()->record_cycle_end();
+  old->heuristics()->record_cycle_end();
+
+  heap->mmu_tracker()->record_full(GCId::current());
+  heap->log_heap_status("At end of Full GC");
+
+  assert(old->state() == ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP,
+         "After full GC, old generation should be waiting for bootstrap.");
+
+  // Since we allow temporary violation of these constraints during Full GC, we want to enforce that the assertions are
+  // made valid by the time Full GC completes.
+  assert_regions_used_not_more_than_capacity(old);
+  assert_regions_used_not_more_than_capacity(young);
+  assert_usage_not_more_than_regions_used(old);
+  assert_usage_not_more_than_regions_used(young);
+
+  // Establish baseline for next old-has-grown trigger.
+  old->set_live_bytes_after_last_mark(old->used_including_humongous_waste());
+}
+
+void ShenandoahGenerationalFullGC::rebuild_remembered_set(ShenandoahHeap* heap) {
+  ShenandoahGCPhase phase(ShenandoahPhaseTimings::full_gc_reconstruct_remembered_set);
+  ShenandoahRegionIterator regions;
+  ShenandoahReconstructRememberedSetTask task(&regions);
+  heap->workers()->run_task(&task);
+}
+
+void ShenandoahGenerationalFullGC::balance_generations_after_gc(ShenandoahHeap* heap) {
+  size_t old_usage = heap->old_generation()->used_regions_size();
+  size_t old_capacity = heap->old_generation()->max_capacity();
+
+  assert(old_usage % ShenandoahHeapRegion::region_size_bytes() == 0, "Old usage must align with region size");
+  assert(old_capacity % ShenandoahHeapRegion::region_size_bytes() == 0, "Old capacity must align with region size");
+
+  if (old_capacity > old_usage) {
+    size_t excess_old_regions = (old_capacity - old_usage) / ShenandoahHeapRegion::region_size_bytes();
+    heap->generation_sizer()->transfer_to_young(excess_old_regions);
+  } else if (old_capacity < old_usage) {
+    size_t old_regions_deficit = (old_usage - old_capacity) / ShenandoahHeapRegion::region_size_bytes();
+    heap->generation_sizer()->force_transfer_to_old(old_regions_deficit);
+  }
+
+  log_info(gc)("FullGC done: young usage: " PROPERFMT ", old usage: " PROPERFMT,
+               PROPERFMTARGS(heap->young_generation()->used()),
+               PROPERFMTARGS(heap->old_generation()->used()));
+}
+
+void ShenandoahGenerationalFullGC::balance_generations_after_rebuilding_free_set() {
+  auto result = ShenandoahGenerationalHeap::heap()->balance_generations();
+  LogTarget(Info, gc, ergo) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    result.print_on("Full GC", &ls);
+  }
+}
+
+void ShenandoahGenerationalFullGC::log_live_in_old(ShenandoahHeap* heap) {
+  LogTarget(Info, gc) lt;
+  if (lt.is_enabled()) {
+    size_t live_bytes_in_old = 0;
+    for (size_t i = 0; i < heap->num_regions(); i++) {
+      ShenandoahHeapRegion* r = heap->get_region(i);
+      if (r->is_old()) {
+        live_bytes_in_old += r->get_live_data_bytes();
+      }
+    }
+    log_info(gc)("Live bytes in old after STW mark: " PROPERFMT, PROPERFMTARGS(live_bytes_in_old));
+  }
+}
+
+void ShenandoahGenerationalFullGC::restore_top_before_promote(ShenandoahHeap* heap) {
+  for (size_t i = 0; i < heap->num_regions(); i++) {
+    ShenandoahHeapRegion* r = heap->get_region(i);
+    if (r->get_top_before_promote() != nullptr) {
+      r->restore_top_before_promote();
+    }
+  }
+}
+
+void ShenandoahGenerationalFullGC::account_for_region(ShenandoahHeapRegion* r, size_t &region_count, size_t &region_usage, size_t &humongous_waste) {
+  region_count++;
+  region_usage += r->used();
+  if (r->is_humongous_start()) {
+    // For each humongous object, we take this path once regardless of how many regions it spans.
+    HeapWord* obj_addr = r->bottom();
+    oop obj = cast_to_oop(obj_addr);
+    size_t word_size = obj->size();
+    size_t region_size_words = ShenandoahHeapRegion::region_size_words();
+    size_t overreach = word_size % region_size_words;
+    if (overreach != 0) {
+      humongous_waste += (region_size_words - overreach) * HeapWordSize;
+    }
+    // else, this humongous object aligns exactly on region size, so no waste.
+  }
+}
+
+void ShenandoahGenerationalFullGC::maybe_coalesce_and_fill_region(ShenandoahHeapRegion* r) {
+  if (r->is_pinned() && r->is_old() && r->is_active() && !r->is_humongous()) {
+    r->begin_preemptible_coalesce_and_fill();
+    r->oop_fill_and_coalesce_without_cancel();
+  }
+}
+
+void ShenandoahGenerationalFullGC::compute_balances() {
+  auto heap = ShenandoahGenerationalHeap::heap();
+
+  // In case this Full GC resulted from degeneration, clear the tally on anticipated promotion.
+  heap->old_generation()->set_promotion_potential(0);
+  // Invoke this in case we are able to transfer memory from OLD to YOUNG.
+  heap->compute_old_generation_balance(0, 0);
+}
+
+ShenandoahPrepareForGenerationalCompactionObjectClosure::ShenandoahPrepareForGenerationalCompactionObjectClosure(PreservedMarks* preserved_marks,
+                                                          GrowableArray<ShenandoahHeapRegion*>& empty_regions,
+                                                          ShenandoahHeapRegion* from_region, uint worker_id) :
+        _preserved_marks(preserved_marks),
+        _heap(ShenandoahHeap::heap()),
+        _tenuring_threshold(0),
+        _empty_regions(empty_regions),
+        _empty_regions_pos(0),
+        _old_to_region(nullptr),
+        _young_to_region(nullptr),
+        _from_region(nullptr),
+        _from_affiliation(ShenandoahAffiliation::FREE),
+        _old_compact_point(nullptr),
+        _young_compact_point(nullptr),
+        _worker_id(worker_id) {
+  assert(from_region != nullptr, "Worker needs from_region");
+  // assert from_region has live?
+  if (from_region->is_old()) {
+    _old_to_region = from_region;
+    _old_compact_point = from_region->bottom();
+  } else if (from_region->is_young()) {
+    _young_to_region = from_region;
+    _young_compact_point = from_region->bottom();
+  }
+
+  _tenuring_threshold = _heap->age_census()->tenuring_threshold();
+}
+
+void ShenandoahPrepareForGenerationalCompactionObjectClosure::set_from_region(ShenandoahHeapRegion* from_region) {
+  log_debug(gc)("Worker %u compacting %s Region " SIZE_FORMAT " which had used " SIZE_FORMAT " and %s live",
+                _worker_id, from_region->affiliation_name(),
+                from_region->index(), from_region->used(), from_region->has_live()? "has": "does not have");
+
+  _from_region = from_region;
+  _from_affiliation = from_region->affiliation();
+  if (_from_region->has_live()) {
+    if (_from_affiliation == ShenandoahAffiliation::OLD_GENERATION) {
+      if (_old_to_region == nullptr) {
+        _old_to_region = from_region;
+        _old_compact_point = from_region->bottom();
+      }
+    } else {
+      assert(_from_affiliation == ShenandoahAffiliation::YOUNG_GENERATION, "from_region must be OLD or YOUNG");
+      if (_young_to_region == nullptr) {
+        _young_to_region = from_region;
+        _young_compact_point = from_region->bottom();
+      }
+    }
+  } // else, we won't iterate over this _from_region so we don't need to set up to region to hold copies
+}
+
+void ShenandoahPrepareForGenerationalCompactionObjectClosure::finish() {
+  finish_old_region();
+  finish_young_region();
+}
+
+void ShenandoahPrepareForGenerationalCompactionObjectClosure::finish_old_region() {
+  if (_old_to_region != nullptr) {
+    log_debug(gc)("Planned compaction into Old Region " SIZE_FORMAT ", used: " SIZE_FORMAT " tabulated by worker %u",
+            _old_to_region->index(), _old_compact_point - _old_to_region->bottom(), _worker_id);
+    _old_to_region->set_new_top(_old_compact_point);
+    _old_to_region = nullptr;
+  }
+}
+
+void ShenandoahPrepareForGenerationalCompactionObjectClosure::finish_young_region() {
+  if (_young_to_region != nullptr) {
+    log_debug(gc)("Worker %u planned compaction into Young Region " SIZE_FORMAT ", used: " SIZE_FORMAT,
+            _worker_id, _young_to_region->index(), _young_compact_point - _young_to_region->bottom());
+    _young_to_region->set_new_top(_young_compact_point);
+    _young_to_region = nullptr;
+  }
+}
+
+bool ShenandoahPrepareForGenerationalCompactionObjectClosure::is_compact_same_region() {
+  return (_from_region == _old_to_region) || (_from_region == _young_to_region);
+}
+
+void ShenandoahPrepareForGenerationalCompactionObjectClosure::do_object(oop p) {
+  assert(_from_region != nullptr, "must set before work");
+  assert((_from_region->bottom() <= cast_from_oop<HeapWord*>(p)) && (cast_from_oop<HeapWord*>(p) < _from_region->top()),
+         "Object must reside in _from_region");
+  assert(_heap->complete_marking_context()->is_marked(p), "must be marked");
+  assert(!_heap->complete_marking_context()->allocated_after_mark_start(p), "must be truly marked");
+
+  size_t obj_size = p->size();
+  uint from_region_age = _from_region->age();
+  uint object_age = p->age();
+
+  bool promote_object = false;
+  if ((_from_affiliation == ShenandoahAffiliation::YOUNG_GENERATION) &&
+      (from_region_age + object_age >= _tenuring_threshold)) {
+    if ((_old_to_region != nullptr) && (_old_compact_point + obj_size > _old_to_region->end())) {
+      finish_old_region();
+      _old_to_region = nullptr;
+    }
+    if (_old_to_region == nullptr) {
+      if (_empty_regions_pos < _empty_regions.length()) {
+        ShenandoahHeapRegion* new_to_region = _empty_regions.at(_empty_regions_pos);
+        _empty_regions_pos++;
+        new_to_region->set_affiliation(OLD_GENERATION);
+        _old_to_region = new_to_region;
+        _old_compact_point = _old_to_region->bottom();
+        promote_object = true;
+      }
+      // Else this worker thread does not yet have any empty regions into which this aged object can be promoted so
+      // we leave promote_object as false, deferring the promotion.
+    } else {
+      promote_object = true;
+    }
+  }
+
+  if (promote_object || (_from_affiliation == ShenandoahAffiliation::OLD_GENERATION)) {
+    assert(_old_to_region != nullptr, "_old_to_region should not be nullptr when evacuating to OLD region");
+    if (_old_compact_point + obj_size > _old_to_region->end()) {
+      ShenandoahHeapRegion* new_to_region;
+
+      log_debug(gc)("Worker %u finishing old region " SIZE_FORMAT ", compact_point: " PTR_FORMAT ", obj_size: " SIZE_FORMAT
+      ", &compact_point[obj_size]: " PTR_FORMAT ", region end: " PTR_FORMAT,  _worker_id, _old_to_region->index(),
+              p2i(_old_compact_point), obj_size, p2i(_old_compact_point + obj_size), p2i(_old_to_region->end()));
+
+      // Object does not fit.  Get a new _old_to_region.
+      finish_old_region();
+      if (_empty_regions_pos < _empty_regions.length()) {
+        new_to_region = _empty_regions.at(_empty_regions_pos);
+        _empty_regions_pos++;
+        new_to_region->set_affiliation(OLD_GENERATION);
+      } else {
+        // If we've exhausted the previously selected _old_to_region, we know that the _old_to_region is distinct
+        // from _from_region.  That's because there is always room for _from_region to be compacted into itself.
+        // Since we're out of empty regions, let's use _from_region to hold the results of its own compaction.
+        new_to_region = _from_region;
+      }
+
+      assert(new_to_region != _old_to_region, "must not reuse same OLD to-region");
+      assert(new_to_region != nullptr, "must not be nullptr");
+      _old_to_region = new_to_region;
+      _old_compact_point = _old_to_region->bottom();
+    }
+
+    // Object fits into current region, record new location, if object does not move:
+    assert(_old_compact_point + obj_size <= _old_to_region->end(), "must fit");
+    shenandoah_assert_not_forwarded(nullptr, p);
+    if (_old_compact_point != cast_from_oop<HeapWord*>(p)) {
+      _preserved_marks->push_if_necessary(p, p->mark());
+      p->forward_to(cast_to_oop(_old_compact_point));
+    }
+    _old_compact_point += obj_size;
+  } else {
+    assert(_from_affiliation == ShenandoahAffiliation::YOUNG_GENERATION,
+           "_from_region must be OLD_GENERATION or YOUNG_GENERATION");
+    assert(_young_to_region != nullptr, "_young_to_region should not be nullptr when compacting YOUNG _from_region");
+
+    // After full gc compaction, all regions have age 0.  Embed the region's age into the object's age in order to preserve
+    // tenuring progress.
+    if (_heap->is_aging_cycle()) {
+      ShenandoahHeap::increase_object_age(p, from_region_age + 1);
+    } else {
+      ShenandoahHeap::increase_object_age(p, from_region_age);
+    }
+
+    if (_young_compact_point + obj_size > _young_to_region->end()) {
+      ShenandoahHeapRegion* new_to_region;
+
+      log_debug(gc)("Worker %u finishing young region " SIZE_FORMAT ", compact_point: " PTR_FORMAT ", obj_size: " SIZE_FORMAT
+      ", &compact_point[obj_size]: " PTR_FORMAT ", region end: " PTR_FORMAT,  _worker_id, _young_to_region->index(),
+              p2i(_young_compact_point), obj_size, p2i(_young_compact_point + obj_size), p2i(_young_to_region->end()));
+
+      // Object does not fit.  Get a new _young_to_region.
+      finish_young_region();
+      if (_empty_regions_pos < _empty_regions.length()) {
+        new_to_region = _empty_regions.at(_empty_regions_pos);
+        _empty_regions_pos++;
+        new_to_region->set_affiliation(YOUNG_GENERATION);
+      } else {
+        // If we've exhausted the previously selected _young_to_region, we know that the _young_to_region is distinct
+        // from _from_region.  That's because there is always room for _from_region to be compacted into itself.
+        // Since we're out of empty regions, let's use _from_region to hold the results of its own compaction.
+        new_to_region = _from_region;
+      }
+
+      assert(new_to_region != _young_to_region, "must not reuse same OLD to-region");
+      assert(new_to_region != nullptr, "must not be nullptr");
+      _young_to_region = new_to_region;
+      _young_compact_point = _young_to_region->bottom();
+    }
+
+    // Object fits into current region, record new location, if object does not move:
+    assert(_young_compact_point + obj_size <= _young_to_region->end(), "must fit");
+    shenandoah_assert_not_forwarded(nullptr, p);
+
+    if (_young_compact_point != cast_from_oop<HeapWord*>(p)) {
+      _preserved_marks->push_if_necessary(p, p->mark());
+      p->forward_to(cast_to_oop(_young_compact_point));
+    }
+    _young_compact_point += obj_size;
+  }
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.hpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALFULLGC_HPP
+#define SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALFULLGC_HPP
+
+#include "gc/shared/preservedMarks.hpp"
+#include "memory/iterator.hpp"
+#include "oops/oop.inline.hpp"
+#include "utilities/growableArray.hpp"
+
+class ShenandoahHeap;
+class ShenandoahHeapRegion;
+
+class ShenandoahGenerationalFullGC {
+public:
+  // Prepares the generational mode heap for a full collection.
+  static void prepare();
+
+  // Full GC may have compacted objects in the old generation, so we need to rebuild the card tables.
+  static void rebuild_remembered_set(ShenandoahHeap* heap);
+
+  // Records end of cycle for young and old and establishes size of live bytes in old
+  static void handle_completion(ShenandoahHeap* heap);
+
+  // Full GC may have promoted regions and may have temporarily violated constraints on the usage and
+  // capacity of the old generation. This method will balance the accounting of regions between the
+  // young and old generations. This is somewhat vestigial, but the outcome of this method is used
+  // when rebuilding the free sets.
+  static void balance_generations_after_gc(ShenandoahHeap* heap);
+
+  // This will compute the target size for the old generation. It will be expressed in terms of
+  // a region surplus and deficit, which will be redistributed accordingly after rebuilding the
+  // free set.
+  static void compute_balances();
+
+  // Rebuilding the free set may have resulted in regions being pulled in to the old generation
+  // evacuation reserve. For this reason, we must update the usage and capacity of the generations
+  // again. In the distant past, the free set did not know anything about generations, so we had
+  // a layer built above it to represent how much young/old memory was available. This layer is
+  // redundant and adds complexity. We would like to one day remove it. Until then, we must keep it
+  // synchronized with the free set's view of things.
+  static void balance_generations_after_rebuilding_free_set();
+
+  // Logs the number of live bytes marked in the old generation. This is _not_ the same
+  // value used as the baseline for the old generation _after_ the full gc is complete.
+  // The value reported in the logs does not include objects and regions that may be
+  // promoted during the full gc.
+  static void log_live_in_old(ShenandoahHeap* heap);
+
+  // This is used to tally the number, usage and space wasted by humongous objects for each generation.
+  static void account_for_region(ShenandoahHeapRegion* r, size_t &region_count, size_t &region_usage, size_t &humongous_waste);
+
+  // Regions which are scheduled for in-place promotion during evacuation temporarily
+  // have their top set to their end to prevent new objects from being allocated in them
+  // before they are promoted. If the full GC encounters such a region, it means the
+  // in-place promotion did not happen, and we must restore the original value of top.
+  static void restore_top_before_promote(ShenandoahHeap* heap);
+
+  // Pinned regions are not compacted, so they may still hold unmarked objects with
+  // references to reclaimed memory. Remembered set scanning will crash if it attempts
+  // to iterate the oops in these objects. This method fills in dead objects for pinned,
+  // old regions.
+  static void maybe_coalesce_and_fill_region(ShenandoahHeapRegion* r);
+};
+
+class ShenandoahPrepareForGenerationalCompactionObjectClosure : public ObjectClosure {
+private:
+  PreservedMarks*          const _preserved_marks;
+  ShenandoahHeap*          const _heap;
+  uint                           _tenuring_threshold;
+
+  // _empty_regions is a thread-local list of heap regions that have been completely emptied by this worker thread's
+  // compaction efforts.  The worker thread that drives these efforts adds compacted regions to this list if the
+  // region has not been compacted onto itself.
+  GrowableArray<ShenandoahHeapRegion*>& _empty_regions;
+  int _empty_regions_pos;
+  ShenandoahHeapRegion*          _old_to_region;
+  ShenandoahHeapRegion*          _young_to_region;
+  ShenandoahHeapRegion*          _from_region;
+  ShenandoahAffiliation          _from_affiliation;
+  HeapWord*                      _old_compact_point;
+  HeapWord*                      _young_compact_point;
+  uint                           _worker_id;
+
+public:
+  ShenandoahPrepareForGenerationalCompactionObjectClosure(PreservedMarks* preserved_marks,
+                                                          GrowableArray<ShenandoahHeapRegion*>& empty_regions,
+                                                          ShenandoahHeapRegion* from_region, uint worker_id);
+
+  void set_from_region(ShenandoahHeapRegion* from_region);
+  void finish();
+  void finish_old_region();
+  void finish_young_region();
+  bool is_compact_same_region();
+  int empty_regions_pos() const { return _empty_regions_pos; }
+
+  void do_object(oop p) override;
+};
+
+#endif //SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALFULLGC_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -24,10 +24,13 @@
 
 #include "precompiled.hpp"
 
+#include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
 #include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahInitLogger.hpp"
+#include "gc/shenandoah/shenandoahMemoryPool.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
+#include "gc/shenandoah/shenandoahRegulatorThread.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 
 #include "logging/log.hpp"
@@ -45,12 +48,12 @@ public:
     ShenandoahGenerationalHeap* heap = ShenandoahGenerationalHeap::heap();
 
     ShenandoahYoungGeneration* young = heap->young_generation();
-    log_info(gc, init)("Young Generation Soft Size: " PROPERFMT, PROPERFMTARGS(young->soft_max_capacity()));
-    log_info(gc, init)("Young Generation Max: " PROPERFMT, PROPERFMTARGS(young->max_capacity()));
+    log_info(gc, init)("Young Generation Soft Size: " EXACTFMT, EXACTFMTARGS(young->soft_max_capacity()));
+    log_info(gc, init)("Young Generation Max: " EXACTFMT, EXACTFMTARGS(young->max_capacity()));
 
     ShenandoahOldGeneration* old = heap->old_generation();
-    log_info(gc, init)("Old Generation Soft Size: " PROPERFMT, PROPERFMTARGS(old->soft_max_capacity()));
-    log_info(gc, init)("Old Generation Max: " PROPERFMT, PROPERFMTARGS(old->max_capacity()));
+    log_info(gc, init)("Old Generation Soft Size: " EXACTFMT, EXACTFMTARGS(old->soft_max_capacity()));
+    log_info(gc, init)("Old Generation Max: " EXACTFMT, EXACTFMTARGS(old->max_capacity()));
   }
 
 protected:
@@ -64,11 +67,202 @@ protected:
 };
 
 ShenandoahGenerationalHeap* ShenandoahGenerationalHeap::heap() {
+  shenandoah_assert_generational();
   CollectedHeap* heap = Universe::heap();
   return checked_cast<ShenandoahGenerationalHeap*>(heap);
 }
 
+ShenandoahGenerationalHeap::ShenandoahGenerationalHeap(ShenandoahCollectorPolicy* policy) :
+  ShenandoahHeap(policy),
+  _regulator_thread(nullptr) { }
+
 void ShenandoahGenerationalHeap::print_init_logger() const {
   ShenandoahGenerationalInitLogger logger;
   logger.print_all();
+}
+
+void ShenandoahGenerationalHeap::initialize_serviceability() {
+  assert(mode()->is_generational(), "Only for the generational mode");
+  _young_gen_memory_pool = new ShenandoahYoungGenMemoryPool(this);
+  _old_gen_memory_pool = new ShenandoahOldGenMemoryPool(this);
+  cycle_memory_manager()->add_pool(_young_gen_memory_pool);
+  cycle_memory_manager()->add_pool(_old_gen_memory_pool);
+  stw_memory_manager()->add_pool(_young_gen_memory_pool);
+  stw_memory_manager()->add_pool(_old_gen_memory_pool);
+}
+
+GrowableArray<MemoryPool*> ShenandoahGenerationalHeap::memory_pools() {
+  assert(mode()->is_generational(), "Only for the generational mode");
+  GrowableArray<MemoryPool*> memory_pools(2);
+  memory_pools.append(_young_gen_memory_pool);
+  memory_pools.append(_old_gen_memory_pool);
+  return memory_pools;
+}
+
+void ShenandoahGenerationalHeap::initialize_controller() {
+  auto control_thread = new ShenandoahGenerationalControlThread();
+  _control_thread = control_thread;
+  _regulator_thread = new ShenandoahRegulatorThread(control_thread);
+}
+
+void ShenandoahGenerationalHeap::gc_threads_do(ThreadClosure* tcl) const {
+  if (!shenandoah_policy()->is_at_shutdown()) {
+    ShenandoahHeap::gc_threads_do(tcl);
+    tcl->do_thread(regulator_thread());
+  }
+}
+
+void ShenandoahGenerationalHeap::stop() {
+  regulator_thread()->stop();
+  ShenandoahHeap::stop();
+}
+
+ShenandoahGenerationalHeap::TransferResult ShenandoahGenerationalHeap::balance_generations() {
+  shenandoah_assert_heaplocked_or_safepoint();
+
+  ShenandoahOldGeneration* old_gen = old_generation();
+  const size_t old_region_surplus = old_gen->get_region_surplus();
+  const size_t old_region_deficit = old_gen->get_region_deficit();
+  old_gen->set_region_surplus(0);
+  old_gen->set_region_deficit(0);
+
+  if (old_region_surplus) {
+    bool success = generation_sizer()->transfer_to_young(old_region_surplus);
+    return TransferResult {
+      success, old_region_surplus, "young"
+    };
+  }
+
+  if (old_region_deficit) {
+    const bool success = generation_sizer()->transfer_to_old(old_region_deficit);
+    if (!success) {
+      old_gen->handle_failed_transfer();
+    }
+    return TransferResult {
+      success, old_region_deficit, "old"
+    };
+  }
+
+  return TransferResult {true, 0, "none"};
+}
+
+// Make sure old-generation is large enough, but no larger than is necessary, to hold mixed evacuations
+// and promotions, if we anticipate either. Any deficit is provided by the young generation, subject to
+// xfer_limit, and any surplus is transferred to the young generation.
+// xfer_limit is the maximum we're able to transfer from young to old.
+void ShenandoahGenerationalHeap::compute_old_generation_balance(size_t old_xfer_limit, size_t old_cset_regions) {
+
+  // We can limit the old reserve to the size of anticipated promotions:
+  // max_old_reserve is an upper bound on memory evacuated from old and promoted to old,
+  // clamped by the old generation space available.
+  //
+  // Here's the algebra.
+  // Let SOEP = ShenandoahOldEvacRatioPercent,
+  //     OE = old evac,
+  //     YE = young evac, and
+  //     TE = total evac = OE + YE
+  // By definition:
+  //            SOEP/100 = OE/TE
+  //                     = OE/(OE+YE)
+  //  => SOEP/(100-SOEP) = OE/((OE+YE)-OE)      // componendo-dividendo: If a/b = c/d, then a/(b-a) = c/(d-c)
+  //                     = OE/YE
+  //  =>              OE = YE*SOEP/(100-SOEP)
+
+  // We have to be careful in the event that SOEP is set to 100 by the user.
+  assert(ShenandoahOldEvacRatioPercent <= 100, "Error");
+  const size_t old_available = old_generation()->available();
+  // The free set will reserve this amount of memory to hold young evacuations
+  const size_t young_reserve = (young_generation()->max_capacity() * ShenandoahEvacReserve) / 100;
+
+  // In the case that ShenandoahOldEvacRatioPercent equals 100, max_old_reserve is limited only by xfer_limit.
+
+  const size_t bound_on_old_reserve = old_available + old_xfer_limit + young_reserve;
+  const size_t max_old_reserve = (ShenandoahOldEvacRatioPercent == 100)?
+                                 bound_on_old_reserve: MIN2((young_reserve * ShenandoahOldEvacRatioPercent) / (100 - ShenandoahOldEvacRatioPercent),
+                                                            bound_on_old_reserve);
+
+  const size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
+
+  // Decide how much old space we should reserve for a mixed collection
+  size_t reserve_for_mixed = 0;
+  const size_t mixed_candidates = old_heuristics()->unprocessed_old_collection_candidates();
+  const bool doing_mixed = (mixed_candidates > 0);
+  if (doing_mixed) {
+    // We want this much memory to be unfragmented in order to reliably evacuate old.  This is conservative because we
+    // may not evacuate the entirety of unprocessed candidates in a single mixed evacuation.
+    const size_t max_evac_need = (size_t)
+            (old_heuristics()->unprocessed_old_collection_candidates_live_memory() * ShenandoahOldEvacWaste);
+    assert(old_available >= old_generation()->free_unaffiliated_regions() * region_size_bytes,
+           "Unaffiliated available must be less than total available");
+    const size_t old_fragmented_available =
+            old_available - old_generation()->free_unaffiliated_regions() * region_size_bytes;
+    reserve_for_mixed = max_evac_need + old_fragmented_available;
+    if (reserve_for_mixed > max_old_reserve) {
+      reserve_for_mixed = max_old_reserve;
+    }
+  }
+
+  // Decide how much space we should reserve for promotions from young
+  size_t reserve_for_promo = 0;
+  const size_t promo_load = old_generation()->get_promotion_potential();
+  const bool doing_promotions = promo_load > 0;
+  if (doing_promotions) {
+    // We're promoting and have a bound on the maximum amount that can be promoted
+    assert(max_old_reserve >= reserve_for_mixed, "Sanity");
+    const size_t available_for_promotions = max_old_reserve - reserve_for_mixed;
+    reserve_for_promo = MIN2((size_t)(promo_load * ShenandoahPromoEvacWaste), available_for_promotions);
+  }
+
+  // This is the total old we want to ideally reserve
+  const size_t old_reserve = reserve_for_mixed + reserve_for_promo;
+  assert(old_reserve <= max_old_reserve, "cannot reserve more than max for old evacuations");
+
+  // We now check if the old generation is running a surplus or a deficit.
+  size_t old_region_deficit = 0;
+  size_t old_region_surplus = 0;
+
+  const size_t max_old_available = old_generation()->available() + old_cset_regions * region_size_bytes;
+  if (max_old_available >= old_reserve) {
+    // We are running a surplus, so the old region surplus can go to young
+    const size_t old_surplus = max_old_available - old_reserve;
+    old_region_surplus = old_surplus / region_size_bytes;
+    const size_t unaffiliated_old_regions = old_generation()->free_unaffiliated_regions() + old_cset_regions;
+    old_region_surplus = MIN2(old_region_surplus, unaffiliated_old_regions);
+  } else {
+    // We are running a deficit which we'd like to fill from young.
+    // Ignore that this will directly impact young_generation()->max_capacity(),
+    // indirectly impacting young_reserve and old_reserve.  These computations are conservative.
+    const size_t old_need = old_reserve - max_old_available;
+    // The old region deficit (rounded up) will come from young
+    old_region_deficit = (old_need + region_size_bytes - 1) / region_size_bytes;
+
+    // Round down the regions we can transfer from young to old. If we're running short
+    // on young-gen memory, we restrict the xfer. Old-gen collection activities will be
+    // curtailed if the budget is restricted.
+    const size_t max_old_region_xfer = old_xfer_limit / region_size_bytes;
+    old_region_deficit = MIN2(old_region_deficit, max_old_region_xfer);
+  }
+  assert(old_region_deficit == 0 || old_region_surplus == 0, "Only surplus or deficit, never both");
+
+  old_generation()->set_region_surplus(old_region_surplus);
+  old_generation()->set_region_deficit(old_region_deficit);
+}
+
+void ShenandoahGenerationalHeap::reset_generation_reserves() {
+  young_generation()->set_evacuation_reserve(0);
+  old_generation()->set_evacuation_reserve(0);
+  old_generation()->set_promoted_reserve(0);
+}
+
+void ShenandoahGenerationalHeap::TransferResult::print_on(const char* when, outputStream* ss) const {
+  auto heap = ShenandoahGenerationalHeap::heap();
+  ShenandoahYoungGeneration* const young_gen = heap->young_generation();
+  ShenandoahOldGeneration* const old_gen = heap->old_generation();
+  const size_t young_available = young_gen->available();
+  const size_t old_available = old_gen->available();
+  ss->print_cr("After %s, %s " SIZE_FORMAT " regions to %s to prepare for next gc, old available: "
+                     PROPERFMT ", young_available: " PROPERFMT,
+                     when,
+                     success? "successfully transferred": "failed to transfer", region_count, region_destination,
+                     PROPERFMTARGS(old_available), PROPERFMTARGS(young_available));
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -27,13 +27,54 @@
 
 #include "gc/shenandoah/shenandoahHeap.hpp"
 
+class ShenandoahRegulatorThread;
+class ShenandoahGenerationalControlThread;
+
 class ShenandoahGenerationalHeap : public ShenandoahHeap {
 public:
-  explicit ShenandoahGenerationalHeap(ShenandoahCollectorPolicy* policy) : ShenandoahHeap(policy) {}
+  explicit ShenandoahGenerationalHeap(ShenandoahCollectorPolicy* policy);
 
   static ShenandoahGenerationalHeap* heap();
 
   void print_init_logger() const override;
+
+  // ---------- Serviceability
+  //
+  void initialize_serviceability() override;
+  GrowableArray<MemoryPool*> memory_pools() override;
+
+  ShenandoahRegulatorThread* regulator_thread() const { return _regulator_thread;  }
+
+  void gc_threads_do(ThreadClosure* tcl) const override;
+
+  void stop() override;
+
+  // Used for logging the result of a region transfer outside of the heap lock
+  struct TransferResult {
+    bool success;
+    size_t region_count;
+    const char* region_destination;
+
+    void print_on(const char* when, outputStream* ss) const;
+  };
+
+  // Zeros out the evacuation and promotion reserves
+  void reset_generation_reserves();
+
+  // Computes the optimal size for the old generation, represented as a surplus or deficit of old regions
+  void compute_old_generation_balance(size_t old_xfer_limit, size_t old_cset_regions);
+
+  // Transfers surplus old regions to young, or takes regions from young to satisfy old region deficit
+  TransferResult balance_generations();
+
+
+private:
+  void initialize_controller() override;
+
+  ShenandoahRegulatorThread* _regulator_thread;
+
+  MemoryPool* _young_gen_memory_pool;
+  MemoryPool* _old_gen_memory_pool;
 };
 
 #endif //SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALHEAP

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -33,7 +33,7 @@
 class ShenandoahGlobalGeneration : public ShenandoahGeneration {
 public:
   ShenandoahGlobalGeneration(bool generational, uint max_queues, size_t max_capacity, size_t soft_max_capacity)
-  : ShenandoahGeneration(generational ? GLOBAL_GEN : GLOBAL_NON_GEN, max_queues, max_capacity, soft_max_capacity) { }
+  : ShenandoahGeneration(generational ? GLOBAL : NON_GEN, max_queues, max_capacity, soft_max_capacity) { }
 
 public:
   const char* name() const override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -41,9 +41,8 @@
 #include "gc/shenandoah/shenandoahWorkGroup.hpp"
 #include "gc/shenandoah/shenandoahHeapRegionSet.inline.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
-#include "gc/shenandoah/shenandoahControlThread.hpp"
+#include "gc/shenandoah/shenandoahGenerationalControlThread.hpp"
 #include "gc/shenandoah/shenandoahMarkingContext.inline.hpp"
-#include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
 #include "gc/shenandoah/shenandoahThreadLocalData.hpp"
 #include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
 #include "gc/shenandoah/mode/shenandoahMode.hpp"
@@ -76,6 +75,18 @@ inline WorkerThreads* ShenandoahHeap::workers() const {
 
 inline WorkerThreads* ShenandoahHeap::safepoint_workers() {
   return _safepoint_workers;
+}
+
+inline void ShenandoahHeap::notify_gc_progress() {
+  Atomic::store(&_gc_no_progress_count, (size_t) 0);
+
+}
+inline void ShenandoahHeap::notify_gc_no_progress() {
+  Atomic::inc(&_gc_no_progress_count);
+}
+
+inline size_t ShenandoahHeap::get_gc_no_progress_count() const {
+  return Atomic::load(&_gc_no_progress_count);
 }
 
 inline size_t ShenandoahHeap::heap_region_index_containing(const void* addr) const {
@@ -360,183 +371,6 @@ inline oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
   return try_evacuate_object(p, thread, r, target_gen);
 }
 
-// try_evacuate_object registers the object and dirties the associated remembered set information when evacuating
-// to OLD_GENERATION.
-inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, ShenandoahHeapRegion* from_region,
-                                               ShenandoahAffiliation target_gen) {
-  bool alloc_from_lab = true;
-  bool has_plab = false;
-  HeapWord* copy = nullptr;
-  size_t size = p->size();
-  bool is_promotion = (target_gen == OLD_GENERATION) && from_region->is_young();
-
-#ifdef ASSERT
-  if (ShenandoahOOMDuringEvacALot &&
-      (os::random() & 1) == 0) { // Simulate OOM every ~2nd slow-path call
-        copy = nullptr;
-  } else {
-#endif
-    if (UseTLAB) {
-      switch (target_gen) {
-        case YOUNG_GENERATION: {
-           copy = allocate_from_gclab(thread, size);
-           if ((copy == nullptr) && (size < ShenandoahThreadLocalData::gclab_size(thread))) {
-             // GCLAB allocation failed because we are bumping up against the limit on young evacuation reserve.  Try resetting
-             // the desired GCLAB size and retry GCLAB allocation to avoid cascading of shared memory allocations.
-             ShenandoahThreadLocalData::set_gclab_size(thread, PLAB::min_size());
-             copy = allocate_from_gclab(thread, size);
-             // If we still get nullptr, we'll try a shared allocation below.
-           }
-           break;
-        }
-        case OLD_GENERATION: {
-           PLAB* plab = ShenandoahThreadLocalData::plab(thread);
-           if (plab != nullptr) {
-             has_plab = true;
-           }
-           copy = allocate_from_plab(thread, size, is_promotion);
-           if ((copy == nullptr) && (size < ShenandoahThreadLocalData::plab_size(thread)) &&
-               ShenandoahThreadLocalData::plab_retries_enabled(thread)) {
-             // PLAB allocation failed because we are bumping up against the limit on old evacuation reserve or because
-             // the requested object does not fit within the current plab but the plab still has an "abundance" of memory,
-             // where abundance is defined as >= PLAB::min_size().  In the former case, we try resetting the desired
-             // PLAB size and retry PLAB allocation to avoid cascading of shared memory allocations.
-
-             // In this situation, PLAB memory is precious.  We'll try to preserve our existing PLAB by forcing
-             // this particular allocation to be shared.
-             if (plab->words_remaining() < PLAB::min_size()) {
-               ShenandoahThreadLocalData::set_plab_size(thread, PLAB::min_size());
-               copy = allocate_from_plab(thread, size, is_promotion);
-               // If we still get nullptr, we'll try a shared allocation below.
-               if (copy == nullptr) {
-                 // If retry fails, don't continue to retry until we have success (probably in next GC pass)
-                 ShenandoahThreadLocalData::disable_plab_retries(thread);
-               }
-             }
-             // else, copy still equals nullptr.  this causes shared allocation below, preserving this plab for future needs.
-           }
-           break;
-        }
-        default: {
-          ShouldNotReachHere();
-          break;
-        }
-      }
-    }
-
-    if (copy == nullptr) {
-      // If we failed to allocate in LAB, we'll try a shared allocation.
-      if (!is_promotion || !has_plab || (size > PLAB::min_size())) {
-        ShenandoahAllocRequest req = ShenandoahAllocRequest::for_shared_gc(size, target_gen);
-        copy = allocate_memory(req, is_promotion);
-        alloc_from_lab = false;
-      }
-      // else, we leave copy equal to nullptr, signaling a promotion failure below if appropriate.
-      // We choose not to promote objects smaller than PLAB::min_size() by way of shared allocations, as this is too
-      // costly.  Instead, we'll simply "evacuate" to young-gen memory (using a GCLAB) and will promote in a future
-      // evacuation pass.  This condition is denoted by: is_promotion && has_plab && (size <= PLAB::min_size())
-    }
-#ifdef ASSERT
-  }
-#endif
-
-  if (copy == nullptr) {
-    if (target_gen == OLD_GENERATION) {
-      assert(mode()->is_generational(), "Should only be here in generational mode.");
-      if (from_region->is_young()) {
-        // Signal that promotion failed. Will evacuate this old object somewhere in young gen.
-        report_promotion_failure(thread, size);
-        return nullptr;
-      } else {
-        // Remember that evacuation to old gen failed. We'll want to trigger a full gc to recover from this
-        // after the evacuation threads have finished.
-        handle_old_evacuation_failure();
-      }
-    }
-
-    control_thread()->handle_alloc_failure_evac(size);
-
-    _oom_evac_handler.handle_out_of_memory_during_evacuation();
-
-    return ShenandoahBarrierSet::resolve_forwarded(p);
-  }
-
-  // Copy the object:
-  _evac_tracker->begin_evacuation(thread, size * HeapWordSize);
-  Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(p), copy, size);
-
-  oop copy_val = cast_to_oop(copy);
-
-  if (mode()->is_generational() && target_gen == YOUNG_GENERATION && is_aging_cycle()) {
-    ShenandoahHeap::increase_object_age(copy_val, from_region->age() + 1);
-  }
-
-  // Try to install the new forwarding pointer.
-  ContinuationGCSupport::relativize_stack_chunk(copy_val);
-
-  oop result = ShenandoahForwarding::try_update_forwardee(p, copy_val);
-  if (result == copy_val) {
-    // Successfully evacuated. Our copy is now the public one!
-    _evac_tracker->end_evacuation(thread, size * HeapWordSize);
-    if (mode()->is_generational()) {
-      if (target_gen == OLD_GENERATION) {
-        handle_old_evacuation(copy, size, from_region->is_young());
-      } else {
-        // When copying to the old generation above, we don't care
-        // about recording object age in the census stats.
-        assert(target_gen == YOUNG_GENERATION, "Error");
-        // We record this census only when simulating pre-adaptive tenuring behavior, or
-        // when we have been asked to record the census at evacuation rather than at mark
-        if (ShenandoahGenerationalCensusAtEvac || !ShenandoahGenerationalAdaptiveTenuring) {
-          _evac_tracker->record_age(thread, size * HeapWordSize, ShenandoahHeap::get_object_age(copy_val));
-        }
-      }
-    }
-    shenandoah_assert_correct(nullptr, copy_val);
-    return copy_val;
-  }  else {
-    // Failed to evacuate. We need to deal with the object that is left behind. Since this
-    // new allocation is certainly after TAMS, it will be considered live in the next cycle.
-    // But if it happens to contain references to evacuated regions, those references would
-    // not get updated for this stale copy during this cycle, and we will crash while scanning
-    // it the next cycle.
-    if (alloc_from_lab) {
-       // For LAB allocations, it is enough to rollback the allocation ptr. Either the next
-       // object will overwrite this stale copy, or the filler object on LAB retirement will
-       // do this.
-       switch (target_gen) {
-         case YOUNG_GENERATION: {
-             ShenandoahThreadLocalData::gclab(thread)->undo_allocation(copy, size);
-            break;
-         }
-         case OLD_GENERATION: {
-            ShenandoahThreadLocalData::plab(thread)->undo_allocation(copy, size);
-            if (is_promotion) {
-              ShenandoahThreadLocalData::subtract_from_plab_promoted(thread, size * HeapWordSize);
-            } else {
-              ShenandoahThreadLocalData::subtract_from_plab_evacuated(thread, size * HeapWordSize);
-            }
-            break;
-         }
-         default: {
-           ShouldNotReachHere();
-           break;
-         }
-       }
-    } else {
-      // For non-LAB allocations, we have no way to retract the allocation, and
-      // have to explicitly overwrite the copy with the filler object. With that overwrite,
-      // we have to keep the fwdptr initialized and pointing to our (stale) copy.
-      assert(size >= ShenandoahHeap::min_fill_size(), "previously allocated object known to be larger than min_size");
-      fill_with_object(copy, size);
-      shenandoah_assert_correct(nullptr, copy_val);
-      // For non-LAB allocations, the object has already been registered
-    }
-    shenandoah_assert_correct(nullptr, result);
-    return result;
-  }
-}
-
 void ShenandoahHeap::increase_object_age(oop obj, uint additional_age) {
   // This operates on new copy of an object. This means that the object's mark-word
   // is thread-local and therefore safe to access. However, when the mark is
@@ -583,10 +417,6 @@ uint ShenandoahHeap::get_object_age(oop obj) {
   }
   assert(w.age() <= markWord::max_age, "Impossible!");
   return w.age();
-}
-
-inline bool ShenandoahHeap::clear_old_evacuation_failure() {
-  return _old_gen_oom_evac.try_unset();
 }
 
 bool ShenandoahHeap::is_in(const void* p) const {
@@ -697,10 +527,6 @@ inline bool ShenandoahHeap::is_stable() const {
   return _gc_state.is_clear();
 }
 
-inline bool ShenandoahHeap::has_evacuation_reserve_quantities() const {
-  return _has_evacuation_reserve_quantities;
-}
-
 inline bool ShenandoahHeap::is_idle() const {
   return _gc_state.is_unset(MARKING | EVACUATION | UPDATEREFS);
 }
@@ -751,60 +577,6 @@ inline bool ShenandoahHeap::is_concurrent_weak_root_in_progress() const {
 
 inline bool ShenandoahHeap::is_aging_cycle() const {
   return _is_aging_cycle.is_set();
-}
-
-inline size_t ShenandoahHeap::set_promoted_reserve(size_t new_val) {
-  size_t orig = _promoted_reserve;
-  _promoted_reserve = new_val;
-  return orig;
-}
-
-inline size_t ShenandoahHeap::get_promoted_reserve() const {
-  return _promoted_reserve;
-}
-
-inline size_t ShenandoahHeap::set_old_evac_reserve(size_t new_val) {
-  size_t orig = _old_evac_reserve;
-  _old_evac_reserve = new_val;
-  return orig;
-}
-
-inline size_t ShenandoahHeap::get_old_evac_reserve() const {
-  return _old_evac_reserve;
-}
-
-inline void ShenandoahHeap::augment_old_evac_reserve(size_t increment) {
-  _old_evac_reserve += increment;
-}
-
-inline void ShenandoahHeap::augment_promo_reserve(size_t increment) {
-  _promoted_reserve += increment;
-}
-
-inline void ShenandoahHeap::reset_promoted_expended() {
-  Atomic::store(&_promoted_expended, (size_t) 0);
-}
-
-inline size_t ShenandoahHeap::expend_promoted(size_t increment) {
-  return Atomic::add(&_promoted_expended, increment);
-}
-
-inline size_t ShenandoahHeap::unexpend_promoted(size_t decrement) {
-  return Atomic::sub(&_promoted_expended, decrement);
-}
-
-inline size_t ShenandoahHeap::get_promoted_expended() {
-  return Atomic::load(&_promoted_expended);
-}
-
-inline size_t ShenandoahHeap::set_young_evac_reserve(size_t new_val) {
-  size_t orig = _young_evac_reserve;
-  _young_evac_reserve = new_val;
-  return orig;
-}
-
-inline size_t ShenandoahHeap::get_young_evac_reserve() const {
-  return _young_evac_reserve;
 }
 
 template<class T>

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -32,7 +32,6 @@
 #include "gc/shenandoah/shenandoahAllocRequest.hpp"
 #include "gc/shenandoah/shenandoahAsserts.hpp"
 #include "gc/shenandoah/shenandoahHeap.hpp"
-#include "gc/shenandoah/shenandoahPacer.hpp"
 #include "gc/shenandoah/shenandoahPadding.hpp"
 #include "utilities/sizes.hpp"
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
@@ -157,8 +157,8 @@ static int encode_phase(ShenandoahHeap* heap) {
 
 static int get_generation_shift(ShenandoahGeneration* generation) {
   switch (generation->type()) {
-    case GLOBAL_NON_GEN:
-    case GLOBAL_GEN:
+    case NON_GEN:
+    case GLOBAL:
       return 0;
     case OLD:
       return 2;

--- a/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
@@ -41,9 +41,9 @@ void ShenandoahInitLogger::print_heap() {
   GCInitLogger::print_heap();
 
   log_info(gc, init)("Heap Region Count: " SIZE_FORMAT, ShenandoahHeapRegion::region_count());
-  log_info(gc, init)("Heap Region Size: " PROPERFMT, PROPERFMTARGS(ShenandoahHeapRegion::region_size_bytes()));
-  log_info(gc, init)("TLAB Size Max: " PROPERFMT, PROPERFMTARGS(ShenandoahHeapRegion::max_tlab_size_bytes()));
-  log_info(gc, init)("Humongous Object Threshold: " PROPERFMT, PROPERFMTARGS(ShenandoahHeapRegion::humongous_threshold_bytes()));
+  log_info(gc, init)("Heap Region Size: " EXACTFMT, EXACTFMTARGS(ShenandoahHeapRegion::region_size_bytes()));
+  log_info(gc, init)("TLAB Size Max: " EXACTFMT, EXACTFMTARGS(ShenandoahHeapRegion::max_tlab_size_bytes()));
+  log_info(gc, init)("Humongous Object Threshold: " EXACTFMT, EXACTFMTARGS(ShenandoahHeapRegion::humongous_threshold_bytes()));
 }
 
 void ShenandoahInitLogger::print_gc_specific() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.cpp
@@ -88,7 +88,8 @@ void ShenandoahMark::mark_loop_prework(uint w, TaskTerminator *t, ShenandoahRefe
 }
 
 template<bool CANCELLABLE, StringDedupMode STRING_DEDUP>
-void ShenandoahMark::mark_loop(ShenandoahGenerationType generation, uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp, StringDedup::Requests* const req) {
+void ShenandoahMark::mark_loop(uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
+                               ShenandoahGenerationType generation, StringDedup::Requests* const req) {
   bool update_refs = ShenandoahHeap::heap()->has_forwarded_objects();
   switch (generation) {
     case YOUNG:
@@ -98,11 +99,11 @@ void ShenandoahMark::mark_loop(ShenandoahGenerationType generation, uint worker_
       // Old generation collection only performs marking, it should not update references.
       mark_loop_prework<OLD, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, false);
       break;
-    case GLOBAL_GEN:
-      mark_loop_prework<GLOBAL_GEN, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, update_refs);
+    case GLOBAL:
+      mark_loop_prework<GLOBAL, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, update_refs);
       break;
-    case GLOBAL_NON_GEN:
-      mark_loop_prework<GLOBAL_NON_GEN, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, update_refs);
+    case NON_GEN:
+      mark_loop_prework<NON_GEN, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, update_refs);
       break;
     default:
       ShouldNotReachHere();
@@ -110,30 +111,30 @@ void ShenandoahMark::mark_loop(ShenandoahGenerationType generation, uint worker_
   }
 }
 
-void ShenandoahMark::mark_loop(ShenandoahGenerationType generation, uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
-                               bool cancellable, StringDedupMode dedup_mode, StringDedup::Requests* const req) {
+void ShenandoahMark::mark_loop(uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
+                               ShenandoahGenerationType generation, bool cancellable, StringDedupMode dedup_mode, StringDedup::Requests* const req) {
   if (cancellable) {
     switch(dedup_mode) {
       case NO_DEDUP:
-        mark_loop<true, NO_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<true, NO_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
       case ENQUEUE_DEDUP:
-        mark_loop<true, ENQUEUE_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<true, ENQUEUE_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
       case ALWAYS_DEDUP:
-        mark_loop<true, ALWAYS_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<true, ALWAYS_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
     }
   } else {
     switch(dedup_mode) {
       case NO_DEDUP:
-        mark_loop<false, NO_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<false, NO_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
       case ENQUEUE_DEDUP:
-        mark_loop<false, ENQUEUE_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<false, ENQUEUE_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
       case ALWAYS_DEDUP:
-        mark_loop<false, ALWAYS_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<false, ALWAYS_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.hpp
@@ -29,8 +29,19 @@
 #include "gc/shared/ageTable.hpp"
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shared/taskTerminator.hpp"
-#include "gc/shenandoah/shenandoahOopClosures.hpp"
+#include "gc/shenandoah/shenandoahGenerationType.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
+#include "gc/shenandoah/shenandoahGeneration.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.hpp"
+
+enum StringDedupMode {
+  NO_DEDUP,      // Do not do anything for String deduplication
+  ENQUEUE_DEDUP, // Enqueue candidate Strings for deduplication, if meet age threshold
+  ALWAYS_DEDUP   // Enqueue Strings for deduplication
+};
+
+class ShenandoahMarkingContext;
+class ShenandoahReferenceProcessor;
 
 // Base class for mark
 // Mark class does not maintain states. Instead, mark states are
@@ -95,11 +106,11 @@ private:
   inline void dedup_string(oop obj, StringDedup::Requests* const req);
 protected:
   template<bool CANCELLABLE, StringDedupMode STRING_DEDUP>
-  void mark_loop(ShenandoahGenerationType generation, uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
-                 StringDedup::Requests* const req);
+  void mark_loop(uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
+                 ShenandoahGenerationType generation, StringDedup::Requests* const req);
 
-  void mark_loop(ShenandoahGenerationType generation, uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
-                 bool cancellable, StringDedupMode dedup_mode, StringDedup::Requests* const req);
+  void mark_loop(uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
+                 ShenandoahGenerationType generation, bool cancellable, StringDedupMode dedup_mode, StringDedup::Requests* const req);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHMARK_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -33,6 +33,7 @@
 #include "gc/shenandoah/shenandoahBarrierSet.inline.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahMarkingContext.inline.hpp"
+#include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahStringDedup.inline.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.inline.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
@@ -115,7 +116,7 @@ inline void ShenandoahMark::count_liveness(ShenandoahLiveData* live_data, oop ob
   const size_t size = obj->size();
 
   // Age census for objects in the young generation
-  if (GENERATION == YOUNG || (GENERATION == GLOBAL_GEN && region->is_young())) {
+  if (GENERATION == YOUNG || (GENERATION == GLOBAL && region->is_young())) {
     assert(heap->mode()->is_generational(), "Only if generational");
     if (ShenandoahGenerationalAdaptiveTenuring && !ShenandoahGenerationalCensusAtEvac) {
       assert(region->is_young(), "Only for young objects");
@@ -281,7 +282,7 @@ bool ShenandoahMark::in_generation(ShenandoahHeap* const heap, oop obj) {
     return heap->is_in_young(obj);
   } else if (GENERATION == OLD) {
     return heap->is_in_old(obj);
-  } else if (GENERATION == GLOBAL_GEN || GENERATION == GLOBAL_NON_GEN) {
+  } else if (GENERATION == GLOBAL || GENERATION == NON_GEN) {
     return true;
   } else {
     return false;
@@ -303,7 +304,7 @@ inline void ShenandoahMark::mark_through_ref(T *p, ShenandoahObjToScanQueue* q, 
     if (in_generation<GENERATION>(heap, obj)) {
       mark_ref(q, mark_context, weak, obj);
       shenandoah_assert_marked(p, obj);
-      // TODO: As implemented herein, GLOBAL_GEN collections reconstruct the card table during GLOBAL_GEN concurrent
+      // TODO: As implemented herein, GLOBAL collections reconstruct the card table during GLOBAL concurrent
       // marking. Note that the card table is cleaned at init_mark time so it needs to be reconstructed to support
       // future young-gen collections.  It might be better to reconstruct card table in
       // ShenandoahHeapRegion::global_oop_iterate_and_fill_dead.  We could either mark all live memory as dirty, or could
@@ -311,7 +312,7 @@ inline void ShenandoahMark::mark_through_ref(T *p, ShenandoahObjToScanQueue* q, 
       if (GENERATION == YOUNG && heap->is_in_old(p)) {
         // Mark card as dirty because remembered set scanning still finds interesting pointer.
         heap->mark_card_as_dirty((HeapWord*)p);
-      } else if (GENERATION == GLOBAL_GEN && heap->is_in_old(p) && heap->is_in_young(obj)) {
+      } else if (GENERATION == GLOBAL && heap->is_in_old(p) && heap->is_in_young(obj)) {
         // Mark card as dirty because GLOBAL marking finds interesting pointer.
         heap->mark_card_as_dirty((HeapWord*)p);
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMonitoringSupport.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMonitoringSupport.hpp
@@ -25,13 +25,35 @@
 #ifndef SHARE_GC_SHENANDOAH_SHENANDOAHMONITORINGSUPPORT_HPP
 #define SHARE_GC_SHENANDOAH_SHENANDOAHMONITORINGSUPPORT_HPP
 
+#include "gc/shenandoah/shenandoahSharedVariables.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/task.hpp"
 
 class GenerationCounters;
 class HSpaceCounters;
 class ShenandoahHeap;
 class CollectorCounters;
 class ShenandoahHeapRegionCounters;
+class ShenandoahMonitoringSupport;
+
+class ShenandoahPeriodicCountersUpdateTask : public PeriodicTask {
+private:
+  ShenandoahSharedFlag _do_counters_update;
+  ShenandoahSharedFlag _force_counters_update;
+  ShenandoahMonitoringSupport* const _monitoring_support;
+
+public:
+  explicit ShenandoahPeriodicCountersUpdateTask(ShenandoahMonitoringSupport* monitoring_support) :
+    PeriodicTask(100),
+    _monitoring_support(monitoring_support) { }
+
+  void task() override;
+
+  void handle_counters_update();
+  void handle_force_counters_update();
+  void set_forced_counters_update(bool value);
+  void notify_heap_changed();
+};
 
 class ShenandoahMonitoringSupport : public CHeapObj<mtGC> {
 private:
@@ -44,14 +66,20 @@ private:
   HSpaceCounters* _space_counters;
 
   ShenandoahHeapRegionCounters* _heap_region_counters;
+  ShenandoahPeriodicCountersUpdateTask _counters_update_task;
 
 public:
- ShenandoahMonitoringSupport(ShenandoahHeap* heap);
- CollectorCounters* stw_collection_counters();
- CollectorCounters* full_stw_collection_counters();
- CollectorCounters* concurrent_collection_counters();
- CollectorCounters* partial_collection_counters();
- void update_counters();
+  explicit ShenandoahMonitoringSupport(ShenandoahHeap* heap);
+  CollectorCounters* stw_collection_counters();
+  CollectorCounters* full_stw_collection_counters();
+  CollectorCounters* concurrent_collection_counters();
+  CollectorCounters* partial_collection_counters();
+
+  void notify_heap_changed();
+  void set_forced_counters_update(bool value);
+  void handle_force_counters_update();
+
+  void update_counters();
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHMONITORINGSUPPORT_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -26,6 +26,7 @@
 
 #include "gc/shenandoah/heuristics/shenandoahYoungHeuristics.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
 #include "gc/shenandoah/shenandoahOldGC.hpp"
@@ -35,8 +36,6 @@
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "prims/jvmtiTagMap.hpp"
 #include "utilities/events.hpp"
-
-
 
 
 ShenandoahOldGC::ShenandoahOldGC(ShenandoahGeneration* generation, ShenandoahSharedFlag& allow_preemption) :
@@ -85,7 +84,7 @@ void ShenandoahOldGC::op_final_mark() {
 }
 
 bool ShenandoahOldGC::collect(GCCause::Cause cause) {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  auto heap = ShenandoahGenerationalHeap::heap();
   assert(!heap->doing_mixed_evacuations(), "Should not start an old gc with pending mixed evacuations");
   assert(!heap->is_prepare_for_old_mark_in_progress(), "Old regions need to be parsable during concurrent mark.");
 
@@ -148,48 +147,21 @@ bool ShenandoahOldGC::collect(GCCause::Cause cause) {
   // collection.
   vmop_entry_final_roots();
 
-  // We do not rebuild_free following increments of old marking because memory has not been reclaimed..  However, we may
+  // We do not rebuild_free following increments of old marking because memory has not been reclaimed. However, we may
   // need to transfer memory to OLD in order to efficiently support the mixed evacuations that might immediately follow.
   size_t allocation_runway = heap->young_heuristics()->bytes_of_allocation_runway_before_gc_trigger(0);
-  heap->adjust_generation_sizes_for_next_cycle(allocation_runway, 0, 0);
+  heap->compute_old_generation_balance(allocation_runway, 0);
 
-  bool success;
-  size_t region_xfer;
-  const char* region_destination;
-  ShenandoahYoungGeneration* young_gen = heap->young_generation();
-  ShenandoahGeneration* old_gen = heap->old_generation();
+  ShenandoahGenerationalHeap::TransferResult result;
   {
     ShenandoahHeapLocker locker(heap->lock());
-
-    size_t old_region_surplus = heap->get_old_region_surplus();
-    size_t old_region_deficit = heap->get_old_region_deficit();
-    if (old_region_surplus) {
-      success = heap->generation_sizer()->transfer_to_young(old_region_surplus);
-      region_destination = "young";
-      region_xfer = old_region_surplus;
-    } else if (old_region_deficit) {
-      success = heap->generation_sizer()->transfer_to_old(old_region_deficit);
-      region_destination = "old";
-      region_xfer = old_region_deficit;
-      if (!success) {
-        ((ShenandoahOldHeuristics *) old_gen->heuristics())->trigger_cannot_expand();
-      }
-    } else {
-      region_destination = "none";
-      region_xfer = 0;
-      success = true;
-    }
-    heap->set_old_region_surplus(0);
-    heap->set_old_region_deficit(0);
+    result = heap->balance_generations();
   }
 
-  // Report outside the heap lock
-  size_t young_available = young_gen->available();
-  size_t old_available = old_gen->available();
-  log_info(gc, ergo)("After old marking finished, %s " SIZE_FORMAT " regions to %s to prepare for next gc, old available: "
-                     SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
-                     success? "successfully transferred": "failed to transfer", region_xfer, region_destination,
-                     byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                     byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
+  LogTarget(Info, gc, ergo) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    result.print_on("Old Mark", &ls);
+  }
   return true;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -26,6 +26,7 @@
 #define SHARE_VM_GC_SHENANDOAH_SHENANDOAHOLDGENERATION_HPP
 
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahSharedVariables.hpp"
 
 class ShenandoahHeapRegion;
 class ShenandoahHeapRegionClosure;
@@ -36,6 +37,45 @@ private:
   ShenandoahHeapRegion** _coalesce_and_fill_region_array;
   ShenandoahOldHeuristics* _old_heuristics;
 
+  // After determining the desired size of the old generation (see compute_old_generation_balance), these
+  // quantities represent the number of regions above (surplus) or below (deficit) that size.
+  // These values are computed prior to the actual exchange of any regions. These may never both
+  // be positive simultaneously.
+  size_t _region_surplus;
+  size_t _region_deficit;
+
+  // Set when evacuation in the old generation fails. When this is set, the control thread will initiate a
+  // full GC instead of a futile degenerated cycle.
+  ShenandoahSharedFlag _failed_evacuation;
+
+  // Bytes reserved within old-gen to hold the results of promotion. This is separate from
+  // and in addition to the evacuation reserve for intra-generation evacuations (ShenandoahGeneration::_evacuation_reserve).
+  size_t _promoted_reserve;
+
+  // Bytes of old-gen memory expended on promotions. This may be modified concurrently
+  // by mutators and gc workers when promotion LABs are retired during evacuation. It
+  // is therefore always accessed through atomic operations. This is increased when a
+  // PLAB is allocated for promotions. The value is decreased by the amount of memory
+  // remaining in a PLAB when it is retired.
+  size_t _promoted_expended;
+
+  // Represents the quantity of live bytes we expect to promote in place during the next
+  // evacuation cycle. This value is used by the young heuristic to trigger mixed collections.
+  // It is also used when computing the optimum size for the old generation.
+  size_t _promotion_potential;
+
+  // When a region is selected to be promoted in place, the remaining free memory is filled
+  // in to prevent additional allocations (preventing premature promotion of newly allocated
+  // objects. This field records the total amount of padding used for such regions.
+  size_t _pad_for_promote_in_place;
+
+  // During construction of the collection set, we keep track of regions that are eligible
+  // for promotion in place. These fields track the count of those humongous and regular regions.
+  // This data is used to force the evacuation phase even when the collection set is otherwise
+  // empty.
+  size_t _promotable_humongous_regions;
+  size_t _promotable_regular_regions;
+
   bool coalesce_and_fill();
 
 public:
@@ -45,6 +85,61 @@ public:
 
   const char* name() const override {
     return "OLD";
+  }
+
+  // See description in field declaration
+  void set_promoted_reserve(size_t new_val);
+  size_t get_promoted_reserve() const;
+
+  // The promotion reserve is increased when rebuilding the free set transfers a region to the old generation
+  void augment_promoted_reserve(size_t increment);
+
+  // This zeros out the expended promotion count after the promotion reserve is computed
+  void reset_promoted_expended();
+
+  // This is incremented when allocations are made to copy promotions into the old generation
+  size_t expend_promoted(size_t increment);
+
+  // This is used to return unused memory from a retired promotion LAB
+  size_t unexpend_promoted(size_t decrement);
+
+  // This is used on the allocation path to gate promotions that would exceed the reserve
+  size_t get_promoted_expended();
+
+  // See description in field declaration
+  void set_region_surplus(size_t surplus) { _region_surplus = surplus; };
+  void set_region_deficit(size_t deficit) { _region_deficit = deficit; };
+  size_t get_region_surplus() const { return _region_surplus; };
+  size_t get_region_deficit() const { return _region_deficit; };
+
+  // See description in field declaration
+  void set_promotion_potential(size_t val) { _promotion_potential = val; };
+  size_t get_promotion_potential() const { return _promotion_potential; };
+
+  // See description in field declaration
+  void set_pad_for_promote_in_place(size_t pad) { _pad_for_promote_in_place = pad; }
+  size_t get_pad_for_promote_in_place() const { return _pad_for_promote_in_place; }
+
+  // See description in field declaration
+  void set_expected_humongous_region_promotions(size_t region_count) { _promotable_humongous_regions = region_count; }
+  void set_expected_regular_region_promotions(size_t region_count) { _promotable_regular_regions = region_count; }
+  bool has_in_place_promotions() const { return (_promotable_humongous_regions + _promotable_regular_regions) > 0; }
+
+  // This will signal the heuristic to trigger an old generation collection
+  void handle_failed_transfer();
+
+  // This will signal the control thread to run a full GC instead of a futile degenerated gc
+  void handle_failed_evacuation();
+
+  // This logs that an evacuation to the old generation has failed
+  void handle_failed_promotion(Thread* thread, size_t size);
+
+  // A successful evacuation re-dirties the cards and registers the object with the remembered set
+  void handle_evacuation(HeapWord* obj, size_t words, bool promotion);
+
+  // Clear the flag after it is consumed by the control thread
+  bool clear_failed_evacuation() {
+    return _failed_evacuation.try_unset();
   }
 
   void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl) override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
@@ -28,17 +28,12 @@
 
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shenandoah/shenandoahClosures.inline.hpp"
+#include "gc/shenandoah/shenandoahGenerationType.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "memory/iterator.hpp"
 #include "runtime/javaThread.hpp"
-
-enum StringDedupMode {
-  NO_DEDUP,      // Do not do anything for String deduplication
-  ENQUEUE_DEDUP, // Enqueue candidate Strings for deduplication, if meet age threshold
-  ALWAYS_DEDUP   // Enqueue Strings for deduplication
-};
 
 class ShenandoahMarkRefsSuperClosure : public MetadataVisitingOopIterateClosure {
 private:
@@ -140,23 +135,6 @@ private:
 
 public:
   ShenandoahConcUpdateRefsClosure() : ShenandoahUpdateRefsSuperClosure() {}
-
-  virtual void do_oop(narrowOop* p) { work(p); }
-  virtual void do_oop(oop* p)       { work(p); }
-};
-
-class ShenandoahSetRememberedCardsToDirtyClosure : public BasicOopIterateClosure {
-protected:
-  ShenandoahHeap*    const _heap;
-  RememberedScanner* const _scanner;
-
-public:
-  ShenandoahSetRememberedCardsToDirtyClosure() :
-      _heap(ShenandoahHeap::heap()),
-      _scanner(_heap->card_scan()) {}
-
-  template<class T>
-  inline void work(T* p);
 
   virtual void do_oop(narrowOop* p) { work(p); }
   virtual void do_oop(oop* p)       { work(p); }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.inline.hpp
@@ -55,16 +55,4 @@ inline void ShenandoahConcUpdateRefsClosure::work(T* p) {
   _heap->conc_update_with_forwarded(p);
 }
 
-template<class T>
-inline void ShenandoahSetRememberedCardsToDirtyClosure::work(T* p) {
-  T o = RawAccess<>::oop_load(p);
-  if (!CompressedOops::is_null(o)) {
-    oop obj = CompressedOops::decode_not_null(o);
-    if (_heap->is_in_young(obj)) {
-      // Found interesting pointer.  Mark the containing card as dirty.
-      _scanner->mark_card_as_dirty((HeapWord*) p);
-    }
-  }
-}
-
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHOOPCLOSURES_INLINE_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -338,3 +338,8 @@ void ShenandoahPacer::print_cycle_on(outputStream* out) {
   }
   out->cr();
 }
+
+void ShenandoahPeriodicPacerNotifyTask::task() {
+  assert(ShenandoahPacing, "Should not be here otherwise");
+  _pacer->notify_waiters();
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -25,54 +25,45 @@
 
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "gc/shenandoah/mode/shenandoahMode.hpp"
-#include "gc/shenandoah/shenandoahControlThread.hpp"
+#include "gc/shenandoah/shenandoahAsserts.hpp"
+#include "gc/shenandoah/shenandoahGenerationalControlThread.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahRegulatorThread.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "logging/log.hpp"
 
-static ShenandoahHeuristics* get_heuristics(ShenandoahGeneration* nullable) {
-  return nullable != nullptr ? nullable->heuristics() : nullptr;
-}
-
-ShenandoahRegulatorThread::ShenandoahRegulatorThread(ShenandoahControlThread* control_thread) :
+ShenandoahRegulatorThread::ShenandoahRegulatorThread(ShenandoahGenerationalControlThread* control_thread) :
   ConcurrentGCThread(),
   _control_thread(control_thread),
   _sleep(ShenandoahControlIntervalMin),
   _last_sleep_adjust_time(os::elapsedTime()) {
-
+  shenandoah_assert_generational();
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  _old_heuristics = get_heuristics(heap->old_generation());
-  _young_heuristics = get_heuristics(heap->young_generation());
-  _global_heuristics = get_heuristics(heap->global_generation());
+  _old_heuristics = heap->old_generation()->heuristics();
+  _young_heuristics = heap->young_generation()->heuristics();
+  _global_heuristics = heap->global_generation()->heuristics();
 
+  set_name("Shenandoah Regulator Thread");
   create_and_start();
 }
 
 void ShenandoahRegulatorThread::run_service() {
-  if (ShenandoahHeap::heap()->mode()->is_generational()) {
-    if (ShenandoahAllowOldMarkingPreemption) {
-      regulate_young_and_old_cycles();
-    } else {
-      regulate_young_and_global_cycles();
-    }
+  if (ShenandoahAllowOldMarkingPreemption) {
+    regulate_young_and_old_cycles();
   } else {
-    regulate_global_cycles();
+    regulate_young_and_global_cycles();
   }
 
   log_info(gc)("%s: Done.", name());
 }
 
 void ShenandoahRegulatorThread::regulate_young_and_old_cycles() {
-  assert(_young_heuristics != nullptr, "Need young heuristics.");
-  assert(_old_heuristics != nullptr, "Need old heuristics.");
-
   while (!should_terminate()) {
-    ShenandoahControlThread::GCMode mode = _control_thread->gc_mode();
-    if (mode == ShenandoahControlThread::none) {
+    ShenandoahGenerationalControlThread::GCMode mode = _control_thread->gc_mode();
+    if (mode == ShenandoahGenerationalControlThread::none) {
       if (should_start_metaspace_gc()) {
-        if (request_concurrent_gc(ShenandoahControlThread::select_global_generation())) {
+        if (request_concurrent_gc(GLOBAL)) {
           log_info(gc)("Heuristics request for global (unload classes) accepted.");
         }
       } else {
@@ -86,7 +77,7 @@ void ShenandoahRegulatorThread::regulate_young_and_old_cycles() {
           }
         }
       }
-    } else if (mode == ShenandoahControlThread::servicing_old) {
+    } else if (mode == ShenandoahGenerationalControlThread::servicing_old) {
       if (start_young_cycle()) {
         log_info(gc)("Heuristics request to interrupt old for young collection accepted");
       }
@@ -98,29 +89,12 @@ void ShenandoahRegulatorThread::regulate_young_and_old_cycles() {
 
 
 void ShenandoahRegulatorThread::regulate_young_and_global_cycles() {
-  assert(_young_heuristics != nullptr, "Need young heuristics.");
-  assert(_global_heuristics != nullptr, "Need global heuristics.");
-
   while (!should_terminate()) {
-    if (_control_thread->gc_mode() == ShenandoahControlThread::none) {
+    if (_control_thread->gc_mode() == ShenandoahGenerationalControlThread::none) {
       if (start_global_cycle()) {
         log_info(gc)("Heuristics request for global collection accepted.");
       } else if (start_young_cycle()) {
         log_info(gc)("Heuristics request for young collection accepted.");
-      }
-    }
-
-    regulator_sleep();
-  }
-}
-
-void ShenandoahRegulatorThread::regulate_global_cycles() {
-  assert(_global_heuristics != nullptr, "Need global heuristics.");
-
-  while (!should_terminate()) {
-    if (_control_thread->gc_mode() == ShenandoahControlThread::none) {
-      if (start_global_cycle()) {
-        log_info(gc)("Heuristics request for global collection accepted.");
       }
     }
 
@@ -134,10 +108,10 @@ void ShenandoahRegulatorThread::regulator_sleep() {
   // back off exponentially.
   double current = os::elapsedTime();
 
-  if (_heap_changed.try_unset()) {
+  if (ShenandoahHeap::heap()->has_changed()) {
     _sleep = ShenandoahControlIntervalMin;
   } else if ((current - _last_sleep_adjust_time) * 1000 > ShenandoahControlIntervalAdjustPeriod){
-    _sleep = MIN2<int>(ShenandoahControlIntervalMax, MAX2(1, _sleep * 2));
+    _sleep = MIN2<uint>(ShenandoahControlIntervalMax, MAX2(1u, _sleep * 2));
     _last_sleep_adjust_time = current;
   }
 
@@ -160,7 +134,7 @@ bool ShenandoahRegulatorThread::start_young_cycle() {
 }
 
 bool ShenandoahRegulatorThread::start_global_cycle() {
-  return _global_heuristics->should_start_gc() && request_concurrent_gc(ShenandoahControlThread::select_global_generation());
+  return _global_heuristics->should_start_gc() && request_concurrent_gc(GLOBAL);
 }
 
 bool ShenandoahRegulatorThread::request_concurrent_gc(ShenandoahGenerationType generation) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.hpp
@@ -25,12 +25,9 @@
 #define SHARE_GC_SHENANDOAH_SHENANDOAHREGULATORTHREAD_HPP
 
 #include "gc/shared/concurrentGCThread.hpp"
-#include "gc/shared/gcCause.hpp"
-#include "gc/shenandoah/shenandoahSharedVariables.hpp"
-#include "runtime/mutex.hpp"
 
 class ShenandoahHeuristics;
-class ShenandoahControlThread;
+class ShenandoahGenerationalControlThread;
 
 /*
  * The purpose of this class (and thread) is to allow us to continue
@@ -48,29 +45,17 @@ class ShenandoahRegulatorThread: public ConcurrentGCThread {
   friend class VMStructs;
 
  public:
-  explicit ShenandoahRegulatorThread(ShenandoahControlThread* control_thread);
-
-  const char* name() const { return "ShenandoahRegulatorThread";}
-
-  // This is called from allocation path, and thus should be fast.
-  void notify_heap_changed() {
-    // Notify that something had changed.
-    if (_heap_changed.is_unset()) {
-      _heap_changed.set();
-    }
-  }
+  explicit ShenandoahRegulatorThread(ShenandoahGenerationalControlThread* control_thread);
 
  protected:
-  void run_service();
-  void stop_service();
+  void run_service() override;
+  void stop_service() override;
 
  private:
   // When mode is generational
   void regulate_young_and_old_cycles();
   // When mode is generational, but ShenandoahAllowOldMarkingPreemption is false
   void regulate_young_and_global_cycles();
-  // Default behavior for other modes (single generation).
-  void regulate_global_cycles();
 
   // These return true if a cycle was started.
   bool start_old_cycle();
@@ -87,13 +72,12 @@ class ShenandoahRegulatorThread: public ConcurrentGCThread {
   // Provides instrumentation to track how long it takes to acknowledge a request.
   bool request_concurrent_gc(ShenandoahGenerationType generation);
 
-  ShenandoahSharedFlag _heap_changed;
-  ShenandoahControlThread* _control_thread;
+  ShenandoahGenerationalControlThread* _control_thread;
   ShenandoahHeuristics* _young_heuristics;
   ShenandoahHeuristics* _old_heuristics;
   ShenandoahHeuristics* _global_heuristics;
 
-  int _sleep;
+  uint _sleep;
   double _last_sleep_adjust_time;
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahSATBMarkQueueSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSATBMarkQueueSet.hpp
@@ -26,7 +26,6 @@
 #define SHARE_GC_SHENANDOAH_SHENANDOAHSATBMARKQUEUESET_HPP
 
 #include "gc/shared/satbMarkQueue.hpp"
-#include "gc/shenandoah/shenandoahHeap.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/mutex.hpp"
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_SHENANDOAH_SHENANDOAHSTWMARK_HPP
 
 #include "gc/shenandoah/shenandoahMark.hpp"
+#include "gc/shenandoah/shenandoahRootProcessor.hpp"
 
 class ShenandoahSTWMarkTask;
 class ShenandoahGeneration;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -31,6 +31,36 @@
 #include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
 #include "logging/log.hpp"
 
+// A closure that takes an oop in the old generation and, if it's pointing
+// into the young generation, dirties the corresponding remembered set entry.
+// This is only used to rebuild the remembered set after a full GC.
+class ShenandoahDirtyRememberedSetClosure : public BasicOopIterateClosure {
+protected:
+  ShenandoahHeap*    const _heap;
+  RememberedScanner* const _scanner;
+
+public:
+  ShenandoahDirtyRememberedSetClosure() :
+          _heap(ShenandoahHeap::heap()),
+          _scanner(_heap->card_scan()) {}
+
+  template<class T>
+  inline void work(T* p) {
+    assert(_heap->is_in_old(p), "Expecting to get an old gen address");
+    T o = RawAccess<>::oop_load(p);
+    if (!CompressedOops::is_null(o)) {
+      oop obj = CompressedOops::decode_not_null(o);
+      if (_heap->is_in_young(obj)) {
+        // Dirty the card containing the cross-generational pointer.
+        _scanner->mark_card_as_dirty((HeapWord*) p);
+      }
+    }
+  }
+
+  virtual void do_oop(narrowOop* p) { work(p); }
+  virtual void do_oop(oop* p)       { work(p); }
+};
+
 ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(ShenandoahCardTable* card_table, size_t total_card_count) :
   LogCardValsPerIntPtr(log2i_exact(sizeof(intptr_t)) - log2i_exact(sizeof(CardValue))),
   LogCardSizeInWords(log2i_exact(CardTable::card_size_in_words())) {
@@ -370,4 +400,58 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
 
 void ShenandoahRegionChunkIterator::reset() {
   _index = 0;
+}
+
+ShenandoahReconstructRememberedSetTask::ShenandoahReconstructRememberedSetTask(ShenandoahRegionIterator* regions)
+  : WorkerTask("Shenandoah Reset Bitmap")
+  , _regions(regions) { }
+
+void ShenandoahReconstructRememberedSetTask::work(uint worker_id) {
+  ShenandoahParallelWorkerSession worker_session(worker_id);
+  ShenandoahHeapRegion* r = _regions->next();
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  RememberedScanner* scanner = heap->card_scan();
+  ShenandoahDirtyRememberedSetClosure dirty_cards_for_cross_generational_pointers;
+
+  while (r != nullptr) {
+    if (r->is_old() && r->is_active()) {
+      HeapWord* obj_addr = r->bottom();
+      if (r->is_humongous_start()) {
+        // First, clear the remembered set
+        oop obj = cast_to_oop(obj_addr);
+        size_t size = obj->size();
+
+        // First, clear the remembered set for all spanned humongous regions
+        size_t num_regions = ShenandoahHeapRegion::required_regions(size * HeapWordSize);
+        size_t region_span = num_regions * ShenandoahHeapRegion::region_size_words();
+        scanner->reset_remset(r->bottom(), region_span);
+        size_t region_index = r->index();
+        ShenandoahHeapRegion* humongous_region = heap->get_region(region_index);
+        while (num_regions-- != 0) {
+          scanner->reset_object_range(humongous_region->bottom(), humongous_region->end());
+          region_index++;
+          humongous_region = heap->get_region(region_index);
+        }
+
+        // Then register the humongous object and DIRTY relevant remembered set cards
+        scanner->register_object_without_lock(obj_addr);
+        obj->oop_iterate(&dirty_cards_for_cross_generational_pointers);
+      } else if (!r->is_humongous()) {
+        // First, clear the remembered set
+        scanner->reset_remset(r->bottom(), ShenandoahHeapRegion::region_size_words());
+        scanner->reset_object_range(r->bottom(), r->end());
+
+        // Then iterate over all objects, registering object and DIRTYing relevant remembered set cards
+        HeapWord* t = r->top();
+        while (obj_addr < t) {
+          oop obj = cast_to_oop(obj_addr);
+          size_t size = obj->size();
+          scanner->register_object_without_lock(obj_addr);
+          obj_addr += obj->oop_iterate_size(&dirty_cards_for_cross_generational_pointers);
+        }
+      } // else, ignore humongous continuation region
+    }
+    // else, this region is FREE or YOUNG or inactive and we can ignore it.
+    r = _regions->next();
+  }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -174,7 +174,6 @@
 // These limitations will be addressed in future enhancements to the
 // existing implementation.
 
-#include <stdint.h>
 #include "gc/shared/workerThread.hpp"
 #include "gc/shenandoah/shenandoahCardStats.hpp"
 #include "gc/shenandoah/shenandoahCardTable.hpp"
@@ -1047,5 +1046,17 @@ class ShenandoahScanRememberedTask : public WorkerTask {
   void do_work(uint worker_id);
 };
 
+// After Full GC is done, reconstruct the remembered set by iterating over OLD regions,
+// registering all objects between bottom() and top(), and dirtying the cards containing
+// cross-generational pointers.
+class ShenandoahReconstructRememberedSetTask : public WorkerTask {
+private:
+  ShenandoahRegionIterator* _regions;
+
+public:
+  explicit ShenandoahReconstructRememberedSetTask(ShenandoahRegionIterator* regions);
+
+  void work(uint worker_id) override;
+};
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBERED_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
@@ -182,7 +182,7 @@ void ShenandoahUnload::unload() {
 
     {
       ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_class_unload_purge_cldg);
-      ClassLoaderDataGraph::purge(/*at_safepoint*/false);
+      ClassLoaderDataGraph::purge(false /* at_safepoint */);
     }
 
     {

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -74,7 +74,6 @@ ShenandoahGCSession::~ShenandoahGCSession() {
   _tracer->report_gc_reference_stats(_generation->ref_processor()->reference_process_stats());
   _tracer->report_gc_end(_timer->gc_end(), _timer->time_partitions());
   assert(!ShenandoahGCPhase::is_current_phase_valid(), "No current GC phase");
-
 }
 
 ShenandoahGCPauseMark::ShenandoahGCPauseMark(uint gc_id, const char* notification_message, SvcGCMarker::reason_type type) :

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -46,9 +46,9 @@ class ShenandoahGeneration;
 
 #define SHENANDOAH_RETURN_EVENT_MESSAGE(generation_type, prefix, postfix) \
   switch (generation_type) {                                              \
-    case GLOBAL_NON_GEN:                                                  \
-      return prefix "" postfix;                                           \
-    case GLOBAL_GEN:                                                      \
+    case NON_GEN:                                                         \
+      return prefix " (NON-GENERATIONAL)" postfix;                        \
+    case GLOBAL:                                                          \
       return prefix " (GLOBAL)" postfix;                                  \
     case YOUNG:                                                           \
       return prefix " (YOUNG)" postfix;                                   \
@@ -56,7 +56,7 @@ class ShenandoahGeneration;
       return prefix " (OLD)" postfix;                                     \
     default:                                                              \
       ShouldNotReachHere();                                               \
-      return prefix " (?)" postfix;                                       \
+      return prefix " (UNKNOWN)" postfix;                                 \
   }                                                                       \
 
 class ShenandoahGCSession : public StackObj {

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -411,7 +411,7 @@ class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
     size_t generation_used = generation->used();
     size_t generation_used_regions = generation->used_regions();
     if (adjust_for_padding && (generation->is_young() || generation->is_global())) {
-      size_t pad = ShenandoahHeap::heap()->get_pad_for_promote_in_place();
+      size_t pad = heap->old_generation()->get_pad_for_promote_in_place();
       generation_used += pad;
     }
 
@@ -861,7 +861,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
     size_t heap_used;
     if (_heap->mode()->is_generational() && (sizeness == _verify_size_adjusted_for_padding)) {
       // Prior to evacuation, regular regions that are to be evacuated in place are padded to prevent further allocations
-      heap_used = _heap->used() + _heap->get_pad_for_promote_in_place();
+      heap_used = _heap->used() + _heap->old_generation()->get_pad_for_promote_in_place();
     } else if (sizeness != _verify_size_disable) {
       heap_used = _heap->used();
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.cpp
@@ -25,141 +25,52 @@
 #include "precompiled.hpp"
 
 #include "gc/shared/gc_globals.hpp"
-#include "gc/shared/workerPolicy.hpp"
 #include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
-#include "runtime/javaThread.hpp"
-#include "runtime/threads.hpp"
-
-uint ShenandoahWorkerPolicy::_prev_par_marking     = 0;
-uint ShenandoahWorkerPolicy::_prev_conc_marking    = 0;
-uint ShenandoahWorkerPolicy::_prev_conc_rs_scanning = 0;
-uint ShenandoahWorkerPolicy::_prev_conc_evac       = 0;
-uint ShenandoahWorkerPolicy::_prev_conc_root_proc  = 0;
-uint ShenandoahWorkerPolicy::_prev_conc_refs_proc  = 0;
-uint ShenandoahWorkerPolicy::_prev_fullgc          = 0;
-uint ShenandoahWorkerPolicy::_prev_degengc         = 0;
-uint ShenandoahWorkerPolicy::_prev_conc_update_ref = 0;
-uint ShenandoahWorkerPolicy::_prev_par_update_ref  = 0;
-uint ShenandoahWorkerPolicy::_prev_conc_cleanup    = 0;
-uint ShenandoahWorkerPolicy::_prev_conc_reset      = 0;
 
 uint ShenandoahWorkerPolicy::calc_workers_for_init_marking() {
-  uint active_workers = (_prev_par_marking == 0) ? ParallelGCThreads : _prev_par_marking;
-
-  _prev_par_marking =
-    WorkerPolicy::calc_active_workers(ParallelGCThreads,
-                                      active_workers,
-                                      Threads::number_of_non_daemon_threads());
-  return _prev_par_marking;
+  return ParallelGCThreads;
 }
 
 uint ShenandoahWorkerPolicy::calc_workers_for_conc_marking() {
-  uint active_workers = (_prev_conc_marking == 0) ?  ConcGCThreads : _prev_conc_marking;
-  _prev_conc_marking =
-    WorkerPolicy::calc_active_conc_workers(ConcGCThreads,
-                                           active_workers,
-                                           Threads::number_of_non_daemon_threads());
-  return _prev_conc_marking;
+  return ConcGCThreads;
 }
 
 uint ShenandoahWorkerPolicy::calc_workers_for_rs_scanning() {
-  uint active_workers = (_prev_conc_rs_scanning == 0) ? ConcGCThreads : _prev_conc_rs_scanning;
-  _prev_conc_rs_scanning =
-    WorkerPolicy::calc_active_conc_workers(ConcGCThreads,
-                                           active_workers,
-                                           Threads::number_of_non_daemon_threads());
-  return _prev_conc_rs_scanning;
+  return ConcGCThreads;
 }
 
-// Reuse the calculation result from init marking
 uint ShenandoahWorkerPolicy::calc_workers_for_final_marking() {
-  return _prev_par_marking;
+  return ParallelGCThreads;
 }
 
-// Calculate workers for concurrent refs processing
 uint ShenandoahWorkerPolicy::calc_workers_for_conc_refs_processing() {
-  uint active_workers = (_prev_conc_refs_proc == 0) ? ConcGCThreads : _prev_conc_refs_proc;
-  _prev_conc_refs_proc =
-    WorkerPolicy::calc_active_conc_workers(ConcGCThreads,
-                                           active_workers,
-                                           Threads::number_of_non_daemon_threads());
-  return _prev_conc_refs_proc;
+  return ConcGCThreads;
 }
 
-// Calculate workers for concurrent root processing
 uint ShenandoahWorkerPolicy::calc_workers_for_conc_root_processing() {
-  uint active_workers = (_prev_conc_root_proc == 0) ? ConcGCThreads : _prev_conc_root_proc;
-  _prev_conc_root_proc =
-          WorkerPolicy::calc_active_conc_workers(ConcGCThreads,
-                                                 active_workers,
-                                                 Threads::number_of_non_daemon_threads());
-  return _prev_conc_root_proc;
+  return ConcGCThreads;
 }
 
-// Calculate workers for concurrent evacuation (concurrent GC)
 uint ShenandoahWorkerPolicy::calc_workers_for_conc_evac() {
-  uint active_workers = (_prev_conc_evac == 0) ? ConcGCThreads : _prev_conc_evac;
-  _prev_conc_evac =
-    WorkerPolicy::calc_active_conc_workers(ConcGCThreads,
-                                           active_workers,
-                                           Threads::number_of_non_daemon_threads());
-  return _prev_conc_evac;
+  return ConcGCThreads;
 }
 
-// Calculate workers for parallel fullgc
 uint ShenandoahWorkerPolicy::calc_workers_for_fullgc() {
-  uint active_workers = (_prev_fullgc == 0) ?  ParallelGCThreads : _prev_fullgc;
-  _prev_fullgc =
-    WorkerPolicy::calc_active_workers(ParallelGCThreads,
-                                      active_workers,
-                                      Threads::number_of_non_daemon_threads());
-  return _prev_fullgc;
+  return ParallelGCThreads;
 }
 
-// Calculate workers for parallel degenerated gc
 uint ShenandoahWorkerPolicy::calc_workers_for_stw_degenerated() {
-  uint active_workers = (_prev_degengc == 0) ?  ParallelGCThreads : _prev_degengc;
-  _prev_degengc =
-    WorkerPolicy::calc_active_workers(ParallelGCThreads,
-                                      active_workers,
-                                      Threads::number_of_non_daemon_threads());
-  return _prev_degengc;
+  return ParallelGCThreads;
 }
 
-// Calculate workers for concurrent reference update
 uint ShenandoahWorkerPolicy::calc_workers_for_conc_update_ref() {
-  uint active_workers = (_prev_conc_update_ref == 0) ? ConcGCThreads : _prev_conc_update_ref;
-  _prev_conc_update_ref =
-    WorkerPolicy::calc_active_conc_workers(ConcGCThreads,
-                                           active_workers,
-                                           Threads::number_of_non_daemon_threads());
-  return _prev_conc_update_ref;
+  return ConcGCThreads;
 }
 
-// Calculate workers for parallel reference update
 uint ShenandoahWorkerPolicy::calc_workers_for_final_update_ref() {
-  uint active_workers = (_prev_par_update_ref == 0) ? ParallelGCThreads : _prev_par_update_ref;
-  _prev_par_update_ref =
-    WorkerPolicy::calc_active_workers(ParallelGCThreads,
-                                      active_workers,
-                                      Threads::number_of_non_daemon_threads());
-  return _prev_par_update_ref;
-}
-
-uint ShenandoahWorkerPolicy::calc_workers_for_conc_cleanup() {
-  uint active_workers = (_prev_conc_cleanup == 0) ? ConcGCThreads : _prev_conc_cleanup;
-  _prev_conc_cleanup =
-          WorkerPolicy::calc_active_conc_workers(ConcGCThreads,
-                                                 active_workers,
-                                                 Threads::number_of_non_daemon_threads());
-  return _prev_conc_cleanup;
+  return ParallelGCThreads;
 }
 
 uint ShenandoahWorkerPolicy::calc_workers_for_conc_reset() {
-  uint active_workers = (_prev_conc_reset == 0) ? ConcGCThreads : _prev_conc_reset;
-  _prev_conc_reset =
-          WorkerPolicy::calc_active_conc_workers(ConcGCThreads,
-                                                 active_workers,
-                                                 Threads::number_of_non_daemon_threads());
-  return _prev_conc_reset;
+  return ConcGCThreads;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
@@ -28,20 +28,6 @@
 #include "memory/allStatic.hpp"
 
 class ShenandoahWorkerPolicy : AllStatic {
-private:
-  static uint _prev_par_marking;
-  static uint _prev_conc_marking;
-  static uint _prev_conc_rs_scanning;
-  static uint _prev_conc_root_proc;
-  static uint _prev_conc_refs_proc;
-  static uint _prev_conc_evac;
-  static uint _prev_fullgc;
-  static uint _prev_degengc;
-  static uint _prev_conc_update_ref;
-  static uint _prev_par_update_ref;
-  static uint _prev_conc_cleanup;
-  static uint _prev_conc_reset;
-
 public:
   // Calculate the number of workers for initial marking
   static uint calc_workers_for_init_marking();
@@ -75,9 +61,6 @@ public:
 
   // Calculate workers for parallel/final reference update
   static uint calc_workers_for_final_update_ref();
-
-  // Calculate workers for concurrent cleanup
-  static uint calc_workers_for_conc_cleanup();
 
   // Calculate workers for concurrent reset
   static uint calc_workers_for_conc_reset();

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -496,9 +496,10 @@
           "How many back-to-back Degenerated GCs should happen before "     \
           "going to a Full GC.")                                            \
                                                                             \
-  product(uintx, ShenandoahOOMGCRetries, 3, EXPERIMENTAL,                   \
-          "How many GCs should happen before we throw OutOfMemoryException "\
-          "for allocation request, including at least one Full GC.")        \
+  product(uintx, ShenandoahNoProgressThreshold, 5, EXPERIMENTAL,            \
+          "After this number of consecutive Full GCs fail to make "         \
+          "progress, Shenandoah will raise out of memory errors. Note "     \
+          "that progress is determined by ShenandoahCriticalFreeThreshold") \
                                                                             \
   product(bool, ShenandoahImplicitGCInvokesConcurrent, false, EXPERIMENTAL, \
           "Should internally-caused GC requests invoke concurrent cycles, " \

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
@@ -85,7 +85,7 @@ class ShenandoahOldHeuristicTest : public ::testing::Test {
     ShenandoahHeapLocker locker(_heap->lock());
     ShenandoahResetRegions reset;
     _heap->heap_region_iterate(&reset);
-    _heap->set_old_evac_reserve(_heap->old_generation()->soft_max_capacity() / 4);
+    _heap->old_generation()->set_evacuation_reserve(_heap->old_generation()->soft_max_capacity() / 4);
     _heuristics->abandon_collection_candidates();
     _collection_set->clear();
   }

--- a/test/hotspot/jtreg/gc/ergonomics/TestDynamicNumberOfGCThreads.java
+++ b/test/hotspot/jtreg/gc/ergonomics/TestDynamicNumberOfGCThreads.java
@@ -53,13 +53,8 @@ public class TestDynamicNumberOfGCThreads {
       testDynamicNumberOfGCThreads("UseParallelGC");
     }
 
-    if (GC.Shenandoah.isSupported()) {
-      noneGCSupported = false;
-      testDynamicNumberOfGCThreads("UseShenandoahGC");
-    }
-
     if (noneGCSupported) {
-      throw new SkippedException("Skipping test because none of G1/Parallel/Shenandoah is supported.");
+      throw new SkippedException("Skipping test because none of G1/Parallel is supported.");
     }
   }
 

--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestThreadFailure.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestThreadFailure.java
@@ -81,6 +81,7 @@ public class TestThreadFailure {
                     "-Xmx32m",
                     "-XX:+UnlockExperimentalVMOptions",
                     "-XX:+UseShenandoahGC", "-XX:ShenandoahGCMode=generational",
+                    "-XX:ShenandoahNoProgressThreshold=16",
                     TestThreadFailure.class.getName(),
                     "test");
 


### PR DESCRIPTION
The delta for this fork has grown too great for individual backport PRs. This change synchronizes the `shenandoah-jdk21u` fork by essentially checking out the `shenandoah` directory from `shenandoah` and reverting the few things we can't take because of changes outside of `shenandoah`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8329342](https://bugs.openjdk.org/browse/JDK-8329342): GenShen: Synchronize shenandoah-jdk21u:master with shenandoah:master (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/31.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/31.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/31#issuecomment-2027783782)