### PR TITLE
8329350: GenShen: Do not reset mark bitmaps on a safepoint

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -40,6 +40,7 @@
 
 #include "utilities/quickSort.hpp"
 
+
 class ShenandoahResetUpdateRegionStateClosure : public ShenandoahHeapRegionClosure {
  private:
   ShenandoahHeap* _heap;
@@ -233,7 +234,11 @@ void ShenandoahGeneration::prepare_gc() {
 
   // Capture Top At Mark Start for this generation (typically young) and reset mark bitmap.
   ShenandoahResetUpdateRegionStateClosure cl;
-  parallel_heap_region_iterate(&cl);
+  parallel_region_iterate_free(&cl);
+}
+
+void ShenandoahGeneration::parallel_region_iterate_free(ShenandoahHeapRegionClosure* cl) {
+  ShenandoahHeap::heap()->parallel_heap_region_iterate(cl);
 }
 
 void ShenandoahGeneration::compute_evacuation_budgets(ShenandoahHeap* const heap) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -179,6 +179,9 @@ private:
   // Apply closure to all regions affiliated with this generation.
   virtual void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl) = 0;
 
+  // Apply closure to all regions affiliated with this generation (include free regions);
+  virtual void parallel_region_iterate_free(ShenandoahHeapRegionClosure* cl);
+
   // Apply closure to all regions affiliated with this generation (single threaded).
   virtual void heap_region_iterate(ShenandoahHeapRegionClosure* cl) = 0;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -3395,32 +3395,6 @@ void ShenandoahHeap::transfer_old_pointers_from_satb() {
   _old_generation->transfer_pointers_from_satb();
 }
 
-template<>
-void ShenandoahGenerationRegionClosure<YOUNG>::heap_region_do(ShenandoahHeapRegion* region) {
-  // Visit young regions
-  if (region->is_young()) {
-    _cl->heap_region_do(region);
-  }
-}
-
-template<>
-void ShenandoahGenerationRegionClosure<OLD>::heap_region_do(ShenandoahHeapRegion* region) {
-  // Visit old regions
-  if (region->is_old()) {
-    _cl->heap_region_do(region);
-  }
-}
-
-template<>
-void ShenandoahGenerationRegionClosure<GLOBAL>::heap_region_do(ShenandoahHeapRegion* region) {
-  _cl->heap_region_do(region);
-}
-
-template<>
-void ShenandoahGenerationRegionClosure<NON_GEN>::heap_region_do(ShenandoahHeapRegion* region) {
-  _cl->heap_region_do(region);
-}
-
 bool ShenandoahHeap::verify_generation_usage(bool verify_old, size_t old_regions, size_t old_bytes, size_t old_waste,
                                              bool verify_young, size_t young_regions, size_t young_bytes, size_t young_waste) {
   size_t tally_old_regions = 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -124,16 +124,6 @@ public:
   virtual bool is_thread_safe() { return false; }
 };
 
-template<ShenandoahGenerationType GENERATION>
-class ShenandoahGenerationRegionClosure : public ShenandoahHeapRegionClosure {
- public:
-  explicit ShenandoahGenerationRegionClosure(ShenandoahHeapRegionClosure* cl) : _cl(cl) {}
-  void heap_region_do(ShenandoahHeapRegion* r);
-  virtual bool is_thread_safe() { return _cl->is_thread_safe(); }
- private:
-  ShenandoahHeapRegionClosure* _cl;
-};
-
 typedef ShenandoahLock    ShenandoahHeapLock;
 typedef ShenandoahLocker  ShenandoahHeapLocker;
 typedef Stack<oop, mtGC>  ShenandoahScanObjectStack;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -675,7 +675,9 @@ void ShenandoahHeapRegion::recycle() {
   shenandoah_assert_heaplocked();
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   ShenandoahGeneration* generation = heap->generation_for(affiliation());
+
   heap->decrease_used(generation, used());
+  generation->decrement_affiliated_region_count();
 
   set_top(bottom());
   clear_live_data();
@@ -686,7 +688,7 @@ void ShenandoahHeapRegion::recycle() {
   set_update_watermark(bottom());
 
   make_empty();
-  ShenandoahHeap::heap()->generation_for(affiliation())->decrement_affiliated_region_count();
+
   set_affiliation(FREE);
   if (ZapUnusedHeapArea) {
     SpaceMangler::mangle_region(MemRegion(bottom(), end()));

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SRC_SHARE_GC_SHENANDOAH_SHENANDOAHHEAPREGIONCLOSURES_HPP
+#define SRC_SHARE_GC_SHENANDOAH_SHENANDOAHHEAPREGIONCLOSURES_HPP
+
+
+#include "gc/shenandoah/shenandoahHeap.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
+
+// Applies the given closure to all regions with the given affiliation
+template<ShenandoahAffiliation AFFILIATION>
+class ShenandoahIncludeRegionClosure : public ShenandoahHeapRegionClosure {
+private:
+  ShenandoahHeapRegionClosure* _closure;
+
+public:
+  explicit ShenandoahIncludeRegionClosure(ShenandoahHeapRegionClosure* closure): _closure(closure) {}
+
+  void heap_region_do(ShenandoahHeapRegion* r) override {
+    if (r->affiliation() == AFFILIATION) {
+      _closure->heap_region_do(r);
+    }
+  }
+
+  bool is_thread_safe() override {
+    return _closure->is_thread_safe();
+  }
+};
+
+// Applies the given closure to all regions without the given affiliation
+template<ShenandoahAffiliation AFFILIATION>
+class ShenandoahExcludeRegionClosure : public ShenandoahHeapRegionClosure {
+private:
+  ShenandoahHeapRegionClosure* _closure;
+
+public:
+  explicit ShenandoahExcludeRegionClosure(ShenandoahHeapRegionClosure* closure): _closure(closure) {}
+
+  void heap_region_do(ShenandoahHeapRegion* r) override {
+    if (r->affiliation() != AFFILIATION) {
+      _closure->heap_region_do(r);
+    }
+  }
+
+  bool is_thread_safe() override {
+    return _closure->is_thread_safe();
+  }
+};
+
+#endif //SRC_SHARE_GC_SHENANDOAH_SHENANDOAHHEAPREGIONCLOSURES_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.cpp
@@ -80,12 +80,6 @@ HeapWord* ShenandoahMarkingContext::top_bitmap(ShenandoahHeapRegion* r) {
 }
 
 void ShenandoahMarkingContext::clear_bitmap(ShenandoahHeapRegion* r) {
-  if (!r->is_affiliated()) {
-    // Heap iterators include FREE regions, which don't need to be cleared.
-    // TODO: would be better for certain iterators to not include FREE regions.
-    return;
-  }
-
   HeapWord* bottom = r->bottom();
   HeapWord* top_bitmap = _top_bitmaps[r->index()];
 
@@ -96,9 +90,6 @@ void ShenandoahMarkingContext::clear_bitmap(ShenandoahHeapRegion* r) {
     _mark_bit_map.clear_range_large(MemRegion(bottom, top_bitmap));
     _top_bitmaps[r->index()] = bottom;
   }
-
-  // TODO: Why is clear_live_data here?
-  r->clear_live_data();
 
   assert(is_bitmap_clear_range(bottom, r->end()),
          "Region " SIZE_FORMAT " should have no marks in bitmap", r->index());

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
@@ -97,19 +97,8 @@ inline void ShenandoahMarkingContext::capture_top_at_mark_start(ShenandoahHeapRe
   log_debug(gc)("Capturing TAMS for %s Region " SIZE_FORMAT ", was: " PTR_FORMAT ", now: " PTR_FORMAT,
                 r->affiliation_name(), idx, p2i(old_tams), p2i(new_tams));
 
-  if ((old_tams == r->bottom()) && (new_tams > old_tams)) {
-    log_debug(gc)("Clearing mark bitmap for %s Region " SIZE_FORMAT " while capturing TAMS",
-                  r->affiliation_name(), idx);
-    // TODO: Do we really need to do bitmap clears here?
-    // This could take a while, and we would instead like to clear bitmaps outside the pause.
-    clear_bitmap(r);
-  }
-
   _top_at_mark_starts_base[idx] = new_tams;
-  if (new_tams > r->bottom()) {
-    // In this case, new_tams is greater than old _top_bitmaps[idx]
-    _top_bitmaps[idx] = new_tams;
-  }
+  _top_bitmaps[idx] = new_tams;
 }
 
 inline void ShenandoahMarkingContext::reset_top_at_mark_start(ShenandoahHeapRegion* r) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -140,6 +140,9 @@ public:
   }
 
   void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl) override;
+
+  void parallel_region_iterate_free(ShenandoahHeapRegionClosure* cl) override;
+
   void heap_region_iterate(ShenandoahHeapRegionClosure* cl) override;
 
   bool contains(ShenandoahHeapRegion* region) const override;
@@ -149,10 +152,10 @@ public:
   bool is_concurrent_mark_in_progress() override;
 
   bool entry_coalesce_and_fill();
-  virtual void prepare_gc() override;
+  void prepare_gc() override;
   void prepare_regions_and_collection_set(bool concurrent) override;
-  virtual void record_success_concurrent(bool abbreviated) override;
-  virtual void cancel_marking() override;
+  void record_success_concurrent(bool abbreviated) override;
+  void cancel_marking() override;
 
   // We leave the SATB barrier on for the entirety of the old generation
   // marking phase. In some cases, this can cause a write to a perfectly

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -26,6 +26,7 @@
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
 #include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahHeapRegionClosures.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahVerifier.hpp"
@@ -56,13 +57,13 @@ bool ShenandoahYoungGeneration::contains(ShenandoahHeapRegion* region) const {
 
 void ShenandoahYoungGeneration::parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl) {
   // Just iterate over the young generation here.
-  ShenandoahGenerationRegionClosure<YOUNG> young_regions(cl);
-  ShenandoahHeap::heap()->parallel_heap_region_iterate(&young_regions);
+  ShenandoahIncludeRegionClosure<YOUNG_GENERATION> young_regions_cl(cl);
+  ShenandoahHeap::heap()->parallel_heap_region_iterate(&young_regions_cl);
 }
 
 void ShenandoahYoungGeneration::heap_region_iterate(ShenandoahHeapRegionClosure* cl) {
-  ShenandoahGenerationRegionClosure<YOUNG> young_regions(cl);
-  ShenandoahHeap::heap()->heap_region_iterate(&young_regions);
+  ShenandoahIncludeRegionClosure<YOUNG_GENERATION> young_regions_cl(cl);
+  ShenandoahHeap::heap()->heap_region_iterate(&young_regions_cl);
 }
 
 bool ShenandoahYoungGeneration::is_concurrent_mark_in_progress() {
@@ -97,4 +98,9 @@ size_t ShenandoahYoungGeneration::available() const {
 size_t ShenandoahYoungGeneration::soft_available() const {
   size_t available = this->ShenandoahGeneration::soft_available();
   return MIN2(available, ShenandoahHeap::heap()->free_set()->available());
+}
+
+void ShenandoahYoungGeneration::parallel_region_iterate_free(ShenandoahHeapRegionClosure* cl) {
+  ShenandoahExcludeRegionClosure<OLD_GENERATION> exclude_cl(cl);
+  ShenandoahHeap::heap()->parallel_heap_region_iterate(&exclude_cl);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -44,6 +44,9 @@ public:
   bool is_concurrent_mark_in_progress() override;
 
   void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl) override;
+
+  void parallel_region_iterate_free(ShenandoahHeapRegionClosure* cl) override;
+
   void heap_region_iterate(ShenandoahHeapRegionClosure* cl) override;
 
   bool contains(ShenandoahHeapRegion* region) const override;


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329350](https://bugs.openjdk.org/browse/JDK-8329350): GenShen: Do not reset mark bitmaps on a safepoint (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/37.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/37.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/37#issuecomment-2073417690)