### PR TITLE
8330414: GenShen: Class unloading requires old regions be made parseable

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -67,7 +67,11 @@ ShenandoahOldHeuristics::ShenandoahOldHeuristics(ShenandoahOldGeneration* genera
   _old_generation(generation),
   _cannot_expand_trigger(false),
   _fragmentation_trigger(false),
-  _growth_trigger(false) {
+  _growth_trigger(false),
+  _fragmentation_density(0.0),
+  _fragmentation_first_old_region(0),
+  _fragmentation_last_old_region(0)
+{
 }
 
 bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* collection_set) {
@@ -204,11 +208,8 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
     // We have added the last of our collection candidates to a mixed collection.
     // Any triggers that occurred during mixed evacuations may no longer be valid.  They can retrigger if appropriate.
     clear_triggers();
-    if (has_coalesce_and_fill_candidates()) {
-      _old_generation->transition_to(ShenandoahOldGeneration::FILLING);
-    } else {
-      _old_generation->transition_to(ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP);
-    }
+
+    _old_generation->complete_mixed_evacuations();
   } else if (included_old_regions == 0) {
     // We have candidates, but none were included for evacuation - are they all pinned?
     // or did we just not have enough room for any of them in this collection set?
@@ -217,7 +218,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
     // (pinned) regions parsable.
     if (all_candidates_are_pinned()) {
       log_info(gc)("All candidate regions " UINT32_FORMAT " are pinned", unprocessed_old_collection_candidates());
-      _old_generation->transition_to(ShenandoahOldGeneration::FILLING);
+      _old_generation->abandon_mixed_evacuations();
     } else {
       log_info(gc)("No regions selected for mixed collection. "
                    "Old evacuation budget: " PROPERFMT ", Remaining evacuation budget: " PROPERFMT

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -110,11 +110,10 @@ private:
   static int compare_by_index(RegionData a, RegionData b);
 
  protected:
-  virtual void choose_collection_set_from_regiondata(ShenandoahCollectionSet* set, RegionData* data, size_t data_size,
-                                                     size_t free) override;
+  void choose_collection_set_from_regiondata(ShenandoahCollectionSet* set, RegionData* data, size_t data_size, size_t free) override;
 
 public:
-  ShenandoahOldHeuristics(ShenandoahOldGeneration* generation);
+  explicit ShenandoahOldHeuristics(ShenandoahOldGeneration* generation);
 
   // Prepare for evacuation of old-gen regions by capturing the mark results of a recently completed concurrent mark pass.
   void prepare_for_old_collections();
@@ -193,7 +192,7 @@ public:
 
   bool is_experimental() override;
 
- private:
+private:
   void slide_pinned_regions_to_front();
   bool all_candidates_are_pinned();
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -58,7 +58,7 @@ protected:
 
 public:
   ShenandoahConcurrentGC(ShenandoahGeneration* generation, bool do_old_gc_bootstrap);
-  bool collect(GCCause::Cause cause);
+  bool collect(GCCause::Cause cause) override;
   ShenandoahDegenPoint degen_point() const;
 
   // Return true if this cycle found enough immediate garbage to skip evacuation
@@ -104,6 +104,7 @@ private:
   void entry_evacuate();
   void entry_update_thread_roots();
   void entry_updaterefs();
+  void entry_global_coalesce_and_fill();
   void entry_cleanup_complete();
 
   // Actual work for the phases
@@ -123,6 +124,7 @@ private:
   void op_update_thread_roots();
   void op_final_updaterefs();
   void op_final_roots();
+  void op_global_coalesce_and_fill();
   void op_cleanup_complete();
 
 protected:

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -58,6 +58,9 @@ private:
   void op_update_roots();
   void op_cleanup_complete();
 
+  // This will rebuild card offsets, which is necessary if classes were unloaded
+  void op_global_coalesce_and_fill();
+
   // Fail handling
   void op_degenerated_futile();
   void op_degenerated_fail();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -709,7 +709,7 @@ void ShenandoahGenerationalControlThread::service_stw_degenerated_cycle(GCCause:
   } else {
     assert(_degen_generation->is_young(), "Expected degenerated young cycle, if not global.");
     ShenandoahOldGeneration* old = heap->old_generation();
-    if (old->state() == ShenandoahOldGeneration::BOOTSTRAPPING) {
+    if (old->is_bootstrapping()) {
       old->transition_to(ShenandoahOldGeneration::MARKING);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
@@ -80,7 +80,6 @@ void ShenandoahGenerationalEvacuationTask::work(uint worker_id) {
 void ShenandoahGenerationalEvacuationTask::do_work() {
   ShenandoahConcurrentEvacuator cl(_heap);
   ShenandoahHeapRegion* r;
-  ShenandoahMarkingContext* const ctx = _heap->marking_context();
 
   while ((r = _regions->next()) != nullptr) {
     log_debug(gc)("GenerationalEvacuationTask do_work(), looking at %s region " SIZE_FORMAT ", (age: %d) [%s, %s, %s]",

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -91,6 +91,7 @@ public:
   // Transfers surplus old regions to young, or takes regions from young to satisfy old region deficit
   TransferResult balance_generations();
 
+  void coalesce_and_fill_old_regions(bool concurrent);
 
 private:
   void initialize_controller() override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -972,7 +972,7 @@ HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) 
 void ShenandoahHeap::cancel_old_gc() {
   shenandoah_assert_safepoint();
   assert(old_generation() != nullptr, "Should only have mixed collections in generation mode.");
-  if (old_generation()->state() == ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP) {
+  if (old_generation()->is_idle()) {
 #ifdef ASSERT
     old_generation()->validate_waiting_for_bootstrap();
 #endif
@@ -2094,6 +2094,9 @@ void ShenandoahHeap::recycle_trash() {
 
 void ShenandoahHeap::do_class_unloading() {
   _unloader.unload();
+  if (mode()->is_generational()) {
+    old_generation()->set_parseable(false);
+  }
 }
 
 void ShenandoahHeap::stw_weak_refs(bool full_gc) {
@@ -2173,7 +2176,7 @@ void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
 }
 
 bool ShenandoahHeap::is_prepare_for_old_mark_in_progress() const {
-  return old_generation()->state() == ShenandoahOldGeneration::FILLING;
+  return old_generation()->is_preparing_for_mark();
 }
 
 void ShenandoahHeap::set_aging_cycle(bool in_progress) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -452,51 +452,9 @@ void ShenandoahHeapRegion::print_on(outputStream* st) const {
 #undef SHR_PTR_FORMAT
 }
 
-// oop_iterate without closure and without cancellation.  always return true.
-bool ShenandoahHeapRegion::oop_fill_and_coalesce_without_cancel() {
-  HeapWord* obj_addr = resume_coalesce_and_fill();
-
-  assert(!is_humongous(), "No need to fill or coalesce humongous regions");
-  if (!is_active()) {
-    end_preemptible_coalesce_and_fill();
-    return true;
-  }
-
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  ShenandoahMarkingContext* marking_context = heap->marking_context();
-  // All objects above TAMS are considered live even though their mark bits will not be set.  Note that young-
-  // gen evacuations that interrupt a long-running old-gen concurrent mark may promote objects into old-gen
-  // while the old-gen concurrent marking is ongoing.  These newly promoted objects will reside above TAMS
-  // and will be treated as live during the current old-gen marking pass, even though they will not be
-  // explicitly marked.
-  HeapWord* t = marking_context->top_at_mark_start(this);
-
-  // Expect marking to be completed before these threads invoke this service.
-  assert(heap->active_generation()->is_mark_complete(), "sanity");
-  while (obj_addr < t) {
-    oop obj = cast_to_oop(obj_addr);
-    if (marking_context->is_marked(obj)) {
-      assert(obj->klass() != nullptr, "klass should not be nullptr");
-      obj_addr += obj->size();
-    } else {
-      // Object is not marked.  Coalesce and fill dead object with dead neighbors.
-      HeapWord* next_marked_obj = marking_context->get_next_marked_addr(obj_addr, t);
-      assert(next_marked_obj <= t, "next marked object cannot exceed top");
-      size_t fill_size = next_marked_obj - obj_addr;
-      assert(fill_size >= ShenandoahHeap::min_fill_size(), "previously allocated objects known to be larger than min_size");
-      ShenandoahHeap::fill_with_object(obj_addr, fill_size);
-      heap->card_scan()->coalesce_objects(obj_addr, fill_size);
-      obj_addr = next_marked_obj;
-    }
-  }
-  // Mark that this region has been coalesced and filled
-  end_preemptible_coalesce_and_fill();
-  return true;
-}
-
 // oop_iterate without closure, return true if completed without cancellation
-bool ShenandoahHeapRegion::oop_fill_and_coalesce() {
-  HeapWord* obj_addr = resume_coalesce_and_fill();
+bool ShenandoahHeapRegion::oop_coalesce_and_fill(bool cancellable) {
+
   // Consider yielding to cancel/preemption request after this many coalesce operations (skip marked, or coalesce free).
   const size_t preemption_stride = 128;
 
@@ -508,6 +466,10 @@ bool ShenandoahHeapRegion::oop_fill_and_coalesce() {
 
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   ShenandoahMarkingContext* marking_context = heap->marking_context();
+
+  // Expect marking to be completed before these threads invoke this service.
+  assert(heap->active_generation()->is_mark_complete(), "sanity");
+
   // All objects above TAMS are considered live even though their mark bits will not be set.  Note that young-
   // gen evacuations that interrupt a long-running old-gen concurrent mark may promote objects into old-gen
   // while the old-gen concurrent marking is ongoing.  These newly promoted objects will reside above TAMS
@@ -515,8 +477,8 @@ bool ShenandoahHeapRegion::oop_fill_and_coalesce() {
   // explicitly marked.
   HeapWord* t = marking_context->top_at_mark_start(this);
 
-  // Expect marking to be completed before these threads invoke this service.
-  assert(heap->active_generation()->is_mark_complete(), "sanity");
+  // Resume coalesce and fill from this address
+  HeapWord* obj_addr = resume_coalesce_and_fill();
 
   size_t ops_before_preempt_check = preemption_stride;
   while (obj_addr < t) {
@@ -534,7 +496,7 @@ bool ShenandoahHeapRegion::oop_fill_and_coalesce() {
       heap->card_scan()->coalesce_objects(obj_addr, fill_size);
       obj_addr = next_marked_obj;
     }
-    if (ops_before_preempt_check-- == 0) {
+    if (cancellable && ops_before_preempt_check-- == 0) {
       if (heap->cancelled_gc()) {
         suspend_coalesce_and_fill(obj_addr);
         return false;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -402,10 +402,7 @@ public:
   // Coalesce contiguous spans of garbage objects by filling header and reregistering start locations with remembered set.
   // This is used by old-gen GC following concurrent marking to make old-gen HeapRegions parsable.  Return true iff
   // region is completely coalesced and filled.  Returns false if cancelled before task is complete.
-  bool oop_fill_and_coalesce();
-
-  // Like oop_fill_and_coalesce(), but without honoring cancellation requests.
-  bool oop_fill_and_coalesce_without_cancel();
+  bool oop_coalesce_and_fill(bool cancellable);
 
   // Invoke closure on every reference contained within the humongous object that spans this humongous
   // region if the reference is contained within a DIRTY card and the reference is no more than words following

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -110,6 +110,7 @@ bool ShenandoahPhaseTimings::is_worker_phase(Phase phase) {
     case full_gc_weakrefs:
     case full_gc_purge_class_unload:
     case full_gc_purge_weak_par:
+    case degen_gc_coalesce_and_fill:
     case degen_gc_weakrefs:
     case degen_gc_purge_class_unload:
     case degen_gc_purge_weak_par:
@@ -120,6 +121,7 @@ bool ShenandoahPhaseTimings::is_worker_phase(Phase phase) {
     case conc_weak_roots_work:
     case conc_weak_refs:
     case conc_strong_roots:
+    case conc_coalesce_and_fill:
       return true;
     default:
       return false;

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -102,8 +102,6 @@ class outputStream;
   f(conc_class_unload_purge_ec,                     "    Exception Caches")            \
   f(conc_strong_roots,                              "Concurrent Strong Roots")         \
   SHENANDOAH_PAR_PHASE_DO(conc_strong_roots_,       "  CSR: ", f)                      \
-  f(coalesce_and_fill,                              "Coalesce and Fill Old Dead")      \
-  SHENANDOAH_PAR_PHASE_DO(coalesce_and_fill_,       "  CFOD: ", f)                     \
   f(conc_evac,                                      "Concurrent Evacuation")           \
                                                                                        \
   f(final_roots_gross,                              "Pause Final Roots (G)")           \
@@ -124,6 +122,8 @@ class outputStream;
   f(final_update_refs_rebuild_freeset,              "  Rebuild Free Set")              \
                                                                                        \
   f(conc_cleanup_complete,                          "Concurrent Cleanup")              \
+  f(conc_coalesce_and_fill,                         "Concurrent Coalesce and Fill")    \
+  SHENANDOAH_PAR_PHASE_DO(conc_coalesce_,           "  CC&F: ", f)                     \
                                                                                        \
   f(degen_gc_gross,                                 "Pause Degenerated GC (G)")        \
   f(degen_gc,                                       "Pause Degenerated GC (N)")        \
@@ -153,6 +153,8 @@ class outputStream;
   f(degen_gc_update_roots,                          "  Degen Update Roots")            \
   SHENANDOAH_PAR_PHASE_DO(degen_gc_update_,         "    DU: ", f)                     \
   f(degen_gc_cleanup_complete,                      "  Cleanup")                       \
+  f(degen_gc_coalesce_and_fill,                     "  Degen Coalesce and Fill")       \
+  SHENANDOAH_PAR_PHASE_DO(degen_coalesce_,          "    DC&F", f)                     \
                                                                                        \
   f(full_gc_gross,                                  "Pause Full GC (G)")               \
   f(full_gc,                                        "Pause Full GC (N)")               \

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -551,6 +551,7 @@ template <typename ClosureType>
 void ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, size_t count, HeapWord* end_of_range,
                                                                ClosureType* cl, bool use_write_table, uint worker_id) {
 
+  assert(ShenandoahHeap::heap()->old_generation()->is_parseable(), "Old generation regions must be parseable for remembered set scan");
   // If old-gen evacuation is active, then MarkingContext for old-gen heap regions is valid.  We use the MarkingContext
   // bits to determine which objects within a DIRTY card need to be scanned.  This is necessary because old-gen heap
   // regions that are in the candidate collection set have not been coalesced and filled.  Thus, these heap regions


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330414](https://bugs.openjdk.org/browse/JDK-8330414): GenShen: Class unloading requires old regions be made parseable (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/40.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/40.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/40#issuecomment-2083660181)