### PR TITLE
8338620: GenShen: Distinguish between young and old collector in GC configuration

### DIFF
--- a/src/hotspot/share/gc/shared/gcConfiguration.cpp
+++ b/src/hotspot/share/gc/shared/gcConfiguration.cpp
@@ -32,7 +32,6 @@
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
 #include "utilities/debug.hpp"
-#include "utilities/macros.hpp"
 
 GCName GCConfiguration::young_collector() const {
   if (UseG1GC) {
@@ -43,15 +42,6 @@ GCName GCConfiguration::young_collector() const {
     return ParallelScavenge;
   }
 
-  if (UseShenandoahGC) {
-#if INCLUDE_SHENANDOAHGC
-    if (strcmp(ShenandoahGCMode, "generational") == 0) {
-      return Shenandoah;
-    }
-#endif
-    return NA;
-  }
-
   if (UseZGC) {
     if (ZGenerational) {
       return ZMinor;
@@ -59,6 +49,16 @@ GCName GCConfiguration::young_collector() const {
       return NA;
     }
   }
+
+  if (UseShenandoahGC) {
+#if INCLUDE_SHENANDOAHGC
+    if (ShenandoahCardBarrier) {
+      return ShenandoahYoung;
+    }
+#endif
+    return NA;
+  }
+
   return DefNew;
 }
 
@@ -71,10 +71,6 @@ GCName GCConfiguration::old_collector() const {
     return ParallelOld;
   }
 
-  if (UseShenandoahGC) {
-    return Shenandoah;
-  }
-
   if (UseZGC) {
     if (ZGenerational) {
       return ZMajor;
@@ -82,6 +78,16 @@ GCName GCConfiguration::old_collector() const {
       return Z;
     }
   }
+
+  if (UseShenandoahGC) {
+#if INCLUDE_SHENANDOAHGC
+    if (ShenandoahCardBarrier) {
+      return ShenandoahOld;
+    }
+#endif
+    return Shenandoah;
+  }
+
   return SerialOld;
 }
 

--- a/src/hotspot/share/gc/shared/gcName.hpp
+++ b/src/hotspot/share/gc/shared/gcName.hpp
@@ -39,6 +39,8 @@ enum GCName {
   ZMajor,
   Z, // Support for the legacy, single-gen mode
   Shenandoah,
+  ShenandoahYoung,
+  ShenandoahOld,
   NA,
   GCNameEndSentinel
 };
@@ -58,6 +60,8 @@ class GCNameHelper {
       case ZMajor: return "ZGC Major";
       case Z: return "Z";
       case Shenandoah: return "Shenandoah";
+      case ShenandoahYoung: return "Shenandoah Young";
+      case ShenandoahOld: return "Shenandoah Old";
       case NA: return "N/A";
       default: ShouldNotReachHere(); return nullptr;
     }


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338620](https://bugs.openjdk.org/browse/JDK-8338620): GenShen: Distinguish between young and old collector in GC configuration (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/91.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/91.diff</a>

</details>
