### PR TITLE
8333825: GenShen: Revert/Remove ShenandoahMaxEvacLABRatio

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -86,9 +86,7 @@ size_t ShenandoahGenerationalHeap::calculate_min_plab() {
 
 size_t ShenandoahGenerationalHeap::calculate_max_plab() {
   size_t MaxTLABSizeWords = ShenandoahHeapRegion::max_tlab_size_words();
-  return ((ShenandoahMaxEvacLABRatio > 0)?
-          align_down(MIN2(MaxTLABSizeWords, PLAB::min_size() * ShenandoahMaxEvacLABRatio), CardTable::card_size_in_words()):
-          align_down(MaxTLABSizeWords, CardTable::card_size_in_words()));
+  return align_down(MaxTLABSizeWords, CardTable::card_size_in_words());
 }
 
 // Returns size in bytes
@@ -392,51 +390,50 @@ HeapWord* ShenandoahGenerationalHeap::allocate_from_plab_slow(Thread* thread, si
 
   assert(mode()->is_generational(), "PLABs only relevant to generational GC");
   const size_t plab_min_size = this->plab_min_size();
+  // PLABs are aligned to card boundaries to avoid synchronization with concurrent
+  // allocations in other PLABs.
   const size_t min_size = (size > plab_min_size)? align_up(size, CardTable::card_size_in_words()): plab_min_size;
 
-  // Figure out size of new PLAB, looking back at heuristics. Expand aggressively.  PLABs must align on size
-  // of card table in order to avoid the need for synchronization when registering newly allocated objects within
-  // the card table.
+  // Figure out size of new PLAB, using value determined at last refill.
   size_t cur_size = ShenandoahThreadLocalData::plab_size(thread);
   if (cur_size == 0) {
     cur_size = plab_min_size;
   }
 
-  // Limit growth of PLABs to the smaller of ShenandoahMaxEvacLABRatio * the minimum size and ShenandoahHumongousThreshold.
-  // This minimum value is represented by generational_heap->plab_max_size().  Enforcing this limit enables more equitable
-  // distribution of available evacuation budget between the many threads that are coordinating in the evacuation effort.
+  // Expand aggressively, doubling at each refill in this epoch, ceiling at plab_max_size()
   size_t future_size = MIN2(cur_size * 2, plab_max_size());
-  assert(is_aligned(future_size, CardTable::card_size_in_words()), "Align by design, future_size: " SIZE_FORMAT
-          ", alignment: " SIZE_FORMAT ", cur_size: " SIZE_FORMAT ", max: " SIZE_FORMAT,
+  // Doubling, starting at a card-multiple, should give us a card-multiple. (Ceiling and floor
+  // are card multiples.)
+  assert(is_aligned(future_size, CardTable::card_size_in_words()), "Card multiple by construction, future_size: " SIZE_FORMAT
+          ", card_size: " SIZE_FORMAT ", cur_size: " SIZE_FORMAT ", max: " SIZE_FORMAT,
          future_size, (size_t) CardTable::card_size_in_words(), cur_size, plab_max_size());
 
   // Record new heuristic value even if we take any shortcut. This captures
   // the case when moderately-sized objects always take a shortcut. At some point,
   // heuristics should catch up with them.  Note that the requested cur_size may
   // not be honored, but we remember that this is the preferred size.
+  log_debug(gc, free)("Set new PLAB size: " SIZE_FORMAT, future_size);
   ShenandoahThreadLocalData::set_plab_size(thread, future_size);
   if (cur_size < size) {
     // The PLAB to be allocated is still not large enough to hold the object. Fall back to shared allocation.
     // This avoids retiring perfectly good PLABs in order to represent a single large object allocation.
+    log_debug(gc, free)("Current PLAB size (" SIZE_FORMAT ") is too small for " SIZE_FORMAT, cur_size, size);
     return nullptr;
   }
 
   // Retire current PLAB, and allocate a new one.
   PLAB* plab = ShenandoahThreadLocalData::plab(thread);
   if (plab->words_remaining() < plab_min_size) {
-    // Retire current PLAB, and allocate a new one.
-    // CAUTION: retire_plab may register the remnant filler object with the remembered set scanner without a lock.  This
-    // is safe iff it is assured that each PLAB is a whole-number multiple of card-mark memory size and each PLAB is
-    // aligned with the start of a card's memory range.
+    // Retire current PLAB. This takes care of any PLAB book-keeping.
+    // retire_plab() registers the remnant filler object with the remembered set scanner without a lock.
+    // Since PLABs are card-aligned, concurrent registrations in other PLABs don't interfere.
     retire_plab(plab, thread);
 
     size_t actual_size = 0;
-    // allocate_new_plab resets plab_evacuated and plab_promoted and disables promotions if old-gen available is
-    // less than the remaining evacuation need.  It also adjusts plab_preallocated and expend_promoted if appropriate.
     HeapWord* plab_buf = allocate_new_plab(min_size, cur_size, &actual_size);
     if (plab_buf == nullptr) {
       if (min_size == plab_min_size) {
-        // Disable plab promotions for this thread because we cannot even allocate a plab of minimal size.  This allows us
+        // Disable PLAB promotions for this thread because we cannot even allocate a minimal PLAB. This allows us
         // to fail faster on subsequent promotion attempts.
         ShenandoahThreadLocalData::disable_plab_promotions(thread);
       }
@@ -465,7 +462,7 @@ HeapWord* ShenandoahGenerationalHeap::allocate_from_plab_slow(Thread* thread, si
     }
     return plab->allocate(size);
   } else {
-    // If there's still at least min_size() words available within the current plab, don't retire it.  Let's gnaw
+    // If there's still at least min_size() words available within the current plab, don't retire it.  Let's nibble
     // away on this plab as long as we can.  Meanwhile, return nullptr to force this particular allocation request
     // to be satisfied with a shared allocation.  By packing more promotions into the previously allocated PLAB, we
     // reduce the likelihood of evacuation failures, and we reduce the need for downsizing our PLABs.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -918,19 +918,13 @@ HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) 
   // Figure out size of new GCLAB, looking back at heuristics. Expand aggressively.
   size_t new_size = ShenandoahThreadLocalData::gclab_size(thread) * 2;
 
-  // Limit growth of GCLABs to ShenandoahMaxEvacLABRatio * the minimum size.  This enables more equitable distribution of
-  // available evacuation buidget between the many threads that are coordinating in the evacuation effort.
-  if (ShenandoahMaxEvacLABRatio > 0) {
-    log_debug(gc, free)("Allocate new gclab: " SIZE_FORMAT ", " SIZE_FORMAT, new_size, PLAB::min_size() * ShenandoahMaxEvacLABRatio);
-    new_size = MIN2(new_size, PLAB::min_size() * ShenandoahMaxEvacLABRatio);
-  }
-
   new_size = MIN2(new_size, PLAB::max_size());
   new_size = MAX2(new_size, PLAB::min_size());
 
   // Record new heuristic value even if we take any shortcut. This captures
   // the case when moderately-sized objects always take a shortcut. At some point,
   // heuristics should catch up with them.
+  log_debug(gc, free)("Set new GCLAB size: " SIZE_FORMAT, new_size);
   ShenandoahThreadLocalData::set_gclab_size(thread, new_size);
 
   if (new_size < size) {

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -384,26 +384,6 @@
           "failures, which will trigger stop-the-world Full GC passes.")    \
           range(1.0,100.0)                                                  \
                                                                             \
-  product(uintx, ShenandoahMaxEvacLABRatio, 0, EXPERIMENTAL,                \
-          "Potentially, each running thread maintains a PLAB for "          \
-          "evacuating objects into old-gen memory and a GCLAB for "         \
-          "evacuating objects into young-gen memory.  Each time a thread "  \
-          "exhausts its PLAB or GCLAB, a new local buffer is allocated. "   \
-          "By default, the new buffer is twice the size of the previous "   \
-          "buffer.  The sizes are reset to the minimum at the start of "    \
-          "each GC pass.  This parameter limits the growth of evacuation "  \
-          "buffer sizes to its value multiplied by the minimum buffer "     \
-          "size.  A higher value allows evacuation allocations to be more " \
-          "efficient because less synchronization is required by "          \
-          "individual threads.  However, a larger value increases the "     \
-          "likelihood of evacuation failures, leading to long "             \
-          "stop-the-world pauses.  This is because a large value "          \
-          "allows individual threads to consume large percentages of "      \
-          "the total evacuation budget without necessarily effectively "    \
-          "filling their local evacuation buffers with evacuated "          \
-          "objects.  A value of zero means no maximum size is enforced.")   \
-          range(0, 1024)                                                    \
-                                                                            \
   product(bool, ShenandoahEvacReserveOverflow, true, EXPERIMENTAL,          \
           "Allow evacuations to overflow the reserved space. Enabling it "  \
           "will make evacuations more resilient when evacuation "           \


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333825](https://bugs.openjdk.org/browse/JDK-8333825): GenShen: Revert/Remove ShenandoahMaxEvacLABRatio (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/55.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/55.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/55#issuecomment-2174552439)