### PR TITLE
8329789: GenShen: Over assertive assert when scanning remembered set

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -772,7 +772,11 @@ void ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_clus
     } else {
       // ==== BEGIN CLEAN card range processing ====
 
-      assert(ctbm[cur_index] == CardTable::clean_card_val(), "Error");
+      // If we are using the write table (during update refs, e.g.), a mutator may dirty
+      // a card at any time. This is fine for the algorithm below because it is only
+      // counting contiguous runs of clean cards (and only for non-product builds).
+      assert(use_write_table || ctbm[cur_index] == CardTable::clean_card_val(), "Error");
+
       // walk back over contiguous clean cards
       size_t i = 0;
       while (--cur_index >= (ssize_t)start_card_index && ctbm[cur_index] == CardTable::clean_card_val()) {


### PR DESCRIPTION
Clean backport, assert only and assert only applies to non-product code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329789](https://bugs.openjdk.org/browse/JDK-8329789): GenShen: Over assertive assert when scanning remembered set (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/34.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/34.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/34#issuecomment-2050681196)