### PR TITLE
8338779: GenShen: Prefer log_develop_debug in performance critical code

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1014,7 +1014,7 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
         // If our allocation request has been satisifed after it initially failed, we count this as good gc progress
         notify_gc_progress();
       }
-      if (log_is_enabled(Debug, gc, alloc)) {
+      if (log_develop_is_enabled(Debug, gc, alloc)) {
         ResourceMark rm;
         log_debug(gc, alloc)("Thread: %s, Result: " PTR_FORMAT ", Request: %s, Size: " SIZE_FORMAT
                              ", Original: " SIZE_FORMAT ", Latest: " SIZE_FORMAT,

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -261,11 +261,11 @@ void ShenandoahScanRemembered::process_clusters(size_t first_cluster, size_t cou
           const MemRegion last_mr(right, p);
           assert(p == last_p + last_obj->size(), "Would miss portion of last_obj");
           last_obj->oop_iterate(cl, last_mr);
-          log_debug(gc, remset)("Fixed up non-objArray suffix scan in [" INTPTR_FORMAT ", " INTPTR_FORMAT ")",
-                                p2i(last_mr.start()), p2i(last_mr.end()));
+          log_develop_debug(gc, remset)("Fixed up non-objArray suffix scan in [" INTPTR_FORMAT ", " INTPTR_FORMAT ")",
+                                        p2i(last_mr.start()), p2i(last_mr.end()));
         } else {
-          log_debug(gc, remset)("Skipped suffix scan of objArray in [" INTPTR_FORMAT ", " INTPTR_FORMAT ")",
-                                p2i(right), p2i(p));
+          log_develop_debug(gc, remset)("Skipped suffix scan of objArray in [" INTPTR_FORMAT ", " INTPTR_FORMAT ")",
+                                        p2i(right), p2i(p));
         }
       }
       NOT_PRODUCT(stats.record_scan_obj_cnt(i);)


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338779](https://bugs.openjdk.org/browse/JDK-8338779): GenShen: Prefer log_develop_debug in performance critical code (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/94.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/94.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/94#issuecomment-2353620187)