### PR TITLE
8330071: GenShen: Allow old to expand again at end of each GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -299,7 +299,9 @@ size_t ShenandoahGenerationSizer::max_size_for(ShenandoahGeneration* generation)
     case YOUNG:
       return max_young_size();
     case OLD:
-      return min_young_size();
+      // On the command line, max size of OLD is specified indirectly, by setting a minimum size of young.
+      // OLD is what remains within the heap after YOUNG has been sized.
+      return ShenandoahHeap::heap()->max_capacity() - min_young_size();
     default:
       ShouldNotReachHere();
       return 0;
@@ -311,6 +313,8 @@ size_t ShenandoahGenerationSizer::min_size_for(ShenandoahGeneration* generation)
     case YOUNG:
       return min_young_size();
     case OLD:
+      // On the command line, min size of OLD is specified indirectly, by setting a maximum size of young.
+      // OLD is what remains within the heap after YOUNG has been sized.
       return ShenandoahHeap::heap()->max_capacity() - max_young_size();
     default:
       ShouldNotReachHere();


### PR DESCRIPTION
This pull request contains a backport of commit 0578af80 from the openjdk/shenandoah repository.

The commit being backported was authored by Kelvin Nilsen on 15 Apr 2024 and was reviewed by William Kemper and Y. Srinivas Ramakrishna.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330071](https://bugs.openjdk.org/browse/JDK-8330071): GenShen: Allow old to expand again at end of each GC (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/35.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/35.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/35#issuecomment-2062737353)