### PR TITLE
8327388: GenShen: census during marking is partial

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.cpp
@@ -149,14 +149,12 @@ ShenandoahCycleStats ShenandoahEvacuationTracker::flush_cycle_to_global() {
   _workers_global.accumulate(&workers);
 
   if (_generational && (ShenandoahGenerationalCensusAtEvac || !ShenandoahGenerationalAdaptiveTenuring)) {
-    // Ingest population vectors into the heap's global census
-    // data, and use it to compute an appropriate tenuring threshold
+    // Ingest mutator & worker collected population vectors into the heap's
+    // global census data, and use it to compute an appropriate tenuring threshold
     // for use in the next cycle.
-    ShenandoahAgeCensus* census = ShenandoahHeap::heap()->age_census();
-    census->prepare_for_census_update();
     // The first argument is used for any age 0 cohort population that we may otherwise have
     // missed during the census. This is non-zero only when census happens at marking.
-    census->update_census(0, _mutators_global.age_table(), _workers_global.age_table());
+    ShenandoahHeap::heap()->age_census()->update_census(0, _mutators_global.age_table(), _workers_global.age_table());
   }
 
   return {workers, mutators};

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -122,3 +122,16 @@ void ShenandoahGlobalGeneration::set_mark_incomplete() {
   heap->young_generation()->set_mark_incomplete();
   heap->old_generation()->set_mark_incomplete();
 }
+
+void ShenandoahGlobalGeneration::prepare_gc() {
+  ShenandoahGeneration::prepare_gc();
+
+  if (ShenandoahHeap::heap()->mode()->is_generational()) {
+    assert(type() == GLOBAL, "Unexpected generation type");
+    // Clear any stale/partial local census data before the start of a
+    // new marking cycle
+    ShenandoahHeap::heap()->age_census()->reset_local();
+  } else {
+    assert(type() == NON_GEN, "Unexpected generation type");
+  }
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -65,6 +65,8 @@ public:
   void set_mark_incomplete() override;
 
   ShenandoahHeuristics* initialize_heuristics(ShenandoahMode* gc_mode) override;
+
+  virtual void prepare_gc() override;
 };
 
 #endif // SHARE_VM_GC_SHENANDOAH_SHENANDOAHGLOBALGENERATION_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkClosures.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkClosures.cpp
@@ -81,7 +81,7 @@ void ShenandoahFinalMarkUpdateRegionStateClosure::heap_region_do(ShenandoahHeapR
 
 ShenandoahUpdateCensusZeroCohortClosure::ShenandoahUpdateCensusZeroCohortClosure(
   ShenandoahMarkingContext *ctx) :
-  _ctx(ctx), _pop(0) {}
+  _ctx(ctx), _age0_pop(0), _total_pop(0) {}
 
 void ShenandoahUpdateCensusZeroCohortClosure::heap_region_do(ShenandoahHeapRegion* r) {
   if (_ctx != nullptr && r->is_active()) {
@@ -89,7 +89,10 @@ void ShenandoahUpdateCensusZeroCohortClosure::heap_region_do(ShenandoahHeapRegio
     HeapWord* tams = _ctx->top_at_mark_start(r);
     HeapWord* top  = r->top();
     if (top > tams) {
-      _pop += pointer_delta(top, tams);
+      _age0_pop += pointer_delta(top, tams);
     }
+    // TODO: check significance of _ctx != nullptr above, can that
+    // spoof _total_pop in some corner cases?
+    NOT_PRODUCT(_total_pop += r->get_live_data_words();)
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkClosures.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkClosures.hpp
@@ -45,15 +45,20 @@ public:
 
 // Add [TAMS, top) volume over young regions. Used to correct age 0 cohort census
 // for adaptive tenuring when census is taken during marking.
+// In non-product builds, for the purposes of verification, we also collect the total
+// live objects in young regions as well.
 class ShenandoahUpdateCensusZeroCohortClosure : public ShenandoahHeapRegionClosure {
 private:
   ShenandoahMarkingContext* const _ctx;
-  size_t _pop;   // running tally of population
+  // Population size units are words (not bytes)
+  size_t _age0_pop;                // running tally of age0 population size
+  size_t _total_pop;               // total live population size
 public:
   ShenandoahUpdateCensusZeroCohortClosure(ShenandoahMarkingContext* ctx);
 
   void heap_region_do(ShenandoahHeapRegion* r);
 
-  size_t get_population() { return _pop; }
+  size_t get_age0_population()  { return _age0_pop; }
+  size_t get_total_population() { return _total_pop; }
 };
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHMARKCLOSURES_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -103,3 +103,12 @@ size_t ShenandoahYoungGeneration::soft_available() const {
   return MIN2(available, ShenandoahHeap::heap()->free_set()->available());
 }
 
+void ShenandoahYoungGeneration::prepare_gc() {
+
+  ShenandoahGeneration::prepare_gc();
+
+  assert(type() == YOUNG, "Error?");
+  // Clear any stale/partial local census data before the start of a
+  // new marking cycle
+  ShenandoahHeap::heap()->age_census()->reset_local();
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -77,6 +77,8 @@ public:
   // Do not override available_with_reserve() because that needs to see memory reserved for Collector
 
   size_t soft_available() const override;
+
+  virtual void prepare_gc() override;
 };
 
 #endif // SHARE_VM_GC_SHENANDOAH_SHENANDOAHYOUNGGENERATION_HPP


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327388](https://bugs.openjdk.org/browse/JDK-8327388): GenShen: census during marking is partial (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/57.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/57.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/57#issuecomment-2176245019)