### PR TITLE
8338528: GenShen: Cleanup shenandoahHeapRegion

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -977,7 +977,7 @@ public:
     // Make empty regions that have been allocated into regular
     if (r->is_empty() && live > 0) {
       if (!_is_generational) {
-        r->make_young_maybe();
+        r->make_affiliated_maybe();
       }
       // else, generational mode compaction has already established affiliation.
       r->make_regular_bypass();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -872,7 +872,7 @@ private:
         if (is_mixed) {
           if (r->is_humongous()) {
             // Need to examine both dirty and clean cards during mixed evac.
-            r->oop_iterate_humongous_slice(&cl, false, start_of_range, assignment._chunk_size, true);
+            r->oop_iterate_humongous_slice_all(&cl,start_of_range, assignment._chunk_size);
           } else {
             // Since this is mixed evacuation, old regions that are candidates for collection have not been coalesced
             // and filled.  This will use mark bits to find objects that need to be updated.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -173,7 +173,7 @@ public:
 
   // Allowed transitions from the outside code:
   void make_regular_allocation(ShenandoahAffiliation affiliation);
-  void make_young_maybe();
+  void make_affiliated_maybe();
   void make_regular_bypass();
   void make_humongous_start();
   void make_humongous_cont();
@@ -400,15 +400,20 @@ public:
     return _coalesce_and_fill_boundary;
   }
 
-  // Coalesce contiguous spans of garbage objects by filling header and reregistering start locations with remembered set.
-  // This is used by old-gen GC following concurrent marking to make old-gen HeapRegions parsable.  Return true iff
-  // region is completely coalesced and filled.  Returns false if cancelled before task is complete.
+  // Coalesce contiguous spans of garbage objects by filling header and registering start locations with remembered set.
+  // This is used by old-gen GC following concurrent marking to make old-gen HeapRegions parsable. Old regions must be
+  // parsable because the mark bitmap is not reliable during the concurrent old mark.
+  // Return true iff region is completely coalesced and filled.  Returns false if cancelled before task is complete.
   bool oop_coalesce_and_fill(bool cancellable);
 
   // Invoke closure on every reference contained within the humongous object that spans this humongous
   // region if the reference is contained within a DIRTY card and the reference is no more than words following
   // start within the humongous object.
-  void oop_iterate_humongous_slice(OopIterateClosure* cl, bool dirty_only, HeapWord* start, size_t words, bool write_table);
+  void oop_iterate_humongous_slice_dirty(OopIterateClosure* cl, HeapWord* start, size_t words, bool write_table) const;
+
+  // Invoke closure on every reference contained within the humongous object starting from start and
+  // ending at start + words.
+  void oop_iterate_humongous_slice_all(OopIterateClosure* cl, HeapWord* start, size_t words) const;
 
   HeapWord* block_start(const void* p) const;
   size_t block_size(const HeapWord* p) const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -38,7 +38,7 @@ HeapWord* ShenandoahHeapRegion::allocate_aligned(size_t size, ShenandoahAllocReq
   assert(req.is_lab_alloc(), "allocate_aligned() only applies to LAB allocations");
   assert(is_object_aligned(size), "alloc size breaks alignment: " SIZE_FORMAT, size);
   assert(is_old(), "aligned allocations are only taken from OLD regions to support PLABs");
-  assert(is_aligned(alignment_in_bytes, HeapWordSize), "Expect hea word alignment");
+  assert(is_aligned(alignment_in_bytes, HeapWordSize), "Expect heap word alignment");
 
   HeapWord* orig_top = top();
   size_t alignment_in_words = alignment_in_bytes / HeapWordSize;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -308,7 +308,7 @@ ShenandoahScanRemembered::process_humongous_clusters(ShenandoahHeapRegion* r, si
   size_t first_card_index = first_cluster * ShenandoahCardCluster::CardsPerCluster;
   HeapWord* first_cluster_addr = _rs->addr_for_card_index(first_card_index);
   size_t spanned_words = count * ShenandoahCardCluster::CardsPerCluster * CardTable::card_size_in_words();
-  start_region->oop_iterate_humongous_slice(cl, true, first_cluster_addr, spanned_words, use_write_table);
+  start_region->oop_iterate_humongous_slice_dirty(cl, first_cluster_addr, spanned_words, use_write_table);
 }
 
 


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338528](https://bugs.openjdk.org/browse/JDK-8338528): GenShen: Cleanup shenandoahHeapRegion (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/88.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/88.diff</a>

</details>
