### PR TITLE
8337847: [GenShen] jdk.test.whitebox.Whitebox.isObjectInOldGen misreports

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -410,7 +410,8 @@ WB_ENTRY(jboolean, WB_isObjectInOldGen(JNIEnv* env, jobject o, jobject obj))
 #endif
 #if INCLUDE_SHENANDOAHGC
   if (UseShenandoahGC) {
-    return Universe::heap()->is_in(p);
+    ShenandoahHeap* sh = ShenandoahHeap::heap();
+    return sh->mode()->is_generational() ?  sh->is_in_old(p) : sh->is_in(p);
   }
 #endif
   GenCollectedHeap* gch = GenCollectedHeap::heap();

--- a/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
@@ -149,7 +149,11 @@ public class TestReferenceRefersToShenandoah {
         if (!WB.isObjectInOldGen(o)) {
             WB.fullGC();
             if (!WB.isObjectInOldGen(o)) {
-                fail("object not promoted by full gc");
+                // This is just a warning, because failing would
+                // be overspecifying for generational shenandoah,
+                // which need not necessarily promote objects upon
+                // a full GC.
+                warn("object not promoted by full gc");
             }
         }
     }
@@ -174,6 +178,10 @@ public class TestReferenceRefersToShenandoah {
 
     private static void fail(String msg) throws Exception {
         throw new RuntimeException(msg);
+    }
+
+    private static void warn(String msg) {
+        System.out.println("Warning: " + msg);
     }
 
     private static void expectCleared(Reference<TestObject> ref,


### PR DESCRIPTION
Clean backport. Fix in test code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337847](https://bugs.openjdk.org/browse/JDK-8337847): [GenShen] jdk.test.whitebox.Whitebox.isObjectInOldGen misreports (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/79.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/79.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/79#issuecomment-2347397400)