### PR TITLE
8336106: Genshen: Fix use of missing API in Shenandoah Old Heuristic test

### DIFF
--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
@@ -85,7 +85,7 @@ class ShenandoahOldHeuristicTest : public ::testing::Test {
     _heap->lock()->lock(false);
     ShenandoahResetRegions reset;
     _heap->heap_region_iterate(&reset);
-    _heap->old_generation()->set_capacity(ShenandoahHeapRegion::region_size_bytes() * 10);
+    _heap->old_generation()->increase_capacity(ShenandoahHeapRegion::region_size_bytes() * 10);
     _heap->old_generation()->set_evacuation_reserve(ShenandoahHeapRegion::region_size_bytes() * 4);
     _heuristics->abandon_collection_candidates();
     _collection_set->clear();


### PR DESCRIPTION
The recent fixes for the Shenandoah Old Heuristic test used an API that hasn't been backported. This change uses a different API available in 21 to achieve the same end.