### PR TITLE
8338763: GenShen: Global GC should not swap remembered sets for the verifier

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -617,11 +617,8 @@ void ShenandoahConcurrentGC::op_init_mark() {
 
 
   if (heap->mode()->is_generational()) {
-    if (_generation->is_young() || (_generation->is_global() && ShenandoahVerify)) {
-      // The current implementation of swap_remembered_set() copies the write-card-table
-      // to the read-card-table. The remembered sets are also swapped for GLOBAL collections
-      // so that the verifier works with the correct copy of the card table when verifying.
-      // TODO: This path should not really depend on ShenandoahVerify.
+    if (_generation->is_young()) {
+      // The current implementation of swap_remembered_set() copies the write-card-table to the read-card-table.
       ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_swap_rset);
       _generation->swap_remembered_set();
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -133,10 +133,8 @@ void ShenandoahDegenGC::op_degenerated() {
       heap->set_unload_classes(_generation->heuristics()->can_unload_classes() &&
                                 (!heap->mode()->is_generational() || _generation->is_global()));
 
-      if (heap->mode()->is_generational() &&
-            (_generation->is_young() || (_generation->is_global() && ShenandoahVerify))) {
-        // Swap remembered sets for young, or if the verifier will run during a global collect
-        // TODO: This path should not depend on ShenandoahVerify
+      if (heap->mode()->is_generational() && _generation->is_young()) {
+        // Swap remembered sets for young
         _generation->swap_remembered_set();
       }
 


### PR DESCRIPTION
Clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338763](https://bugs.openjdk.org/browse/JDK-8338763): GenShen: Global GC should not swap remembered sets for the verifier (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/96.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/96.diff</a>

</details>
