### PR TITLE
8335289: GenShen: Whitebox breakpoint GC requests may cause assertions

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -380,6 +380,16 @@ void ShenandoahControlThread::request_gc(GCCause::Cause cause) {
 }
 
 void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {
+  // For normal requested GCs (System.gc) we want to block the caller. However,
+  // for whitebox requested GC, we want to initiate the GC and return immediately.
+  // The whitebox caller thread will arrange for itself to wait until the GC notifies
+  // it that has reached the requested breakpoint (phase in the GC).
+  if (cause == GCCause::_wb_breakpoint) {
+    _requested_gc_cause = cause;
+    _gc_requested.set();
+    return;
+  }
+
   // Make sure we have at least one complete GC cycle before unblocking
   // from the explicit GC request.
   //
@@ -399,9 +409,7 @@ void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {
     _requested_gc_cause = cause;
     _gc_requested.set();
 
-    if (cause != GCCause::_wb_breakpoint) {
-      ml.wait();
-    }
+    ml.wait();
     current_gc_id = get_gc_id();
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -785,6 +785,16 @@ bool ShenandoahGenerationalControlThread::preempt_old_marking(ShenandoahGenerati
 }
 
 void ShenandoahGenerationalControlThread::handle_requested_gc(GCCause::Cause cause) {
+  // For normal requested GCs (System.gc) we want to block the caller. However,
+  // for whitebox requested GC, we want to initiate the GC and return immediately.
+  // The whitebox caller thread will arrange for itself to wait until the GC notifies
+  // it that has reached the requested breakpoint (phase in the GC).
+  if (cause == GCCause::_wb_breakpoint) {
+    Atomic::xchg(&_requested_gc_cause, cause);
+    notify_control_thread();
+    return;
+  }
+
   // Make sure we have at least one complete GC cycle before unblocking
   // from the explicit GC request.
   //
@@ -807,9 +817,7 @@ void ShenandoahGenerationalControlThread::handle_requested_gc(GCCause::Cause cau
     }
 
     notify_control_thread();
-    if (cause != GCCause::_wb_breakpoint) {
-      ml.wait();
-    }
+    ml.wait();
     current_gc_id = get_gc_id();
   }
 }


### PR DESCRIPTION
Clean backport, low risk. Fixes intermittent test failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335289](https://bugs.openjdk.org/browse/JDK-8335289): GenShen: Whitebox breakpoint GC requests may cause assertions (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/63.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/63.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/63#issuecomment-2197715124)