### PR TITLE
8331609: GenShen: Refactor generational mode allocations

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -801,9 +801,11 @@ ShenandoahGeneration::ShenandoahGeneration(ShenandoahGenerationType type,
   _type(type),
   _task_queues(new ShenandoahObjToScanQueueSet(max_workers)),
   _ref_processor(new ShenandoahReferenceProcessor(MAX2(max_workers, 1U))),
-  _affiliated_region_count(0), _humongous_waste(0), _used(0), _bytes_allocated_since_gc_start(0),
+  _affiliated_region_count(0), _humongous_waste(0), _evacuation_reserve(0),
+  _used(0), _bytes_allocated_since_gc_start(0),
   _max_capacity(max_capacity), _soft_max_capacity(soft_max_capacity),
-  _heuristics(nullptr) {
+  _heuristics(nullptr)
+{
   _is_marking_complete.set();
   assert(max_workers > 0, "At least one queue");
   for (uint i = 0; i < max_workers; ++i) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1108,189 +1108,47 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
 }
 
 HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req, bool& in_new_region) {
-  bool try_smaller_lab_size = false;
-  size_t smaller_lab_size;
-  {
-    // promotion_eligible pertains only to PLAB allocations, denoting that the PLAB is allowed to allocate for promotions.
-    bool promotion_eligible = false;
-    bool allow_allocation = true;
-    bool plab_alloc = false;
-    size_t requested_bytes = req.size() * HeapWordSize;
-    HeapWord* result = nullptr;
+  // If we are dealing with mutator allocation, then we may need to block for safepoint.
+  // We cannot block for safepoint for GC allocations, because there is a high chance
+  // we are already running at safepoint or from stack watermark machinery, and we cannot
+  // block again.
+  ShenandoahHeapLocker locker(lock(), req.is_mutator_alloc());
 
-    // If we are dealing with mutator allocation, then we may need to block for safepoint.
-    // We cannot block for safepoint for GC allocations, because there is a high chance
-    // we are already running at safepoint or from stack watermark machinery, and we cannot
-    // block again.
-    ShenandoahHeapLocker locker(lock(), req.is_mutator_alloc());
-    Thread* thread = Thread::current();
-
-    if (mode()->is_generational()) {
-      if (req.affiliation() == YOUNG_GENERATION) {
-        if (req.is_mutator_alloc()) {
-          size_t young_words_available = young_generation()->available() / HeapWordSize;
-          if (req.is_lab_alloc() && (req.min_size() < young_words_available)) {
-            // Allow ourselves to try a smaller lab size even if requested_bytes <= young_available.  We may need a smaller
-            // lab size because young memory has become too fragmented.
-            try_smaller_lab_size = true;
-            smaller_lab_size = (young_words_available < req.size())? young_words_available: req.size();
-          } else if (req.size() > young_words_available) {
-            // Can't allocate because even min_size() is larger than remaining young_available
-            log_info(gc, ergo)("Unable to shrink %s alloc request of minimum size: " SIZE_FORMAT
-                               ", young words available: " SIZE_FORMAT, req.type_string(),
-                               HeapWordSize * (req.is_lab_alloc()? req.min_size(): req.size()), young_words_available);
-            return nullptr;
-          }
-        }
-      } else {                    // reg.affiliation() == OLD_GENERATION
-        assert(req.type() != ShenandoahAllocRequest::_alloc_gclab, "GCLAB pertains only to young-gen memory");
-        if (req.type() ==  ShenandoahAllocRequest::_alloc_plab) {
-          plab_alloc = true;
-          size_t promotion_avail = old_generation()->get_promoted_reserve();
-          size_t promotion_expended = old_generation()->get_promoted_expended();
-          if (promotion_expended + requested_bytes > promotion_avail) {
-            promotion_avail = 0;
-            if (old_generation()->get_evacuation_reserve() == 0) {
-              // There are no old-gen evacuations in this pass.  There's no value in creating a plab that cannot
-              // be used for promotions.
-              allow_allocation = false;
-            }
-          } else {
-            promotion_avail = promotion_avail - (promotion_expended + requested_bytes);
-            promotion_eligible = true;
-          }
-        } else if (req.is_promotion()) {
-          // This is a shared alloc for promotion
-          size_t promotion_avail = old_generation()->get_promoted_reserve();
-          size_t promotion_expended = old_generation()->get_promoted_expended();
-          if (promotion_expended + requested_bytes > promotion_avail) {
-            promotion_avail = 0;
-          } else {
-            promotion_avail = promotion_avail - (promotion_expended + requested_bytes);
-          }
-          if (promotion_avail == 0) {
-            // We need to reserve the remaining memory for evacuation.  Reject this allocation.  The object will be
-            // evacuated to young-gen memory and promoted during a future GC pass.
-            return nullptr;
-          }
-          // Else, we'll allow the allocation to proceed.  (Since we hold heap lock, the tested condition remains true.)
-        } else {
-          // This is a shared allocation for evacuation.  Memory has already been reserved for this purpose.
-        }
-      }
-    } // This ends the is_generational() block
-
-    // First try the original request.  If TLAB request size is greater than available, allocate() will attempt to downsize
-    // request to fit within available memory.
-    result = (allow_allocation)? _free_set->allocate(req, in_new_region): nullptr;
-    if (result != nullptr) {
-      if (req.is_old()) {
-        ShenandoahThreadLocalData::reset_plab_promoted(thread);
-        if (req.is_gc_alloc()) {
-          bool disable_plab_promotions = false;
-          if (req.type() ==  ShenandoahAllocRequest::_alloc_plab) {
-            if (promotion_eligible) {
-              size_t actual_size = req.actual_size() * HeapWordSize;
-              // The actual size of the allocation may be larger than the requested bytes (due to alignment on card boundaries).
-              // If this puts us over our promotion budget, we need to disable future PLAB promotions for this thread.
-              if (old_generation()->get_promoted_expended() + actual_size <= old_generation()->get_promoted_reserve()) {
-                // Assume the entirety of this PLAB will be used for promotion.  This prevents promotion from overreach.
-                // When we retire this plab, we'll unexpend what we don't really use.
-                ShenandoahThreadLocalData::enable_plab_promotions(thread);
-                old_generation()->expend_promoted(actual_size);
-                ShenandoahThreadLocalData::set_plab_preallocated_promoted(thread, actual_size);
-              } else {
-                disable_plab_promotions = true;
-              }
-            } else {
-              disable_plab_promotions = true;
-            }
-            if (disable_plab_promotions) {
-              // Disable promotions in this thread because entirety of this PLAB must be available to hold old-gen evacuations.
-              ShenandoahThreadLocalData::disable_plab_promotions(thread);
-              ShenandoahThreadLocalData::set_plab_preallocated_promoted(thread, 0);
-            }
-          } else if (req.is_promotion()) {
-            // Shared promotion.  Assume size is requested_bytes.
-            old_generation()->expend_promoted(requested_bytes);
-          }
-        }
-
-        // Register the newly allocated object while we're holding the global lock since there's no synchronization
-        // built in to the implementation of register_object().  There are potential races when multiple independent
-        // threads are allocating objects, some of which might span the same card region.  For example, consider
-        // a card table's memory region within which three objects are being allocated by three different threads:
-        //
-        // objects being "concurrently" allocated:
-        //    [-----a------][-----b-----][--------------c------------------]
-        //            [---- card table memory range --------------]
-        //
-        // Before any objects are allocated, this card's memory range holds no objects.  Note that allocation of object a
-        //   wants to set the starts-object, first-start, and last-start attributes of the preceding card region.
-        //   allocation of object b wants to set the starts-object, first-start, and last-start attributes of this card region.
-        //   allocation of object c also wants to set the starts-object, first-start, and last-start attributes of this
-        //   card region.
-        //
-        // The thread allocating b and the thread allocating c can "race" in various ways, resulting in confusion, such as
-        // last-start representing object b while first-start represents object c.  This is why we need to require all
-        // register_object() invocations to be "mutually exclusive" with respect to each card's memory range.
-        card_scan()->register_object(result);
-      }
-    } else {
-      // The allocation failed.  If this was a plab allocation, We've already retired it and no longer have a plab.
-      if (req.is_old() && req.is_gc_alloc() && (req.type() == ShenandoahAllocRequest::_alloc_plab)) {
-        // We don't need to disable PLAB promotions because there is no PLAB.  We leave promotions enabled because
-        // this allows the surrounding infrastructure to retry alloc_plab_slow() with a smaller PLAB size.
-        ShenandoahThreadLocalData::set_plab_preallocated_promoted(thread, 0);
-      }
-    }
-    if ((result != nullptr) || !try_smaller_lab_size) {
-      return result;
-    }
-    // else, fall through to try_smaller_lab_size
-  } // This closes the block that holds the heap lock, releasing the lock.
-
-  // We failed to allocate the originally requested lab size.  Let's see if we can allocate a smaller lab size.
-  if (req.size() == smaller_lab_size) {
-    // If we were already trying to allocate min size, no value in attempting to repeat the same.  End the recursion.
+  // Make sure the old generation has room for either evacuations or promotions before trying to allocate.
+  if (req.is_old() && !old_generation()->can_allocate(req)) {
     return nullptr;
   }
 
-  // We arrive here if the tlab allocation request can be resized to fit within young_available
-  assert((req.affiliation() == YOUNG_GENERATION) && req.is_lab_alloc() && req.is_mutator_alloc() &&
-         (smaller_lab_size < req.size()), "Only shrink allocation request size for TLAB allocations");
+  // If TLAB request size is greater than available, allocate() will attempt to downsize request to fit within available
+  // memory.
+  HeapWord* result = _free_set->allocate(req, in_new_region);
 
-  // By convention, ShenandoahAllocationRequest is primarily read-only.  The only mutable instance data is represented by
-  // actual_size(), which is overwritten with the size of the allocaion when the allocation request is satisfied.  We use a
-  // recursive call here rather than introducing new methods to mutate the existing ShenandoahAllocationRequest argument.
-  // Mutation of the existing object might result in astonishing results if calling contexts assume the content of immutable
-  // fields remain constant.  The original TLAB allocation request was for memory that exceeded the current capacity.  We'll
-  // attempt to allocate a smaller TLAB.  If this is successful, we'll update actual_size() of our incoming
-  // ShenandoahAllocRequest.  If the recursive request fails, we'll simply return nullptr.
-
-  // Note that we've relinquished the HeapLock and some other thread may perform additional allocation before our recursive
-  // call reacquires the lock.  If that happens, we will need another recursive call to further reduce the size of our request
-  // for each time another thread allocates young memory during the brief intervals that the heap lock is available to
-  // interfering threads.  We expect this interference to be rare.  The recursion bottoms out when young_available is
-  // smaller than req.min_size().  The inner-nested call to allocate_memory_under_lock() uses the same min_size() value
-  // as this call, but it uses a preferred size() that is smaller than our preferred size, and is no larger than what we most
-  // recently saw as the memory currently available within the young generation.
-
-  // TODO: At the expense of code clarity, we could rewrite this recursive solution to use iteration.  We need at most one
-  // extra instance of the ShenandoahAllocRequest, which we can re-initialize multiple times inside a loop, with one iteration
-  // of the loop required for each time the existing solution would recurse.  An iterative solution would be more efficient
-  // in CPU time and stack memory utilization.  The expectation is that it is very rare that we would recurse more than once
-  // so making this change is not currently seen as a high priority.
-
-  ShenandoahAllocRequest smaller_req = ShenandoahAllocRequest::for_tlab(req.min_size(), smaller_lab_size);
-
-  // Note that shrinking the preferred size gets us past the gatekeeper that checks whether there's available memory to
-  // satisfy the allocation request.  The reality is the actual TLAB size is likely to be even smaller, because it will
-  // depend on how much memory is available within mutator regions that are not yet fully used.
-  HeapWord* result = allocate_memory_under_lock(smaller_req, in_new_region);
-  if (result != nullptr) {
-    req.set_actual_size(smaller_req.actual_size());
+  // Record the plab configuration for this result and register the object.
+  if (result != nullptr && req.is_old()) {
+    old_generation()->configure_plab_for_current_thread(req);
+    if (req.type() == ShenandoahAllocRequest::_alloc_shared_gc) {
+      // Register the newly allocated object while we're holding the global lock since there's no synchronization
+      // built in to the implementation of register_object().  There are potential races when multiple independent
+      // threads are allocating objects, some of which might span the same card region.  For example, consider
+      // a card table's memory region within which three objects are being allocated by three different threads:
+      //
+      // objects being "concurrently" allocated:
+      //    [-----a------][-----b-----][--------------c------------------]
+      //            [---- card table memory range --------------]
+      //
+      // Before any objects are allocated, this card's memory range holds no objects.  Note that allocation of object a
+      // wants to set the starts-object, first-start, and last-start attributes of the preceding card region.
+      // Allocation of object b wants to set the starts-object, first-start, and last-start attributes of this card region.
+      // Allocation of object c also wants to set the starts-object, first-start, and last-start attributes of this
+      // card region.
+      //
+      // The thread allocating b and the thread allocating c can "race" in various ways, resulting in confusion, such as
+      // last-start representing object b while first-start represents object c.  This is why we need to require all
+      // register_object() invocations to be "mutually exclusive" with respect to each card's memory range.
+      card_scan()->register_object(result);
+    }
   }
+
   return result;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -218,8 +218,65 @@ size_t ShenandoahOldGeneration::unexpend_promoted(size_t decrement) {
   return Atomic::sub(&_promoted_expended, decrement);
 }
 
-size_t ShenandoahOldGeneration::get_promoted_expended() {
+size_t ShenandoahOldGeneration::get_promoted_expended() const {
   return Atomic::load(&_promoted_expended);
+}
+
+bool ShenandoahOldGeneration::can_allocate(const ShenandoahAllocRequest &req) const {
+  assert(req.type() != ShenandoahAllocRequest::_alloc_gclab, "GCLAB pertains only to young-gen memory");
+
+  const size_t requested_bytes = req.size() * HeapWordSize;
+  // The promotion reserve may also be used for evacuations. If we can promote this object,
+  // then we can also evacuate it.
+  if (can_promote(requested_bytes)) {
+    // The promotion reserve should be able to accommodate this request. The request
+    // might still fail if alignment with the card table increases the size. The request
+    // may also fail if the heap is badly fragmented and the free set cannot find room for it.
+    return true;
+  }
+
+  if (req.type() == ShenandoahAllocRequest::_alloc_plab) {
+    // The promotion reserve cannot accommodate this plab request. Check if we still have room for
+    // evacuations. Note that we cannot really know how much of the plab will be used for evacuations,
+    // so here we only check that some evacuation reserve still exists.
+    return get_evacuation_reserve() > 0;
+  }
+
+  // This is a shared allocation request. We've already checked that it can't be promoted, so if
+  // it is a promotion, we return false. Otherwise, it is a shared evacuation request, and we allow
+  // the allocation to proceed.
+  return !req.is_promotion();
+}
+
+void
+ShenandoahOldGeneration::configure_plab_for_current_thread(const ShenandoahAllocRequest &req) {
+  // Note: Even when a mutator is performing a promotion outside a LAB, we use a 'shared_gc' request.
+  if (req.is_gc_alloc()) {
+    const size_t actual_size = req.actual_size() * HeapWordSize;
+    if (req.type() ==  ShenandoahAllocRequest::_alloc_plab) {
+      // We've created a new plab. Now we configure it whether it will be used for promotions
+      // and evacuations - or just evacuations.
+      Thread* thread = Thread::current();
+      ShenandoahThreadLocalData::reset_plab_promoted(thread);
+
+      // The actual size of the allocation may be larger than the requested bytes (due to alignment on card boundaries).
+      // If this puts us over our promotion budget, we need to disable future PLAB promotions for this thread.
+      if (can_promote(actual_size)) {
+        // Assume the entirety of this PLAB will be used for promotion.  This prevents promotion from overreach.
+        // When we retire this plab, we'll unexpend what we don't really use.
+        expend_promoted(actual_size);
+        ShenandoahThreadLocalData::enable_plab_promotions(thread);
+        ShenandoahThreadLocalData::set_plab_actual_size(thread, actual_size);
+      } else {
+        // Disable promotions in this thread because entirety of this PLAB must be available to hold old-gen evacuations.
+        ShenandoahThreadLocalData::disable_plab_promotions(thread);
+        ShenandoahThreadLocalData::set_plab_actual_size(thread, 0);
+      }
+    } else if (req.is_promotion()) {
+      // Shared promotion.
+      expend_promoted(actual_size);
+    }
+  }
 }
 
 size_t ShenandoahOldGeneration::get_live_bytes_after_last_mark() const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -26,6 +26,7 @@
 #define SHARE_VM_GC_SHENANDOAH_SHENANDOAHOLDGENERATION_HPP
 
 #include "gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp"
+#include "gc/shenandoah/shenandoahAllocRequest.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
 #include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
@@ -112,7 +113,22 @@ public:
   size_t unexpend_promoted(size_t decrement);
 
   // This is used on the allocation path to gate promotions that would exceed the reserve
-  size_t get_promoted_expended();
+  size_t get_promoted_expended() const;
+
+  // Test if there is enough memory reserved for this promotion
+  bool can_promote(size_t requested_bytes) const {
+    size_t promotion_avail = get_promoted_reserve();
+    size_t promotion_expended = get_promoted_expended();
+    return promotion_expended + requested_bytes <= promotion_avail;
+  }
+
+  // Test if there is enough memory available in the old generation to accommodate this request.
+  // The request will be subject to constraints on promotion and evacuation reserves.
+  bool can_allocate(const ShenandoahAllocRequest& req) const;
+
+  // Updates the promotion expenditure tracking and configures whether the plab may be used
+  // for promotions and evacuations, or just evacuations.
+  void configure_plab_for_current_thread(const ShenandoahAllocRequest &req);
 
   // See description in field declaration
   void set_region_balance(ssize_t balance) { _region_balance = balance; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
@@ -40,10 +40,9 @@ ShenandoahThreadLocalData::ShenandoahThreadLocalData() :
   _gclab_size(0),
   _paced_time(0),
   _plab(nullptr),
-  _plab_size(0),
-  _plab_evacuated(0),
+  _plab_desired_size(0),
+  _plab_actual_size(0),
   _plab_promoted(0),
-  _plab_preallocated_promoted(0),
   _plab_allows_promotion(true),
   _plab_retries_enabled(true),
   _evacuation_stats(nullptr) {

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldGeneration.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldGeneration.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "unittest.hpp"
+
+#include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/mode/shenandoahMode.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
+#include "gc/shenandoah/shenandoahThreadLocalData.hpp"
+
+class ShenandoahOldGenerationTest : public ::testing::Test {
+protected:
+  static const size_t INITIAL_PLAB_SIZE;
+  static const size_t INITIAL_PLAB_PROMOTED;
+
+  ShenandoahOldGeneration* old;
+
+  ShenandoahOldGenerationTest()
+    : old(nullptr)
+  {
+  }
+
+  void SetUp() override {
+    if (!(UseShenandoahGC && ShenandoahHeap::heap()->mode()->is_generational())) {
+      GTEST_SKIP() << "Test must be run with -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational";
+      return;
+    }
+
+    ShenandoahHeap::heap()->lock()->lock(false);
+
+    old = new ShenandoahOldGeneration(8, 1024 * 1024, 1024);
+    old->set_promoted_reserve(512 * HeapWordSize);
+    old->expend_promoted(256 * HeapWordSize);
+    old->set_evacuation_reserve(512 * HeapWordSize);
+
+    Thread* thread = Thread::current();
+    ShenandoahThreadLocalData::reset_plab_promoted(thread);
+    ShenandoahThreadLocalData::disable_plab_promotions(thread);
+    ShenandoahThreadLocalData::set_plab_actual_size(thread, INITIAL_PLAB_SIZE);
+    ShenandoahThreadLocalData::add_to_plab_promoted(thread, INITIAL_PLAB_PROMOTED);
+  }
+
+  void TearDown() override {
+    if (UseShenandoahGC) {
+      ShenandoahHeap::heap()->lock()->unlock();
+      delete old;
+    }
+  }
+
+  static bool promotions_enabled() {
+    return ShenandoahThreadLocalData::allow_plab_promotions(Thread::current());
+  }
+
+  static size_t plab_size() {
+    return ShenandoahThreadLocalData::get_plab_actual_size(Thread::current());
+  }
+
+  static size_t plab_promoted() {
+    return ShenandoahThreadLocalData::get_plab_promoted(Thread::current());
+  }
+};
+
+const size_t ShenandoahOldGenerationTest::INITIAL_PLAB_SIZE = 42;
+const size_t ShenandoahOldGenerationTest::INITIAL_PLAB_PROMOTED = 128;
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_can_promote) {
+  EXPECT_TRUE(old->can_promote(128 * HeapWordSize)) << "Should have room to promote";
+  EXPECT_FALSE(old->can_promote(384 * HeapWordSize)) << "Should not have room to promote";
+}
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_can_allocate_plab_for_promotion) {
+  ShenandoahAllocRequest req = ShenandoahAllocRequest::for_plab(128, 128);
+  EXPECT_TRUE(old->can_allocate(req)) << "Should have room to promote";
+}
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_can_allocate_plab_for_evacuation) {
+  ShenandoahAllocRequest req = ShenandoahAllocRequest::for_plab(384, 384);
+  EXPECT_FALSE(old->can_promote(req.size() * HeapWordSize)) << "No room for promotions";
+  EXPECT_TRUE(old->can_allocate(req)) << "Should have room to evacuate";
+}
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_cannot_allocate_plab) {
+  // Simulate having exhausted the evacuation reserve when request is too big to be promoted
+  old->set_evacuation_reserve(0);
+  ShenandoahAllocRequest req = ShenandoahAllocRequest::for_plab(384, 384);
+  EXPECT_FALSE(old->can_allocate(req)) << "No room for promotions or evacuations";
+}
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_can_allocate_for_shared_evacuation) {
+  ShenandoahAllocRequest req = ShenandoahAllocRequest::for_shared_gc(768, ShenandoahAffiliation::OLD_GENERATION, false);
+  EXPECT_FALSE(old->can_promote(req.size() * HeapWordSize)) << "No room for promotion";
+  EXPECT_TRUE(old->can_allocate(req)) << "Should have room to evacuate shared (even though evacuation reserve is smaller than request)";
+}
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_cannot_allocate_for_shared_promotion) {
+  ShenandoahAllocRequest req = ShenandoahAllocRequest::for_shared_gc(768, ShenandoahAffiliation::OLD_GENERATION, true);
+  EXPECT_FALSE(old->can_promote(req.size() * HeapWordSize)) << "No room for promotion";
+  EXPECT_FALSE(old->can_allocate(req)) << "No room to promote, should fall back to evacuation in young gen";
+}
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_expend_promoted) {
+
+  ShenandoahAllocRequest req = ShenandoahAllocRequest::for_plab(128, 128);
+
+  // simulate the allocation
+  req.set_actual_size(128);
+
+  size_t actual_size = req.actual_size() * HeapWordSize;
+  EXPECT_TRUE(old->can_promote(actual_size)) << "Should have room for promotion";
+
+  size_t expended_before = old->get_promoted_expended();
+  old->configure_plab_for_current_thread(req);
+  size_t expended_after = old->get_promoted_expended();
+  EXPECT_EQ(expended_before + actual_size, expended_after) << "Should expend promotion reserve";
+  EXPECT_EQ(plab_promoted(), 0UL) << "Nothing promoted yet";
+  EXPECT_EQ(plab_size(), actual_size) << "New plab should be able to hold this much promotion";
+  EXPECT_TRUE(promotions_enabled()) << "Plab should be available for promotions";
+}
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_actual_size_exceeds_promotion_reserve) {
+  ShenandoahAllocRequest req = ShenandoahAllocRequest::for_plab(128, 128);
+
+  // simulate an allocation that exceeds the promotion reserve after allocation
+  req.set_actual_size(384);
+  EXPECT_FALSE(old->can_promote(req.actual_size() * HeapWordSize)) << "Should have room for promotion";
+
+  size_t expended_before = old->get_promoted_expended();
+  old->configure_plab_for_current_thread(req);
+  size_t expended_after = old->get_promoted_expended();
+
+  EXPECT_EQ(expended_before, expended_after) << "Did not promote, should not expend promotion";
+  EXPECT_EQ(plab_promoted(), 0UL) << "Cannot promote in new plab";
+  EXPECT_EQ(plab_size(), 0UL) << "Should not have space for promotions";
+  EXPECT_FALSE(promotions_enabled()) << "New plab can only be used for evacuations";
+}
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_shared_expends_promoted_but_does_not_change_plab) {
+  ShenandoahAllocRequest req = ShenandoahAllocRequest::for_shared_gc(128, ShenandoahAffiliation::OLD_GENERATION, true);
+  req.set_actual_size(128);
+  size_t actual_size = req.actual_size() * HeapWordSize;
+
+  size_t expended_before = old->get_promoted_expended();
+  old->configure_plab_for_current_thread(req);
+  size_t expended_after = old->get_promoted_expended();
+
+  EXPECT_EQ(expended_before + actual_size, expended_after) << "Shared promotion still expends promotion";
+  EXPECT_EQ(plab_promoted(), INITIAL_PLAB_PROMOTED) << "Shared promotion should not count in plab";
+  EXPECT_EQ(plab_size(), INITIAL_PLAB_SIZE) << "Shared promotion should not change size of plab";
+  EXPECT_FALSE(promotions_enabled());
+}
+
+TEST_VM_F(ShenandoahOldGenerationTest, test_shared_evacuation_has_no_side_effects) {
+  ShenandoahAllocRequest req = ShenandoahAllocRequest::for_shared_gc(128, ShenandoahAffiliation::OLD_GENERATION, false);
+  req.set_actual_size(128);
+
+  size_t expended_before = old->get_promoted_expended();
+  old->configure_plab_for_current_thread(req);
+  size_t expended_after = old->get_promoted_expended();
+
+  EXPECT_EQ(expended_before, expended_after) << "Not a promotion, should not expend promotion reserve";
+  EXPECT_EQ(plab_promoted(), INITIAL_PLAB_PROMOTED) << "Not a plab, should not have touched plab";
+  EXPECT_EQ(plab_size(), INITIAL_PLAB_SIZE) << "Not a plab, should not have touched plab";
+  EXPECT_FALSE(promotions_enabled());
+}


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331609](https://bugs.openjdk.org/browse/JDK-8331609): GenShen: Refactor generational mode allocations (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/46.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/46.diff</a>

</details>
