### PR TITLE
8333109: GenShen: Factor generational mode out of gc helpers (redo)

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -141,16 +141,27 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // Complete marking under STW, and start evacuation
   vmop_entry_final_mark();
 
-  // If GC was cancelled before final mark, then the safepoint operation will do nothing
-  // and the concurrent mark will still be in progress. In this case it is safe to resume
-  // the degenerated cycle from the marking phase. On the other hand, if the GC is cancelled
-  // after final mark (but before this check), then the final mark safepoint operation
-  // will have finished the mark (setting concurrent mark in progress to false). Final mark
-  // will also have setup state (in concurrent stack processing) that will not be safe to
-  // resume from the marking phase in the degenerated cycle. That is, if the cancellation
-  // occurred after final mark, we must resume the degenerated cycle after the marking phase.
-  if (_generation->is_concurrent_mark_in_progress() && check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark)) {
-    assert(!heap->is_concurrent_weak_root_in_progress(), "Weak roots should not be in progress when concurrent mark is in progress");
+  // If the GC was cancelled just before final mark (but after the preceding cancellation check),
+  // then the safepoint operation will do nothing and the concurrent mark will still be in progress.
+  // In this case it is safe (and necessary) to resume the degenerated cycle from the marking phase.
+  //
+  // On the other hand, if the GC is cancelled after final mark (but before this check), then the
+  // final mark safepoint operation will have finished the mark (setting concurrent mark in progress
+  // to false). In this case (final mark has completed), we need control to fall past the next
+  // cancellation check and resume the degenerated cycle from the evacuation phase.
+  if (_generation->is_concurrent_mark_in_progress()) {
+    // If the concurrent mark is still in progress after the final mark safepoint, then the GC has
+    // been cancelled. The degenerated cycle must resume from the marking phase. Without this check,
+    // the non-generational mode may fall all the way to the end of this collect routine without
+    // having done anything (besides mark most of the heap). Without having collected anything, we
+    // can expect an 'out of cycle' degenerated GC which will again mark the entire heap. This is
+    // not optimal.
+    // For the generational mode, we cannot allow this. The generational mode relies on marking
+    // (including the final mark) to rebuild portions of the card table. If the generational mode does
+    // not complete marking after it has swapped the card tables, the root set on subsequent GCs will
+    // be incomplete, heap corruption may follow.
+    bool cancelled = check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark);
+    assert(cancelled, "GC must have been cancelled between concurrent and final mark");
     return false;
   }
 
@@ -231,31 +242,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // We defer generation resizing actions until after cset regions have been recycled.  We do this even following an
   // abbreviated cycle.
   if (heap->mode()->is_generational()) {
-    if (!heap->old_generation()->is_parseable()) {
-      // Class unloading may render the card offsets unusable, so we must rebuild them before
-      // the next remembered set scan. We _could_ let the control thread do this sometime after
-      // the global cycle has completed and before the next young collection, but under memory
-      // pressure the control thread may not have the time (that is, because it's running back
-      // to back GCs). In that scenario, we would have to make the old regions parsable before
-      // we could start a young collection. This could delay the start of the young cycle and
-      // throw off the heuristics.
-      entry_global_coalesce_and_fill();
-    }
-
-    ShenandoahGenerationalHeap::TransferResult result;
-    {
-      ShenandoahGenerationalHeap* gen_heap = ShenandoahGenerationalHeap::heap();
-      ShenandoahHeapLocker locker(gen_heap->lock());
-
-      result = gen_heap->balance_generations();
-      gen_heap->reset_generation_reserves();
-    }
-
-    LogTarget(Info, gc, ergo) lt;
-    if (lt.is_enabled()) {
-      LogStream ls(lt);
-      result.print_on("Concurrent GC", &ls);
-    }
+    ShenandoahGenerationalHeap::heap()->complete_concurrent_cycle();
   }
   return true;
 }
@@ -662,6 +649,7 @@ void ShenandoahConcurrentGC::op_init_mark() {
   start_mark();
 
   if (_do_old_gc_bootstrap) {
+    shenandoah_assert_generational();
     // Update region state for both young and old regions
     // TODO: We should be able to pull this out of the safepoint for the bootstrap
     // cycle. The top of an old region will only move when a GC cycle evacuates
@@ -749,138 +737,100 @@ void ShenandoahConcurrentGC::op_final_mark() {
     // Has to be done after cset selection
     heap->prepare_concurrent_roots();
 
-    if (heap->mode()->is_generational()) {
-      if (!heap->collection_set()->is_empty() || heap->old_generation()->has_in_place_promotions()) {
-        // Even if the collection set is empty, we need to do evacuation if there are regions to be promoted in place.
-        // Concurrent evacuation takes responsibility for registering objects and setting the remembered set cards to dirty.
+    if (!heap->collection_set()->is_empty() || has_in_place_promotions(heap)) {
+      // Even if the collection set is empty, we need to do evacuation if there are regions to be promoted in place.
+      // Concurrent evacuation takes responsibility for registering objects and setting the remembered set cards to dirty.
 
-        LogTarget(Debug, gc, cset) lt;
-        if (lt.is_enabled()) {
-          ResourceMark rm;
-          LogStream ls(lt);
-          heap->collection_set()->print_on(&ls);
-        }
-
-        if (ShenandoahVerify) {
-          heap->verifier()->verify_before_evacuation();
-        }
-
-        heap->set_evacuation_in_progress(true);
-
-        // Verify before arming for concurrent processing.
-        // Otherwise, verification can trigger stack processing.
-        if (ShenandoahVerify) {
-          heap->verifier()->verify_during_evacuation();
-        }
-
-        // Generational mode may promote objects in place during the evacuation phase.
-        // If that is the only reason we are evacuating, we don't need to update references
-        // and there will be no forwarded objects on the heap.
-        heap->set_has_forwarded_objects(!heap->collection_set()->is_empty());
-
-        // Arm nmethods/stack for concurrent processing
-        if (!heap->collection_set()->is_empty()) {
-          // Iff objects will be evaluated, arm the nmethod barriers. These will be disarmed
-          // under the same condition (established in prepare_concurrent_roots) after strong
-          // root evacuation has completed (see op_strong_roots).
-          ShenandoahCodeRoots::arm_nmethods_for_evac();
-          ShenandoahStackWatermark::change_epoch_id();
-        }
-
-        if (ShenandoahPacing) {
-          heap->pacer()->setup_for_evac();
-        }
-      } else {
-        if (ShenandoahVerify) {
-          heap->verifier()->verify_after_concmark();
-        }
-
-        if (VerifyAfterGC) {
-          Universe::verify();
-        }
+      LogTarget(Debug, gc, cset) lt;
+      if (lt.is_enabled()) {
+        ResourceMark rm;
+        LogStream ls(lt);
+        heap->collection_set()->print_on(&ls);
       }
-    } else {
-      // Not is_generational()
+
+      if (ShenandoahVerify) {
+        heap->verifier()->verify_before_evacuation();
+      }
+
+      // TODO: Do we need to set this if we are only promoting regions in place? We don't need the barriers on for that.
+      heap->set_evacuation_in_progress(true);
+
+      // Verify before arming for concurrent processing.
+      // Otherwise, verification can trigger stack processing.
+      if (ShenandoahVerify) {
+        heap->verifier()->verify_during_evacuation();
+      }
+
+      // Generational mode may promote objects in place during the evacuation phase.
+      // If that is the only reason we are evacuating, we don't need to update references
+      // and there will be no forwarded objects on the heap.
+      heap->set_has_forwarded_objects(!heap->collection_set()->is_empty());
+
+      // Arm nmethods/stack for concurrent processing
       if (!heap->collection_set()->is_empty()) {
-        LogTarget(Debug, gc, ergo) lt;
-        if (lt.is_enabled()) {
-          ResourceMark rm;
-          LogStream ls(lt);
-          heap->collection_set()->print_on(&ls);
-        }
-
-        if (ShenandoahVerify) {
-          heap->verifier()->verify_before_evacuation();
-        }
-
-        heap->set_evacuation_in_progress(true);
-
-        // Verify before arming for concurrent processing.
-        // Otherwise, verification can trigger stack processing.
-        if (ShenandoahVerify) {
-          heap->verifier()->verify_during_evacuation();
-        }
-
-        // From here on, we need to update references.
-        heap->set_has_forwarded_objects(true);
-
-        // Arm nmethods/stack for concurrent processing
+        // Iff objects will be evaluated, arm the nmethod barriers. These will be disarmed
+        // under the same condition (established in prepare_concurrent_roots) after strong
+        // root evacuation has completed (see op_strong_roots).
         ShenandoahCodeRoots::arm_nmethods_for_evac();
         ShenandoahStackWatermark::change_epoch_id();
+      }
 
-        if (ShenandoahPacing) {
-          heap->pacer()->setup_for_evac();
-        }
-      } else {
-        if (ShenandoahVerify) {
-          heap->verifier()->verify_after_concmark();
-        }
+      if (ShenandoahPacing) {
+        heap->pacer()->setup_for_evac();
+      }
+    } else {
+      if (ShenandoahVerify) {
+        heap->verifier()->verify_after_concmark();
+      }
 
-        if (VerifyAfterGC) {
-          Universe::verify();
-        }
+      if (VerifyAfterGC) {
+        Universe::verify();
       }
     }
   }
 }
 
+bool ShenandoahConcurrentGC::has_in_place_promotions(ShenandoahHeap* heap) {
+  return heap->mode()->is_generational() && heap->old_generation()->has_in_place_promotions();
+}
+
+template<bool GENERATIONAL>
 class ShenandoahConcurrentEvacThreadClosure : public ThreadClosure {
 private:
   OopClosure* const _oops;
-
 public:
-  ShenandoahConcurrentEvacThreadClosure(OopClosure* oops);
-  void do_thread(Thread* thread);
+  explicit ShenandoahConcurrentEvacThreadClosure(OopClosure* oops) : _oops(oops) {}
+
+  void do_thread(Thread* thread) override {
+    JavaThread* const jt = JavaThread::cast(thread);
+    StackWatermarkSet::finish_processing(jt, _oops, StackWatermarkKind::gc);
+    if (GENERATIONAL) {
+      ShenandoahThreadLocalData::enable_plab_promotions(thread);
+    }
+  }
 };
 
-ShenandoahConcurrentEvacThreadClosure::ShenandoahConcurrentEvacThreadClosure(OopClosure* oops) :
-  _oops(oops) {
-}
-
-void ShenandoahConcurrentEvacThreadClosure::do_thread(Thread* thread) {
-  JavaThread* const jt = JavaThread::cast(thread);
-  StackWatermarkSet::finish_processing(jt, _oops, StackWatermarkKind::gc);
-  ShenandoahThreadLocalData::enable_plab_promotions(thread);
-}
-
+template<bool GENERATIONAL>
 class ShenandoahConcurrentEvacUpdateThreadTask : public WorkerTask {
 private:
   ShenandoahJavaThreadsIterator _java_threads;
 
 public:
-  ShenandoahConcurrentEvacUpdateThreadTask(uint n_workers) :
+  explicit ShenandoahConcurrentEvacUpdateThreadTask(uint n_workers) :
     WorkerTask("Shenandoah Evacuate/Update Concurrent Thread Roots"),
     _java_threads(ShenandoahPhaseTimings::conc_thread_roots, n_workers) {
   }
 
-  void work(uint worker_id) {
-    Thread* worker_thread = Thread::current();
-    ShenandoahThreadLocalData::enable_plab_promotions(worker_thread);
+  void work(uint worker_id) override {
+    if (GENERATIONAL) {
+      Thread* worker_thread = Thread::current();
+      ShenandoahThreadLocalData::enable_plab_promotions(worker_thread);
+    }
 
     // ShenandoahEvacOOMScope has to be setup by ShenandoahContextEvacuateUpdateRootsClosure.
     // Otherwise, may deadlock with watermark lock
     ShenandoahContextEvacuateUpdateRootsClosure oops_cl;
-    ShenandoahConcurrentEvacThreadClosure thr_cl(&oops_cl);
+    ShenandoahConcurrentEvacThreadClosure<GENERATIONAL> thr_cl(&oops_cl);
     _java_threads.threads_do(&thr_cl, worker_id);
   }
 };
@@ -889,8 +839,13 @@ void ShenandoahConcurrentGC::op_thread_roots() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(heap->is_evacuation_in_progress(), "Checked by caller");
   ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_thread_roots);
-  ShenandoahConcurrentEvacUpdateThreadTask task(heap->workers()->active_workers());
-  heap->workers()->run_task(&task);
+  if (heap->mode()->is_generational()) {
+    ShenandoahConcurrentEvacUpdateThreadTask<true> task(heap->workers()->active_workers());
+    heap->workers()->run_task(&task);
+  } else {
+    ShenandoahConcurrentEvacUpdateThreadTask<false> task(heap->workers()->active_workers());
+    heap->workers()->run_task(&task);
+  }
 }
 
 void ShenandoahConcurrentGC::op_weak_refs() {
@@ -1268,39 +1223,8 @@ void ShenandoahConcurrentGC::op_final_roots() {
       heap->old_generation()->transfer_pointers_from_satb();
     }
 
-    ShenandoahMarkingContext *ctx = heap->complete_marking_context();
-    for (size_t i = 0; i < heap->num_regions(); i++) {
-      ShenandoahHeapRegion *r = heap->get_region(i);
-      if (r->is_active() && r->is_young()) {
-        HeapWord* tams = ctx->top_at_mark_start(r);
-        HeapWord* top = r->top();
-        if (top > tams) {
-          r->reset_age();
-        } else if (ShenandoahGenerationalHeap::heap()->is_aging_cycle()) {
-          r->increment_age();
-        }
-      }
-    }
+    ShenandoahGenerationalHeap::heap()->update_region_ages();
   }
-}
-
-void ShenandoahConcurrentGC::entry_global_coalesce_and_fill() {
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
-
-  const char* msg = "Coalescing and filling old regions in global collect";
-  ShenandoahConcurrentPhase gc_phase(msg, ShenandoahPhaseTimings::conc_coalesce_and_fill);
-
-  TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
-  EventMark em("%s", msg);
-  ShenandoahWorkerScope scope(heap->workers(),
-                              ShenandoahWorkerPolicy::calc_workers_for_conc_marking(),
-                              "concurrent coalesce and fill");
-
-  op_global_coalesce_and_fill();
-}
-
-void ShenandoahConcurrentGC::op_global_coalesce_and_fill() {
-  ShenandoahGenerationalHeap::heap()->coalesce_and_fill_old_regions(true);
 }
 
 void ShenandoahConcurrentGC::op_cleanup_complete() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -104,7 +104,7 @@ private:
   void entry_evacuate();
   void entry_update_thread_roots();
   void entry_updaterefs();
-  void entry_global_coalesce_and_fill();
+
   void entry_cleanup_complete();
 
   // Actual work for the phases
@@ -124,7 +124,7 @@ private:
   void op_update_thread_roots();
   void op_final_updaterefs();
   void op_final_roots();
-  void op_global_coalesce_and_fill();
+
   void op_cleanup_complete();
 
 protected:
@@ -132,6 +132,8 @@ protected:
 
 private:
   void start_mark();
+
+  static bool has_in_place_promotions(ShenandoahHeap* heap) ;
 
   // Messages for GC trace events, they have to be immortal for
   // passing around the logging/tracing systems

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -58,9 +58,6 @@ private:
   void op_update_roots();
   void op_cleanup_complete();
 
-  // This will rebuild card offsets, which is necessary if classes were unloaded
-  void op_global_coalesce_and_fill();
-
   // Fail handling
   void op_degenerated_futile();
   void op_degenerated_fail();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -33,14 +33,17 @@
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahInitLogger.hpp"
 #include "gc/shenandoah/shenandoahMemoryPool.hpp"
+#include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "gc/shenandoah/shenandoahRegulatorThread.hpp"
 #include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
+#include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "logging/log.hpp"
+#include "utilities/events.hpp"
 
 
 class ShenandoahGenerationalInitLogger : public ShenandoahInitLogger {
@@ -942,5 +945,88 @@ void ShenandoahGenerationalHeap::update_heap_references(bool concurrent) {
   if (ShenandoahEnableCardStats) { // generational check proxy
     assert(card_scan() != nullptr, "Card table must exist when card stats are enabled");
     card_scan()->log_card_stats(nworkers, CARD_STAT_UPDATE_REFS);
+  }
+}
+
+void ShenandoahGenerationalHeap::complete_degenerated_cycle() {
+  shenandoah_assert_heaplocked_or_safepoint();
+  if (is_concurrent_old_mark_in_progress()) {
+    // This is still necessary for degenerated cycles because the degeneration point may occur
+    // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_updaterefs for
+    // a more detailed explanation.
+    old_generation()->transfer_pointers_from_satb();
+  }
+
+  // We defer generation resizing actions until after cset regions have been recycled.
+  TransferResult result = balance_generations();
+  LogTarget(Info, gc, ergo) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    result.print_on("Degenerated GC", &ls);
+  }
+
+  // In case degeneration interrupted concurrent evacuation or update references, we need to clean up
+  // transient state. Otherwise, these actions have no effect.
+  reset_generation_reserves();
+
+  if (!old_generation()->is_parseable()) {
+    ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_coalesce_and_fill);
+    coalesce_and_fill_old_regions(false);
+  }
+}
+
+void ShenandoahGenerationalHeap::complete_concurrent_cycle() {
+  if (!old_generation()->is_parseable()) {
+    // Class unloading may render the card offsets unusable, so we must rebuild them before
+    // the next remembered set scan. We _could_ let the control thread do this sometime after
+    // the global cycle has completed and before the next young collection, but under memory
+    // pressure the control thread may not have the time (that is, because it's running back
+    // to back GCs). In that scenario, we would have to make the old regions parsable before
+    // we could start a young collection. This could delay the start of the young cycle and
+    // throw off the heuristics.
+    entry_global_coalesce_and_fill();
+  }
+
+  TransferResult result;
+  {
+    ShenandoahHeapLocker locker(lock());
+
+    result = balance_generations();
+    reset_generation_reserves();
+  }
+
+  LogTarget(Info, gc, ergo) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    result.print_on("Concurrent GC", &ls);
+  }
+}
+
+void ShenandoahGenerationalHeap::entry_global_coalesce_and_fill() {
+  const char* msg = "Coalescing and filling old regions";
+  ShenandoahConcurrentPhase gc_phase(msg, ShenandoahPhaseTimings::conc_coalesce_and_fill);
+
+  TraceCollectorStats tcs(monitoring_support()->concurrent_collection_counters());
+  EventMark em("%s", msg);
+  ShenandoahWorkerScope scope(workers(),
+                              ShenandoahWorkerPolicy::calc_workers_for_conc_marking(),
+                              "concurrent coalesce and fill");
+
+  coalesce_and_fill_old_regions(true);
+}
+
+void ShenandoahGenerationalHeap::update_region_ages() {
+  ShenandoahMarkingContext *ctx = complete_marking_context();
+  for (size_t i = 0; i < num_regions(); i++) {
+    ShenandoahHeapRegion *r = get_region(i);
+    if (r->is_active() && r->is_young()) {
+      HeapWord* tams = ctx->top_at_mark_start(r);
+      HeapWord* top = r->top();
+      if (top > tams) {
+        r->reset_age();
+      } else if (is_aging_cycle()) {
+        r->increment_age();
+      }
+    }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -50,6 +50,10 @@ public:
     return _is_aging_cycle.is_set();
   }
 
+  // Ages regions that haven't been used for allocations in the current cycle.
+  // Resets ages for regions that have been used for allocations.
+  void update_region_ages();
+
   oop evacuate_object(oop p, Thread* thread) override;
   oop try_evacuate_object(oop p, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahAffiliation target_gen);
 
@@ -62,6 +66,7 @@ public:
   // ---------- Update References
   //
   void update_heap_references(bool concurrent) override;
+
 private:
   HeapWord* allocate_from_plab(Thread* thread, size_t size, bool is_promotion);
   HeapWord* allocate_from_plab_slow(Thread* thread, size_t size, bool is_promotion);
@@ -103,11 +108,15 @@ public:
   // Transfers surplus old regions to young, or takes regions from young to satisfy old region deficit
   TransferResult balance_generations();
 
-  // Makes old regions parsable
-  void coalesce_and_fill_old_regions(bool concurrent);
-
+  // Balances generations, coalesces and fills old regions if necessary
+  void complete_degenerated_cycle();
+  void complete_concurrent_cycle();
 private:
   void initialize_controller() override;
+  void entry_global_coalesce_and_fill();
+
+  // Makes old regions parsable. This will also rebuild card offsets, which is necessary if classes were unloaded
+  void coalesce_and_fill_old_regions(bool concurrent);
 
   ShenandoahRegulatorThread* _regulator_thread;
 


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333109](https://bugs.openjdk.org/browse/JDK-8333109): GenShen: Factor generational mode out of gc helpers (redo) (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/54.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/54.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/54#issuecomment-2174551427)