### PR TITLE
8328307: GenShen: Re-enable old-has-grown trigger for old-generation GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -57,8 +57,10 @@ int ShenandoahOldHeuristics::compare_by_index(RegionData a, RegionData b) {
   }
 }
 
-ShenandoahOldHeuristics::ShenandoahOldHeuristics(ShenandoahOldGeneration* generation) :
+ShenandoahOldHeuristics::ShenandoahOldHeuristics(ShenandoahOldGeneration* generation, ShenandoahGenerationalHeap* gen_heap) :
   ShenandoahHeuristics(generation),
+  _heap(gen_heap),
+  _old_gen(generation),
   _first_pinned_candidate(NOT_FOUND),
   _last_old_collection_candidate(0),
   _next_old_collection_candidate(0),
@@ -549,7 +551,63 @@ void ShenandoahOldHeuristics::clear_triggers() {
   _cannot_expand_trigger = false;
   _fragmentation_trigger = false;
   _growth_trigger = false;
- }
+}
+
+void ShenandoahOldHeuristics::trigger_collection_if_fragmented(size_t first_old_region, size_t last_old_region, size_t old_region_count, size_t num_regions) {
+  if (ShenandoahGenerationalHumongousReserve > 0) {
+    size_t old_region_span = (first_old_region <= last_old_region)? (last_old_region + 1 - first_old_region): 0;
+    size_t allowed_old_gen_span = num_regions - (ShenandoahGenerationalHumongousReserve * num_regions) / 100;
+
+    // Tolerate lower density if total span is small.  Here's the implementation:
+    //   if old_gen spans more than 100% and density < 75%, trigger old-defrag
+    //   else if old_gen spans more than 87.5% and density < 62.5%, trigger old-defrag
+    //   else if old_gen spans more than 75% and density < 50%, trigger old-defrag
+    //   else if old_gen spans more than 62.5% and density < 37.5%, trigger old-defrag
+    //   else if old_gen spans more than 50% and density < 25%, trigger old-defrag
+    //
+    // A previous implementation was more aggressive in triggering, resulting in degraded throughput when
+    // humongous allocation was not required.
+
+    size_t old_available = _old_gen->available();
+    size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
+    size_t old_unaffiliated_available = _old_gen->free_unaffiliated_regions() * region_size_bytes;
+    assert(old_available >= old_unaffiliated_available, "sanity");
+    size_t old_fragmented_available = old_available - old_unaffiliated_available;
+
+    size_t old_bytes_consumed = old_region_count * region_size_bytes - old_fragmented_available;
+    size_t old_bytes_spanned = old_region_span * region_size_bytes;
+    double old_density = ((double) old_bytes_consumed) / old_bytes_spanned;
+
+    uint eighths = 8;
+    for (uint i = 0; i < 5; i++) {
+      size_t span_threshold = eighths * allowed_old_gen_span / 8;
+      double density_threshold = (eighths - 2) / 8.0;
+      if ((old_region_span >= span_threshold) && (old_density < density_threshold)) {
+        trigger_old_is_fragmented(old_density, first_old_region, last_old_region);
+        return;
+      }
+      eighths--;
+    }
+  }
+}
+
+void ShenandoahOldHeuristics::trigger_collection_if_overgrown() {
+  size_t old_used = _old_gen->used() + _old_gen->get_humongous_waste();
+  size_t trigger_threshold = _old_gen->usage_trigger_threshold();
+  // Detects unsigned arithmetic underflow
+  assert(old_used <= _heap->capacity(),
+         "Old used (" SIZE_FORMAT ", " SIZE_FORMAT") must not be more than heap capacity (" SIZE_FORMAT ")",
+         _old_gen->used(), _old_gen->get_humongous_waste(), _heap->capacity());
+  if (old_used > trigger_threshold) {
+    trigger_old_has_grown();
+  }
+}
+
+void ShenandoahOldHeuristics::trigger_maybe(size_t first_old_region, size_t last_old_region,
+                                            size_t old_region_count, size_t num_regions) {
+  trigger_collection_if_fragmented(first_old_region, last_old_region, old_region_count, num_regions);
+  trigger_collection_if_overgrown();
+}
 
 bool ShenandoahOldHeuristics::should_start_gc() {
   // Cannot start a new old-gen GC until previous one has finished.
@@ -595,7 +653,7 @@ bool ShenandoahOldHeuristics::should_start_gc() {
   if (_growth_trigger) {
     // Growth may be falsely triggered during mixed evacuations, before the mixed-evacuation candidates have been
     // evacuated.  Before acting on a false trigger, we check to confirm the trigger condition is still satisfied.
-    const size_t current_usage = _old_generation->used();
+    const size_t current_usage = _old_generation->used() + _old_generation->get_humongous_waste();
     const size_t trigger_threshold = _old_generation->usage_trigger_threshold();
     const size_t heap_size = heap->capacity();
     const size_t ignore_threshold = (ShenandoahIgnoreOldGrowthBelowPercentage * heap_size) / 100;
@@ -618,6 +676,7 @@ bool ShenandoahOldHeuristics::should_start_gc() {
                    byte_size_in_proper_unit(current_usage), proper_unit_for_byte_size(current_usage), percent_growth);
       return true;
     } else {
+      // Mixed evacuations have decreased current_usage such that old-growth trigger is no longer relevant.
       _growth_trigger = false;
     }
   }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -27,6 +27,7 @@
 
 
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 
 class ShenandoahCollectionSet;
 class ShenandoahHeapRegion;
@@ -50,6 +51,9 @@ class ShenandoahOldHeuristics : public ShenandoahHeuristics {
 private:
 
   static uint NOT_FOUND;
+
+  ShenandoahGenerationalHeap* _heap;
+  ShenandoahOldGeneration* _old_gen;
 
   // After final marking of the old generation, this heuristic will select
   // a set of candidate regions to be included in subsequent mixed collections.
@@ -109,12 +113,23 @@ private:
 
   static int compare_by_index(RegionData a, RegionData b);
 
+  inline void trigger_old_is_fragmented(double density, size_t first_old_index, size_t last_old_index) {
+    _fragmentation_trigger = true;
+    _fragmentation_density = density;
+    _fragmentation_first_old_region = first_old_index;
+    _fragmentation_last_old_region = last_old_index;
+  }
+  inline void trigger_old_has_grown() { _growth_trigger = true; }
+
+  void trigger_collection_if_fragmented(size_t first_old_region, size_t last_old_region, size_t old_region_count, size_t num_regions);
+  void trigger_collection_if_overgrown();
+
  protected:
   virtual void choose_collection_set_from_regiondata(ShenandoahCollectionSet* set, RegionData* data, size_t data_size,
                                                      size_t free) override;
 
 public:
-  ShenandoahOldHeuristics(ShenandoahOldGeneration* generation);
+  explicit ShenandoahOldHeuristics(ShenandoahOldGeneration* generation, ShenandoahGenerationalHeap* gen_heap);
 
   // Prepare for evacuation of old-gen regions by capturing the mark results of a recently completed concurrent mark pass.
   void prepare_for_old_collections();
@@ -161,14 +176,6 @@ public:
 
   void trigger_cannot_expand() { _cannot_expand_trigger = true; };
 
-  inline void trigger_old_is_fragmented(double density, size_t first_old_index, size_t last_old_index) {
-    _fragmentation_trigger = true;
-    _fragmentation_density = density;
-    _fragmentation_first_old_region = first_old_index;
-    _fragmentation_last_old_region = last_old_index;
-  }
-  void trigger_old_has_grown() { _growth_trigger = true; }
-
   inline void get_fragmentation_trigger_reason_for_log_message(double &density, size_t &first_index, size_t &last_index) {
     density = _fragmentation_density;
     first_index = _fragmentation_first_old_region;
@@ -176,6 +183,8 @@ public:
   }
 
   void clear_triggers();
+
+  void trigger_maybe(size_t first_old_region, size_t last_old_region, size_t old_region_count, size_t num_regions);
 
   void record_cycle_end() override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2820,8 +2820,11 @@ void ShenandoahHeap::rebuild_free_set(bool concurrent) {
   // Rebuild free set based on adjusted generation sizes.
   _free_set->rebuild(young_cset_regions, old_cset_regions);
 
-  if (mode()->is_generational() && (ShenandoahGenerationalHumongousReserve > 0)) {
-    old_generation()->maybe_trigger_collection(first_old_region, last_old_region, old_region_count);
+  if (mode()->is_generational()) {
+    ShenandoahGenerationalHeap* gen_heap = ShenandoahGenerationalHeap::heap();
+    ShenandoahOldGeneration* old_gen = gen_heap->old_generation();
+    ShenandoahOldHeuristics* old_heuristics = old_gen->heuristics();
+    old_heuristics->trigger_maybe(first_old_region, last_old_region, old_region_count, num_regions());
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -225,10 +225,16 @@ size_t ShenandoahOldGeneration::get_live_bytes_after_last_mark() const {
 }
 
 void ShenandoahOldGeneration::set_live_bytes_after_last_mark(size_t bytes) {
-  _live_bytes_after_last_mark = bytes;
-  _growth_before_compaction /= 2;
-  if (_growth_before_compaction < _min_growth_before_compaction) {
-    _growth_before_compaction = _min_growth_before_compaction;
+  if (bytes == 0) {
+    // Restart search for best old-gen size to the initial state
+    _live_bytes_after_last_mark = ShenandoahHeap::heap()->capacity() * INITIAL_LIVE_FRACTION / FRACTIONAL_DENOMINATOR;
+    _growth_before_compaction = INITIAL_GROWTH_BEFORE_COMPACTION;
+  } else {
+    _live_bytes_after_last_mark = bytes;
+    _growth_before_compaction /= 2;
+    if (_growth_before_compaction < _min_growth_before_compaction) {
+      _growth_before_compaction = _min_growth_before_compaction;
+    }
   }
 }
 
@@ -503,7 +509,7 @@ bool ShenandoahOldGeneration::validate_waiting_for_bootstrap() {
 #endif
 
 ShenandoahHeuristics* ShenandoahOldGeneration::initialize_heuristics(ShenandoahMode* gc_mode) {
-  _old_heuristics = new ShenandoahOldHeuristics(this);
+  _old_heuristics = new ShenandoahOldHeuristics(this, ShenandoahGenerationalHeap::heap());
   _old_heuristics->set_guaranteed_gc_interval(ShenandoahGuaranteedOldGCInterval);
   _heuristics = _old_heuristics;
   return _heuristics;
@@ -596,54 +602,6 @@ void ShenandoahOldGeneration::prepare_for_mixed_collections_after_global_gc() {
   log_info(gc)("After choosing global collection set, mixed candidates: " UINT32_FORMAT ", coalescing candidates: " SIZE_FORMAT,
                _old_heuristics->unprocessed_old_collection_candidates(),
                _old_heuristics->coalesce_and_fill_candidates_count());
-}
-
-void ShenandoahOldGeneration::maybe_trigger_collection(size_t first_old_region, size_t last_old_region, size_t old_region_count) {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  const size_t old_region_span = (first_old_region <= last_old_region)? (last_old_region + 1 - first_old_region): 0;
-  const size_t allowed_old_gen_span = heap->num_regions() - (ShenandoahGenerationalHumongousReserve * heap->num_regions() / 100);
-
-  // Tolerate lower density if total span is small.  Here's the implementation:
-  //   if old_gen spans more than 100% and density < 75%, trigger old-defrag
-  //   else if old_gen spans more than 87.5% and density < 62.5%, trigger old-defrag
-  //   else if old_gen spans more than 75% and density < 50%, trigger old-defrag
-  //   else if old_gen spans more than 62.5% and density < 37.5%, trigger old-defrag
-  //   else if old_gen spans more than 50% and density < 25%, trigger old-defrag
-  //
-  // A previous implementation was more aggressive in triggering, resulting in degraded throughput when
-  // humongous allocation was not required.
-
-  const size_t old_available = available();
-  const size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
-  const size_t old_unaffiliated_available = free_unaffiliated_regions() * region_size_bytes;
-  assert(old_available >= old_unaffiliated_available, "sanity");
-  const size_t old_fragmented_available = old_available - old_unaffiliated_available;
-
-  const size_t old_bytes_consumed = old_region_count * region_size_bytes - old_fragmented_available;
-  const size_t old_bytes_spanned = old_region_span * region_size_bytes;
-  const double old_density = ((double) old_bytes_consumed) / old_bytes_spanned;
-
-  uint eighths = 8;
-  for (uint i = 0; i < 5; i++) {
-    size_t span_threshold = eighths * allowed_old_gen_span / 8;
-    double density_threshold = (eighths - 2) / 8.0;
-    if ((old_region_span >= span_threshold) && (old_density < density_threshold)) {
-      heuristics()->trigger_old_is_fragmented(old_density, first_old_region, last_old_region);
-      break;
-    }
-    eighths--;
-  }
-
-  const size_t old_used = used() + get_humongous_waste();
-  const size_t trigger_threshold = usage_trigger_threshold();
-  // Detects unsigned arithmetic underflow
-  assert(old_used <= heap->free_set()->capacity(),
-         "Old used (" SIZE_FORMAT ", " SIZE_FORMAT") must not be more than heap capacity (" SIZE_FORMAT ")",
-         used(), get_humongous_waste(), heap->free_set()->capacity());
-
-  if (old_used > trigger_threshold) {
-    heuristics()->trigger_old_has_grown();
-  }
 }
 
 void ShenandoahOldGeneration::parallel_region_iterate_free(ShenandoahHeapRegionClosure* cl) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
 
 class ShenandoahHeapRegion;
@@ -199,7 +200,6 @@ public:
   // Abandon any regions waiting for mixed collections
   void abandon_collection_candidates();
 
-  void maybe_trigger_collection(size_t first_old_region, size_t last_old_region, size_t old_region_count);
 public:
   enum State {
     FILLING, WAITING_FOR_BOOTSTRAP, BOOTSTRAPPING, MARKING, EVACUATING
@@ -212,7 +212,7 @@ public:
 private:
   State _state;
 
-  static const size_t FRACTIONAL_DENOMINATOR = 64536;
+  static const size_t FRACTIONAL_DENOMINATOR = 65536;
 
   // During initialization of the JVM, we search for the correct old-gen size by initially performing old-gen
   // collection when old-gen usage is 50% more (INITIAL_GROWTH_BEFORE_COMPACTION) than the initial old-gen size

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Test that growth of old-gen triggers old-gen marking
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @run driver TestOldGrowthTriggers
+ */
+
+import java.util.*;
+import java.math.BigInteger;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestOldGrowthTriggers {
+
+  public static void makeOldAllocations() {
+    // Expect most of the BigInteger entries placed into array to be promoted, and most will eventually become garbage within old
+
+    final int array_size = 512 * 1024;   // 512K entries
+    BigInteger array[] = new BigInteger[array_size];
+    Random r = new Random(46);
+
+    for (int i = 0; i < array_size; i++) {
+      array[i] = new BigInteger(128, r);
+    }
+
+    for (int refill_count = 0; refill_count < 192; refill_count++) {
+      // Each refill repopulates array_size randomly selected elements within array
+      for (int i = 0; i < array_size; i++) {
+        int replace_index = r.nextInt(array_size);
+        int derive_index = r.nextInt(array_size);
+        switch (i & 0x3) {
+          case 0:
+            // 50% chance of creating garbage
+            array[replace_index] = array[replace_index].max(array[derive_index]);
+            break;
+          case 1:
+            // 50% chance of creating garbage
+            array[replace_index] = array[replace_index].min(array[derive_index]);
+            break;
+          case 2:
+            // creates new old BigInteger, releases old BigInteger,
+            // may create ephemeral data while computing gcd
+            array[replace_index] = array[replace_index].gcd(array[derive_index]);
+            break;
+          case 3:
+            // creates new old BigInteger, releases old BigInteger
+            array[replace_index] = array[replace_index].multiply(array[derive_index]);
+            break;
+        }
+        if ((i & 0x3) == 0x3) {
+        } else {
+        }
+      }
+    }
+  }
+
+  public static void testOld(String... args) throws Exception {
+    String[] cmds = Arrays.copyOf(args, args.length + 2);
+    cmds[args.length] = TestOldGrowthTriggers.class.getName();
+    cmds[args.length + 1] = "test";
+    ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(cmds);
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldHaveExitValue(0);
+    if (!output.getOutput().contains("Trigger (OLD): Old has overgrown")) {
+      throw new AssertionError("Generational mode: Should experience OLD triggers due to growth");
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    if (args.length > 0 && args[0].equals("test")) {
+      makeOldAllocations();
+      return;
+    }
+
+    testOld("-Xlog:gc",
+            "-Xms256m",
+            "-Xmx256m",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+UseShenandoahGC",
+            "-XX:ShenandoahGCMode=generational",
+            "-XX:ShenandoahGuaranteedYoungGCInterval=0",
+            "-XX:ShenandoahGuaranteedOldGCInterval=0"
+            );
+  }
+}


### PR DESCRIPTION
Reviewed-by: wkemper, ysr

This pull request contains a backport of commit bfb798a6 from the openjdk/shenandoah repository.

The commit being backported was authored by Kelvin Nilsen on 29 Apr 2024 and was reviewed by William Kemper and
Y. Srinivas Ramakrishna.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8328307](https://bugs.openjdk.org/browse/JDK-8328307): GenShen: Re-enable old-has-grown trigger for old-generation GC (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/41.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/41.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/41#issuecomment-2084030543)