### PR TITLE
8338336: GenShen: Cleanup stale TODOs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -111,10 +111,6 @@ protected:
 
   static int compare_by_garbage(RegionData a, RegionData b);
 
-  // TODO: We need to enhance this API to give visibility to accompanying old-gen evacuation effort.
-  // In the case that the old-gen evacuation effort is small or zero, the young-gen heuristics
-  // should feel free to dedicate increased efforts to young-gen evacuation.
-
   virtual void choose_collection_set_from_regiondata(ShenandoahCollectionSet* set,
                                                      RegionData* data, size_t data_size,
                                                      size_t free) = 0;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -368,21 +368,12 @@ void ShenandoahOldHeuristics::prepare_for_old_collections() {
 
   _old_generation->set_live_bytes_after_last_mark(live_data);
 
-  // TODO: Consider not running mixed collects if we recovered some threshold percentage of memory from immediate garbage.
-  // This would be similar to young and global collections shortcutting evacuation, though we'd probably want a separate
-  // threshold for the old generation.
-
   // Unlike young, we are more interested in efficiently packing OLD-gen than in reclaiming garbage first.  We sort by live-data.
   // Some regular regions may have been promoted in place with no garbage but also with very little live data.  When we "compact"
   // old-gen, we want to pack these underutilized regions together so we can have more unaffiliated (unfragmented) free regions
   // in old-gen.
 
   QuickSort::sort<RegionData>(candidates, cand_idx, compare_by_live, false);
-
-  // Any old-gen region that contains (ShenandoahOldGarbageThreshold (default value 25)% garbage or more is to be
-  // added to the list of candidates for subsequent mixed evacuations.
-  //
-  // TODO: allow ShenandoahOldGarbageThreshold to be determined adaptively, by heuristics.
 
   const size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
@@ -209,15 +209,6 @@ size_t ShenandoahYoungHeuristics::bytes_of_allocation_runway_before_gc_trigger(s
   // but evac_slack_spiking is only relevant if is_spiking, as defined below.
 
   double avg_cycle_time = _gc_cycle_time_history->davg() + (_margin_of_error_sd * _gc_cycle_time_history->dsd());
-
-  // TODO: Consider making conservative adjustments to avg_cycle_time, such as: (avg_cycle_time *= 2) in cases where
-  // we expect a longer-than-normal GC duration.  This includes mixed evacuations, evacuation that perform promotion
-  // including promotion in place, and OLD GC bootstrap cycles.  It has been observed that these cycles sometimes
-  // require twice or more the duration of "normal" GC cycles.  We have experimented with this approach.  While it
-  // does appear to reduce the frequency of degenerated cycles due to late triggers, it also has the effect of reducing
-  // evacuation slack so that there is less memory available to be transferred to OLD.  The result is that we
-  // throttle promotion and it takes too long to move old objects out of the young generation.
-
   double avg_alloc_rate = _allocation_rate.upper_bound(_margin_of_error_sd);
   size_t evac_slack_avg;
   if (anticipated_available > avg_cycle_time * avg_alloc_rate + penalties + spike_headroom) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -421,23 +421,6 @@ void ShenandoahAsserts::assert_heaplocked_or_safepoint(const char* file, int lin
     return;
   }
 
-  if (ShenandoahSafepoint::is_at_shenandoah_safepoint() && Thread::current()->is_VM_thread()) {
-    return;
-  }
-
-  ShenandoahMessageBuffer msg("Heap lock must be owned by current thread, or be at safepoint");
-  report_vm_error(file, line, msg.buffer());
-}
-
-// Unlike assert_heaplocked_or_safepoint(), this does not require current thread in safepoint to be a VM thread
-// TODO: This should be more aptly named. Nothing in this method checks we are actually in Full GC.
-void ShenandoahAsserts::assert_heaplocked_or_fullgc_safepoint(const char* file, int line) {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-
-  if (heap->lock()->owned_by_self()) {
-    return;
-  }
-
   if (ShenandoahSafepoint::is_at_shenandoah_safepoint()) {
     return;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
@@ -73,7 +73,6 @@ public:
   static void assert_heaplocked(const char* file, int line);
   static void assert_not_heaplocked(const char* file, int line);
   static void assert_heaplocked_or_safepoint(const char* file, int line);
-  static void assert_heaplocked_or_fullgc_safepoint(const char* file, int line);
 
 #ifdef ASSERT
 #define shenandoah_assert_in_heap(interior_loc, obj) \
@@ -166,8 +165,6 @@ public:
 #define shenandoah_assert_heaplocked_or_safepoint() \
                     ShenandoahAsserts::assert_heaplocked_or_safepoint(__FILE__, __LINE__)
 
-#define shenandoah_assert_heaplocked_or_fullgc_safepoint() \
-                    ShenandoahAsserts::assert_heaplocked_or_fullgc_safepoint(__FILE__, __LINE__)
 #define shenandoah_assert_control_or_vm_thread() \
                     assert(Thread::current()->is_VM_thread() || Thread::current() == ShenandoahHeap::heap()->control_thread(), "Expected control thread or vm thread")
 // A stronger version of the above that checks that we are at a safepoint if the vm thread
@@ -238,7 +235,6 @@ public:
 #define shenandoah_assert_heaplocked()
 #define shenandoah_assert_not_heaplocked()
 #define shenandoah_assert_heaplocked_or_safepoint()
-#define shenandoah_assert_heaplocked_or_fullgc_safepoint()
 #define shenandoah_assert_control_or_vm_thread()
 #define shenandoah_assert_control_or_vm_thread_at_safepoint()
 #define shenandoah_assert_generational()

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -486,6 +486,14 @@ void ShenandoahBarrierSet::arraycopy_marking(T* src, T* dst, size_t count, bool 
       // Non-generational, marking
       arraycopy_work<T, false, false, true>(array, count);
     }
+  } else {
+    // Incremental Update mode, marking
+    T* array = src;
+    HeapWord* array_addr = reinterpret_cast<HeapWord*>(array);
+    ShenandoahHeapRegion* r = _heap->heap_region_containing(array_addr);
+    if (array_addr < _heap->marking_context()->top_at_mark_start(r)) {
+      arraycopy_work<T, false, false, true>(array, count);
+    }
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -434,7 +434,6 @@ void ShenandoahBarrierSet::arraycopy_barrier(T* src, T* dst, size_t count) {
 
   if (_heap->mode()->is_generational()) {
     assert(ShenandoahSATBBarrier, "Generational mode assumes SATB mode");
-    // TODO: Could we optimize here by checking that dst is in an old region?
     if ((gc_state & ShenandoahHeap::OLD_MARKING) != 0) {
       // Note that we can't do the arraycopy marking using the 'src' array when
       // SATB mode is enabled (so we can't do this as part of the iteration for
@@ -485,14 +484,6 @@ void ShenandoahBarrierSet::arraycopy_marking(T* src, T* dst, size_t count, bool 
       }
     } else if (array_addr < _heap->marking_context()->top_at_mark_start(r)) {
       // Non-generational, marking
-      arraycopy_work<T, false, false, true>(array, count);
-    }
-  } else {
-    // Incremental Update mode, marking
-    T* array = src;
-    HeapWord* array_addr = reinterpret_cast<HeapWord*>(array);
-    ShenandoahHeapRegion* r = _heap->heap_region_containing(array_addr);
-    if (array_addr < _heap->marking_context()->top_at_mark_start(r)) {
       arraycopy_work<T, false, false, true>(array, count);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -652,10 +652,6 @@ void ShenandoahConcurrentGC::op_init_mark() {
   if (_do_old_gc_bootstrap) {
     shenandoah_assert_generational();
     // Update region state for both young and old regions
-    // TODO: We should be able to pull this out of the safepoint for the bootstrap
-    // cycle. The top of an old region will only move when a GC cycle evacuates
-    // objects into it. When we start an old cycle, we know that nothing can touch
-    // the top of old regions.
     ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_update_region_states);
     ShenandoahInitMarkUpdateRegionStateClosure cl;
     heap->parallel_heap_region_iterate(&cl);
@@ -886,11 +882,9 @@ void ShenandoahEvacUpdateCleanupOopStorageRootsClosure::do_oop(oop* p) {
     if (!_mark_context->is_marked(obj)) {
       shenandoah_assert_generations_reconciled();
       if (_heap->is_in_active_generation(obj)) {
-        // TODO: This worries me. Here we are asserting that an unmarked from-space object is 'correct'.
-        // Normally, I would call this a bogus assert, but there seems to be a legitimate use-case for
-        // accessing from-space objects during class unloading. However, the from-space object may have
-        // been "filled". We've made no effort to prevent old generation classes being unloaded by young
-        // gen (and vice-versa).
+        // Here we are asserting that an unmarked from-space object is 'correct'. There seems to be a legitimate
+        // use-case for accessing from-space objects during concurrent class unloading. In all modes of Shenandoah,
+        // concurrent class unloading only happens during a global collection.
         shenandoah_assert_correct(p, obj);
         ShenandoahHeap::atomic_clear_oop(p, obj);
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -857,7 +857,7 @@ void ShenandoahGeneration::scan_remembered_set(bool is_concurrent) {
 }
 
 size_t ShenandoahGeneration::increment_affiliated_region_count() {
-  shenandoah_assert_heaplocked_or_fullgc_safepoint();
+  shenandoah_assert_heaplocked_or_safepoint();
   // During full gc, multiple GC worker threads may change region affiliations without a lock.  No lock is enforced
   // on read and write of _affiliated_region_count.  At the end of full gc, a single thread overwrites the count with
   // a coherent value.
@@ -866,31 +866,29 @@ size_t ShenandoahGeneration::increment_affiliated_region_count() {
 }
 
 size_t ShenandoahGeneration::decrement_affiliated_region_count() {
-  shenandoah_assert_heaplocked_or_fullgc_safepoint();
+  shenandoah_assert_heaplocked_or_safepoint();
   // During full gc, multiple GC worker threads may change region affiliations without a lock.  No lock is enforced
   // on read and write of _affiliated_region_count.  At the end of full gc, a single thread overwrites the count with
   // a coherent value.
   _affiliated_region_count--;
-  // TODO: REMOVE IS_GLOBAL() QUALIFIER AFTER WE FIX GLOBAL AFFILIATED REGION ACCOUNTING
-  assert(is_global() || ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
          (_used + _humongous_waste <= _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
          "used + humongous cannot exceed regions");
   return _affiliated_region_count;
 }
 
 size_t ShenandoahGeneration::increase_affiliated_region_count(size_t delta) {
-  shenandoah_assert_heaplocked_or_fullgc_safepoint();
+  shenandoah_assert_heaplocked_or_safepoint();
   _affiliated_region_count += delta;
   return _affiliated_region_count;
 }
 
 size_t ShenandoahGeneration::decrease_affiliated_region_count(size_t delta) {
-  shenandoah_assert_heaplocked_or_fullgc_safepoint();
+  shenandoah_assert_heaplocked_or_safepoint();
   assert(_affiliated_region_count >= delta, "Affiliated region count cannot be negative");
 
   _affiliated_region_count -= delta;
-  // TODO: REMOVE IS_GLOBAL() QUALIFIER AFTER WE FIX GLOBAL AFFILIATED REGION ACCOUNTING
-  assert(is_global() || ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
          (_used + _humongous_waste <= _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
          "used + humongous cannot exceed regions");
   return _affiliated_region_count;
@@ -922,8 +920,7 @@ void ShenandoahGeneration::decrease_humongous_waste(size_t bytes) {
 }
 
 void ShenandoahGeneration::decrease_used(size_t bytes) {
-  // TODO: REMOVE IS_GLOBAL() QUALIFIER AFTER WE FIX GLOBAL AFFILIATED REGION ACCOUNTING
-  assert(is_global() || ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
          (_used >= bytes), "cannot reduce bytes used by generation below zero");
   Atomic::sub(&_used, bytes);
 }
@@ -970,15 +967,13 @@ size_t ShenandoahGeneration::increase_capacity(size_t increment) {
   // We do not enforce that new capacity >= heap->max_size_for(this).  The maximum generation size is treated as a rule of thumb
   // which may be violated during certain transitions, such as when we are forcing transfers for the purpose of promoting regions
   // in place.
-  // TODO: REMOVE IS_GLOBAL() QUALIFIER AFTER WE FIX GLOBAL AFFILIATED REGION ACCOUNTING
-  assert(is_global() || ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
          (_max_capacity + increment <= ShenandoahHeap::heap()->max_capacity()), "Generation cannot be larger than heap size");
   assert(increment % ShenandoahHeapRegion::region_size_bytes() == 0, "Generation capacity must be multiple of region size");
   _max_capacity += increment;
 
   // This detects arithmetic wraparound on _used
-  // TODO: REMOVE IS_GLOBAL() QUALIFIER AFTER WE FIX GLOBAL AFFILIATED REGION ACCOUNTING
-  assert(is_global() || ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
          (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() >= _used),
          "Affiliated regions must hold more than what is currently used");
   return _max_capacity;
@@ -1002,15 +997,12 @@ size_t ShenandoahGeneration::decrease_capacity(size_t decrement) {
   _max_capacity -= decrement;
 
   // This detects arithmetic wraparound on _used
-  // TODO: REMOVE IS_GLOBAL() QUALIFIER AFTER WE FIX GLOBAL AFFILIATED REGION ACCOUNTING
-  assert(is_global() || ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
          (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() >= _used),
          "Affiliated regions must hold more than what is currently used");
-  // TODO: REMOVE IS_GLOBAL() QUALIFIER AFTER WE FIX GLOBAL AFFILIATED REGION ACCOUNTING
-  assert(is_global() || ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
          (_used <= _max_capacity), "Cannot use more than capacity");
-  // TODO: REMOVE IS_GLOBAL() QUALIFIER AFTER WE FIX GLOBAL AFFILIATED REGION ACCOUNTING
-  assert(is_global() || ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
          (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() <= _max_capacity),
          "Cannot use more than capacity");
   return _max_capacity;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1260,7 +1260,6 @@ oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, ShenandoahHeapReg
       if ((copy == nullptr) && (size < ShenandoahThreadLocalData::gclab_size(thread))) {
         // GCLAB allocation failed because we are bumping up against the limit on young evacuation reserve.  Try resetting
         // the desired GCLAB size and retry GCLAB allocation to avoid cascading of shared memory allocations.
-        // TODO: is this right? using PLAB::min_size() here for gc lab size?
         ShenandoahThreadLocalData::set_gclab_size(thread, PLAB::min_size());
         copy = allocate_from_gclab(thread, size);
         // If we still get nullptr, we'll try a shared allocation below.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -424,7 +424,7 @@ inline void ShenandoahHeap::assert_lock_for_affiliation(ShenandoahAffiliation or
   // Note: during full GC, all transitions between states are possible.  During Full GC, we should be in a safepoint.
 
   if ((orig_affiliation == ShenandoahAffiliation::FREE) || (new_affiliation == ShenandoahAffiliation::FREE)) {
-    shenandoah_assert_heaplocked_or_fullgc_safepoint();
+    shenandoah_assert_heaplocked_or_safepoint();
   }
 }
 


### PR DESCRIPTION
Conflict with https://bugs.openjdk.org/browse/JDK-8332082, left barrier code in 21 unchanged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8338336](https://bugs.openjdk.org/browse/JDK-8338336): GenShen: Cleanup stale TODOs (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/82.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/82.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/82#issuecomment-2350074908)