### PR TITLE
8333930: GenShen: Check for cancellation of old mark after final mark

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -111,6 +111,12 @@ bool ShenandoahOldGC::collect(GCCause::Cause cause) {
   // Complete marking under STW
   vmop_entry_final_mark();
 
+  if (_generation->is_concurrent_mark_in_progress()) {
+    assert(heap->cancelled_gc(), "Safepoint operation observed gc cancellation");
+    // GC may have been cancelled before final mark, but after the preceding cancellation check.
+    return false;
+  }
+
   // We aren't dealing with old generation evacuation yet. Our heuristic
   // should not have built a cset in final mark.
   assert(!heap->is_evacuation_in_progress(), "Old gen evacuations are not supported");


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333930](https://bugs.openjdk.org/browse/JDK-8333930): GenShen: Check for cancellation of old mark after final mark (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/56.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/56.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/56#issuecomment-2174553957)