### PR TITLE
8328235: GenShen: Robustify ShenandoahGCSession and fix missing use

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -883,6 +883,7 @@ void ShenandoahEvacUpdateCleanupOopStorageRootsClosure::do_oop(oop* p) {
   const oop obj = RawAccess<>::oop_load(p);
   if (!CompressedOops::is_null(obj)) {
     if (!_mark_context->is_marked(obj)) {
+      shenandoah_assert_generations_reconciled();
       if (_heap->is_in_active_generation(obj)) {
         // TODO: This worries me. Here we are asserting that an unmarked from-space object is 'correct'.
         // Normally, I would call this a bogus assert, but there seems to be a legitimate use-case for
@@ -1006,6 +1007,9 @@ void ShenandoahConcurrentGC::op_weak_roots() {
     ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_rendezvous);
     heap->rendezvous_threads();
   }
+  // We can only toggle concurrent_weak_root_in_progress flag
+  // at a safepoint, so that mutators see a consistent
+  // value. The flag will be cleared at the next safepoint.
 }
 
 void ShenandoahConcurrentGC::op_class_unloading() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -442,6 +442,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(Shenandoa
 
   switch (original_state) {
     case ShenandoahOldGeneration::FILLING: {
+      ShenandoahGCSession session(cause, old_generation);
       _allow_old_preemption.set();
       old_generation->entry_coalesce_and_fill();
       _allow_old_preemption.unset();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
@@ -126,12 +126,12 @@ void ShenandoahGenerationalEvacuationTask::do_work() {
 // We identify the entirety of the region as DIRTY to force the next remembered set scan to identify the "interesting poitners"
 // contained herein.
 void ShenandoahGenerationalEvacuationTask::promote_in_place(ShenandoahHeapRegion* region) {
-  ShenandoahMarkingContext* const marking_context = _heap->marking_context();
+  ShenandoahMarkingContext* const marking_context = _heap->complete_marking_context();
   HeapWord* const tams = marking_context->top_at_mark_start(region);
 
   {
     const size_t old_garbage_threshold = (ShenandoahHeapRegion::region_size_bytes() * ShenandoahOldGarbageThreshold) / 100;
-    assert(_heap->active_generation()->is_mark_complete(), "sanity");
+    shenandoah_assert_generations_reconciled();
     assert(!_heap->is_concurrent_old_mark_in_progress(), "Cannot promote in place during old marking");
     assert(region->garbage_before_padded_for_promote() < old_garbage_threshold, "Region " SIZE_FORMAT " has too much garbage for promotion", region->index());
     assert(region->is_young(), "Only young regions can be promoted");
@@ -216,7 +216,8 @@ void ShenandoahGenerationalEvacuationTask::promote_in_place(ShenandoahHeapRegion
 void ShenandoahGenerationalEvacuationTask::promote_humongous(ShenandoahHeapRegion* region) {
   ShenandoahMarkingContext* marking_context = _heap->marking_context();
   oop obj = cast_to_oop(region->bottom());
-  assert(_heap->active_generation()->is_mark_complete(), "sanity");
+  assert(_heap->gc_generation()->is_mark_complete(), "sanity");
+  shenandoah_assert_generations_reconciled();
   assert(region->is_young(), "Only young regions can be promoted");
   assert(region->is_humongous_start(), "Should not promote humongous continuation in isolation");
   assert(region->age() >= _tenuring_threshold, "Only promote regions that are sufficiently aged");

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
@@ -54,6 +54,7 @@ void ShenandoahGenerationalFullGC::prepare() {
   auto heap = ShenandoahGenerationalHeap::heap();
   // Since we may arrive here from degenerated GC failure of either young or old, establish generation as GLOBAL.
   heap->set_gc_generation(heap->global_generation());
+  heap->set_active_generation();
 
   // No need for old_gen->increase_used() as this was done when plabs were allocated.
   heap->reset_generation_reserves();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -195,6 +195,8 @@ oop ShenandoahGenerationalHeap::evacuate_object(oop p, Thread* thread) {
   assert(!r->is_humongous(), "never evacuate humongous objects");
 
   ShenandoahAffiliation target_gen = r->affiliation();
+  // gc_generation() can change asynchronously and should not be used here.
+  assert(active_generation() != nullptr, "Error");
   if (active_generation()->is_young() && target_gen == YOUNG_GENERATION) {
     markWord mark = p->mark();
     if (mark.is_marked()) {
@@ -778,6 +780,7 @@ private:
   template<class T>
   void do_work(uint worker_id) {
     T cl;
+
     if (CONCURRENT && (worker_id == 0)) {
       // We ask the first worker to replenish the Mutator free set by moving regions previously reserved to hold the
       // results of evacuation.  These reserves are no longer necessary because evacuation has completed.
@@ -790,7 +793,9 @@ private:
 
     ShenandoahHeapRegion* r = _regions->next();
     // We update references for global, old, and young collections.
-    assert(_heap->active_generation()->is_mark_complete(), "Expected complete marking");
+    ShenandoahGeneration* const gc_generation = _heap->gc_generation();
+    shenandoah_assert_generations_reconciled();
+    assert(gc_generation->is_mark_complete(), "Expected complete marking");
     ShenandoahMarkingContext* const ctx = _heap->marking_context();
     bool is_mixed = _heap->collection_set()->has_old_regions();
     while (r != nullptr) {
@@ -804,7 +809,7 @@ private:
           _heap->marked_object_oop_iterate(r, &cl, update_watermark);
           region_progress = true;
         } else if (r->is_old()) {
-          if (_heap->active_generation()->is_global()) {
+          if (gc_generation->is_global()) {
             // Note that GLOBAL collection is not as effectively balanced as young and mixed cycles.  This is because
             // concurrent GC threads are parceled out entire heap regions of work at a time and there
             // is no "catchup phase" consisting of remembered set scanning, during which parcels of work are smaller
@@ -841,7 +846,7 @@ private:
       r = _regions->next();
     }
 
-    if (!_heap->active_generation()->is_global()) {
+    if (!gc_generation->is_global()) {
       // Since this is generational and not GLOBAL, we have to process the remembered set.  There's no remembered
       // set processing if not in generational mode or if GLOBAL mode.
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -528,6 +528,7 @@ void ShenandoahHeap::initialize_heuristics() {
 ShenandoahHeap::ShenandoahHeap(ShenandoahCollectorPolicy* policy) :
   CollectedHeap(),
   _gc_generation(nullptr),
+  _active_generation(nullptr),
   _initial_size(0),
   _committed(0),
   _max_workers(MAX3(ConcGCThreads, ParallelGCThreads, 1U)),
@@ -1541,8 +1542,24 @@ void ShenandoahHeap::print_tracing_info() const {
   }
 }
 
+void ShenandoahHeap::set_gc_generation(ShenandoahGeneration* generation) {
+  shenandoah_assert_control_or_vm_thread_at_safepoint();
+  _gc_generation = generation;
+}
+
+// Active generation may only be set by the VM thread at a safepoint.
+void ShenandoahHeap::set_active_generation() {
+  assert(Thread::current()->is_VM_thread(), "Only the VM Thread");
+  assert(SafepointSynchronize::is_at_safepoint(), "Only at a safepoint!");
+  assert(_gc_generation != nullptr, "Will set _active_generation to nullptr");
+  _active_generation = _gc_generation;
+}
+
 void ShenandoahHeap::on_cycle_start(GCCause::Cause cause, ShenandoahGeneration* generation) {
   shenandoah_policy()->record_collection_cause(cause);
+
+  assert(gc_cause()  == GCCause::_no_gc, "Over-writing cause");
+  assert(_gc_generation == nullptr, "Over-writing _gc_generation");
 
   set_gc_cause(cause);
   set_gc_generation(generation);
@@ -1551,12 +1568,17 @@ void ShenandoahHeap::on_cycle_start(GCCause::Cause cause, ShenandoahGeneration* 
 }
 
 void ShenandoahHeap::on_cycle_end(ShenandoahGeneration* generation) {
+  assert(gc_cause() != GCCause::_no_gc, "cause wasn't set");
+  assert(_gc_generation != nullptr, "_gc_generation wasn't set");
+
   generation->heuristics()->record_cycle_end();
   if (mode()->is_generational() && generation->is_global()) {
     // If we just completed a GLOBAL GC, claim credit for completion of young-gen and old-gen GC as well
     young_generation()->heuristics()->record_cycle_end();
     old_generation()->heuristics()->record_cycle_end();
   }
+
+  set_gc_generation(nullptr);
   set_gc_cause(GCCause::_no_gc);
 }
 
@@ -1909,7 +1931,8 @@ void ShenandoahHeap::stw_weak_refs(bool full_gc) {
                                                 : ShenandoahPhaseTimings::degen_gc_weakrefs;
   ShenandoahTimingsTracker t(phase);
   ShenandoahGCWorkerPhase worker_phase(phase);
-  active_generation()->ref_processor()->process_references(phase, workers(), false /* concurrent */);
+  shenandoah_assert_generations_reconciled();
+  gc_generation()->ref_processor()->process_references(phase, workers(), false /* concurrent */);
 }
 
 void ShenandoahHeap::prepare_update_heap_references(bool concurrent) {
@@ -1943,6 +1966,9 @@ void ShenandoahHeap::set_gc_state(uint mask, bool value) {
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "Must be at Shenandoah safepoint");
   _gc_state.set_cond(mask, value);
   _gc_state_changed = true;
+  // Check that if concurrent weak root is set then active_gen isn't null
+  assert(!is_concurrent_weak_root_in_progress() || active_generation() != nullptr, "Error");
+  shenandoah_assert_generations_reconciled();
 }
 
 void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
@@ -2239,7 +2265,8 @@ void ShenandoahHeap::sync_pinned_region_status() {
 void ShenandoahHeap::assert_pinned_region_status() {
   for (size_t i = 0; i < num_regions(); i++) {
     ShenandoahHeapRegion* r = get_region(i);
-    if (active_generation()->contains(r)) {
+    shenandoah_assert_generations_reconciled();
+    if (gc_generation()->contains(r)) {
       assert((r->is_pinned() && r->pin_count() > 0) || (!r->is_pinned() && r->pin_count() == 0),
              "Region " SIZE_FORMAT " pinning status is inconsistent", i);
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -156,21 +156,44 @@ class ShenandoahHeap : public CollectedHeap {
 //
 private:
   ShenandoahHeapLock _lock;
+
+  // Indicates the generation whose collection is in
+  // progress. Mutator threads aren't allowed to read
+  // this field.
   ShenandoahGeneration* _gc_generation;
+
+  // This is set and cleared by only the VMThread
+  // at each STW pause (safepoint) to the value seen in
+  // _gc_generation. This allows the value to be always consistently
+  // seen by all mutators as well as all GC worker threads.
+  // In that sense, it's a stable snapshot of _gc_generation that is
+  // updated at each STW pause associated with a ShenandoahVMOp.
+  ShenandoahGeneration* _active_generation;
 
 public:
   ShenandoahHeapLock* lock() {
     return &_lock;
   }
 
-  ShenandoahGeneration* active_generation() const {
-    // last or latest generation might be a better name here.
+  ShenandoahGeneration* gc_generation() const {
+    // We don't want this field read by a mutator thread
+    assert(!Thread::current()->is_Java_thread(), "Not allowed");
+    // value of _gc_generation field, see above
     return _gc_generation;
   }
 
-  void set_gc_generation(ShenandoahGeneration* generation) {
-    _gc_generation = generation;
+  ShenandoahGeneration* active_generation() const {
+    // value of _active_generation field, see above
+    return _active_generation;
   }
+
+  // Set the _gc_generation field
+  void set_gc_generation(ShenandoahGeneration* generation);
+
+  // Copy the value in the _gc_generation field into
+  // the _active_generation field: can only be called at
+  // a safepoint by the VMThread.
+  void set_active_generation();
 
   ShenandoahHeuristics* heuristics();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -354,31 +354,37 @@ bool ShenandoahHeap::is_in(const void* p) const {
 inline bool ShenandoahHeap::is_in_active_generation(oop obj) const {
   if (!mode()->is_generational()) {
     // everything is the same single generation
+    assert(is_in(obj), "Otherwise shouldn't return true below");
     return true;
   }
 
-  if (active_generation() == nullptr) {
-    // no collection is happening, only expect this to be called
+  ShenandoahGeneration* const gen = active_generation();
+
+  if (gen == nullptr) {
+    // no collection is happening: only expect this to be called
     // when concurrent processing is active, but that could change
     return false;
   }
 
   assert(is_in(obj), "only check if is in active generation for objects (" PTR_FORMAT ") in heap", p2i(obj));
-  assert((active_generation() == (ShenandoahGeneration*) old_generation()) ||
-         (active_generation() == (ShenandoahGeneration*) young_generation()) ||
-         (active_generation() == global_generation()), "Active generation must be old, young, or global");
+  assert(gen->is_old() || gen->is_young() || gen->is_global(),
+         "Active generation must be old, young, or global");
 
   size_t index = heap_region_containing(obj)->index();
+
+  // No flickering!
+  assert(gen == active_generation(), "Race?");
+
   switch (_affiliations[index]) {
   case ShenandoahAffiliation::FREE:
     // Free regions are in Old, Young, Global
     return true;
   case ShenandoahAffiliation::YOUNG_GENERATION:
     // Young regions are in young_generation and global_generation, not in old_generation
-    return (active_generation() != (ShenandoahGeneration*) old_generation());
+    return gen != (ShenandoahGeneration*)old_generation();
   case ShenandoahAffiliation::OLD_GENERATION:
     // Old regions are in old_generation and global_generation, not in young_generation
-    return (active_generation() != (ShenandoahGeneration*) young_generation());
+    return gen != (ShenandoahGeneration*)young_generation();
   default:
     assert(false, "Bad affiliation (%d) for region " SIZE_FORMAT, _affiliations[index], index);
     return false;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -321,7 +321,8 @@ void ShenandoahHeapRegion::make_trash_immediate() {
 
   // On this path, we know there are no marked objects in the region,
   // tell marking context about it to bypass bitmap resets.
-  assert(ShenandoahHeap::heap()->active_generation()->is_mark_complete(), "Marking should be complete here.");
+  assert(ShenandoahHeap::heap()->gc_generation()->is_mark_complete(), "Marking should be complete here.");
+  shenandoah_assert_generations_reconciled();
   ShenandoahHeap::heap()->marking_context()->reset_top_bitmap(this);
 }
 
@@ -471,7 +472,8 @@ bool ShenandoahHeapRegion::oop_coalesce_and_fill(bool cancellable) {
   ShenandoahMarkingContext* marking_context = heap->marking_context();
 
   // Expect marking to be completed before these threads invoke this service.
-  assert(heap->active_generation()->is_mark_complete(), "sanity");
+  assert(heap->gc_generation()->is_mark_complete(), "sanity");
+  shenandoah_assert_generations_reconciled();
 
   // All objects above TAMS are considered live even though their mark bits will not be set.  Note that young-
   // gen evacuations that interrupt a long-running old-gen concurrent mark may promote objects into old-gen

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.cpp
@@ -149,8 +149,12 @@ void ShenandoahMark::mark_loop_work(T* cl, ShenandoahLiveData* live_data, uint w
   ShenandoahObjToScanQueue* q;
   ShenandoahMarkTask t;
 
-  assert(heap->active_generation()->type() == GENERATION, "Sanity");
-  heap->active_generation()->ref_processor()->set_mark_closure(worker_id, cl);
+  // Do not use active_generation() : we must use the gc_generation() set by
+  // ShenandoahGCScope on the ControllerThread's stack; no safepoint may
+  // intervene to update active_generation, so we can't
+  // shenandoah_assert_generations_reconciled() here.
+  assert(heap->gc_generation()->type() == GENERATION, "Sanity: %d != %d", heap->gc_generation()->type(), GENERATION);
+  heap->gc_generation()->ref_processor()->set_mark_closure(worker_id, cl);
 
   /*
    * Process outstanding queues, if any.

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -104,7 +104,8 @@ void ShenandoahSTWMark::mark() {
   ShenandoahCodeRoots::arm_nmethods_for_mark();
 
   // Weak reference processing
-  ShenandoahReferenceProcessor* rp = heap->active_generation()->ref_processor();
+  ShenandoahReferenceProcessor* rp = heap->gc_generation()->ref_processor();
+  shenandoah_assert_generations_reconciled();
   rp->reset_thread_locals();
   rp->set_soft_reference_policy(heap->soft_ref_policy()->should_clear_all_soft_refs());
 
@@ -172,7 +173,8 @@ void ShenandoahSTWMark::mark_roots(uint worker_id) {
 void ShenandoahSTWMark::finish_mark(uint worker_id) {
   ShenandoahPhaseTimings::Phase phase = _full_gc ? ShenandoahPhaseTimings::full_gc_mark : ShenandoahPhaseTimings::degen_gc_stw_mark;
   ShenandoahWorkerTimingsTracker timer(phase, ShenandoahPhaseTimings::ParallelMark, worker_id);
-  ShenandoahReferenceProcessor* rp = ShenandoahHeap::heap()->active_generation()->ref_processor();
+  ShenandoahReferenceProcessor* rp = ShenandoahHeap::heap()->gc_generation()->ref_processor();
+  shenandoah_assert_generations_reconciled();
   StringDedup::Requests requests;
 
   mark_loop(worker_id, &_terminator, rp,

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -34,15 +34,33 @@
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahVMOperations.hpp"
 #include "interpreter/oopMapCache.hpp"
+#include "logging/log.hpp"
 #include "memory/universe.hpp"
 
 bool VM_ShenandoahOperation::doit_prologue() {
+  log_active_generation("Prologue");
   assert(!ShenandoahHeap::heap()->has_gc_state_changed(), "GC State can only be changed on a safepoint.");
   return true;
 }
 
 void VM_ShenandoahOperation::doit_epilogue() {
+  log_active_generation("Epilogue");
   assert(!ShenandoahHeap::heap()->has_gc_state_changed(), "GC State was not synchronized to java threads.");
+}
+
+void VM_ShenandoahOperation::log_active_generation(const char* prefix) {
+  ShenandoahGeneration* agen = ShenandoahHeap::heap()->active_generation();
+  ShenandoahGeneration* ggen = ShenandoahHeap::heap()->gc_generation();
+  log_debug(gc, heap)("%s: active_generation is %s, gc_generation is %s", prefix,
+                      agen == nullptr ? "nullptr" : shenandoah_generation_name(agen->type()),
+                      ggen == nullptr ? "nullptr" : shenandoah_generation_name(ggen->type()));
+}
+
+void VM_ShenandoahOperation::set_active_generation() {
+  if (evaluate_at_safepoint()) {
+    assert(SafepointSynchronize::is_at_safepoint(), "Error??");
+    ShenandoahHeap::heap()->set_active_generation();
+  }
 }
 
 bool VM_ShenandoahReferenceOperation::doit_prologue() {
@@ -62,42 +80,49 @@ void VM_ShenandoahReferenceOperation::doit_epilogue() {
 
 void VM_ShenandoahInitMark::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Init Mark", SvcGCMarker::CONCURRENT);
+  set_active_generation();
   _gc->entry_init_mark();
   ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
 }
 
 void VM_ShenandoahFinalMarkStartEvac::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Final Mark", SvcGCMarker::CONCURRENT);
+  set_active_generation();
   _gc->entry_final_mark();
   ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
 }
 
 void VM_ShenandoahFullGC::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Full GC", SvcGCMarker::FULL);
+  set_active_generation();
   _full_gc->entry_full(_gc_cause);
   ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
 }
 
 void VM_ShenandoahDegeneratedGC::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Degenerated GC", SvcGCMarker::CONCURRENT);
+  set_active_generation();
   _gc->entry_degenerated();
   ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
 }
 
 void VM_ShenandoahInitUpdateRefs::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Init Update Refs", SvcGCMarker::CONCURRENT);
+  set_active_generation();
   _gc->entry_init_updaterefs();
   ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
 }
 
 void VM_ShenandoahFinalUpdateRefs::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Final Update Refs", SvcGCMarker::CONCURRENT);
+  set_active_generation();
   _gc->entry_final_updaterefs();
   ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
 }
 
 void VM_ShenandoahFinalRoots::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Final Roots", SvcGCMarker::CONCURRENT);
+  set_active_generation();
   _gc->entry_final_roots();
   ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
@@ -38,16 +38,21 @@ class ShenandoahFullGC;
 //   - VM_ShenandoahFinalMarkStartEvac: finish up concurrent marking, and start evacuation
 //   - VM_ShenandoahInitUpdateRefs: initiate update references
 //   - VM_ShenandoahFinalUpdateRefs: finish up update references
+//   - VM_ShenandoahFinalRoots
 //   - VM_ShenandoahReferenceOperation:
 //       - VM_ShenandoahFullGC: do full GC
 //       - VM_ShenandoahDegeneratedGC: do STW degenerated GC
 
 class VM_ShenandoahOperation : public VM_Operation {
 protected:
-  uint         _gc_id;
+  uint _gc_id;
+
+  void set_active_generation();
 public:
   VM_ShenandoahOperation() : _gc_id(GCId::current()) {};
   bool skip_thread_oop_barriers() const override { return true; }
+
+  void log_active_generation(const char* prefix);
   bool doit_prologue() override;
   void doit_epilogue() override;
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -94,8 +94,9 @@ public:
     }
 
     if (_heap->mode()->is_generational()) {
-      _generation = _heap->active_generation();
+      _generation = _heap->gc_generation();
       assert(_generation != nullptr, "Expected active generation in this mode");
+      shenandoah_assert_generations_reconciled();
     }
   }
 
@@ -189,8 +190,9 @@ private:
           // fallthrough for fast failure for un-live regions:
         case ShenandoahVerifier::_verify_liveness_conservative:
           check(ShenandoahAsserts::_safe_oop, obj, obj_reg->has_live() ||
-                (obj_reg->is_old() && _heap->active_generation()->is_young()),
+                (obj_reg->is_old() && _heap->gc_generation()->is_young()),
                    "Object must belong to region with live data");
+          shenandoah_assert_generations_reconciled();
           break;
         default:
           assert(false, "Unhandled liveness verification");
@@ -638,8 +640,9 @@ public:
     }
 
     if (_heap->mode()->is_generational()) {
-      _generation = _heap->active_generation();
+      _generation = _heap->gc_generation();
       assert(_generation != nullptr, "Expected active generation in this mode.");
+      shenandoah_assert_generations_reconciled();
     }
   };
 
@@ -879,8 +882,9 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
 
   ShenandoahGeneration* generation;
   if (_heap->mode()->is_generational()) {
-    generation = _heap->active_generation();
+    generation = _heap->gc_generation();
     guarantee(generation != nullptr, "Need to know which generation to verify.");
+    shenandoah_assert_generations_reconciled();
   } else {
     generation = nullptr;
   }
@@ -1353,7 +1357,8 @@ void ShenandoahVerifier::verify_rem_set_before_mark() {
   ShenandoahOldGeneration* old_generation = _heap->old_generation();
   log_debug(gc)("Verifying remembered set at %s mark", old_generation->is_doing_mixed_evacuations() ? "mixed" : "young");
 
-  if (old_generation->is_mark_complete() || _heap->active_generation()->is_global()) {
+  shenandoah_assert_generations_reconciled();
+  if (old_generation->is_mark_complete() || _heap->gc_generation()->is_global()) {
     ctx = _heap->complete_marking_context();
   } else {
     ctx = nullptr;
@@ -1433,7 +1438,8 @@ void ShenandoahVerifier::verify_rem_set_before_update_ref() {
 
   ShenandoahMarkingContext* ctx;
 
-  if (_heap->old_generation()->is_mark_complete() || _heap->active_generation()->is_global()) {
+  shenandoah_assert_generations_reconciled();
+  if (_heap->old_generation()->is_mark_complete() || _heap->gc_generation()->is_global()) {
     ctx = _heap->complete_marking_context();
   } else {
     ctx = nullptr;


### PR DESCRIPTION
Clean backport of commit [d2102347](https://github.com/openjdk/shenandoah/commit/d2102347ea9c1199221ec33f4e721aefa1193cea) from the [openjdk/shenandoah](https://git.openjdk.org/shenandoah) repository.

The commit being backported was authored by Y. Srinivas Ramakrishna on 2 Jul 2024 and was reviewed by William Kemper.

**Testing:** 
 - [x ] Code pipeline testing -- failure orthogonal to the changes here and being independently investigated
 - [x] jtreg local
 - [x] [GHA](https://github.com/openjdk-bots/shenandoah-jdk21u/actions/runs/9915888290)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328235](https://bugs.openjdk.org/browse/JDK-8328235): GenShen: Robustify ShenandoahGCSession and fix missing use (**Sub-task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/68.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/68.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/68#issuecomment-2226640107)