### PR TITLE
8338881: GenShen: Use explicit third temp register for post barrier

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -441,7 +441,7 @@ void ShenandoahBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet 
     }
     BarrierSetAssembler::store_at(masm, decorators, type, Address(tmp3, 0), val, noreg, noreg, noreg);
     if (ShenandoahCardBarrier) {
-      store_check(masm, r3);
+      store_check(masm, tmp3);
     }
   }
 


### PR DESCRIPTION
Conflict with IU barrier support in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8338881](https://bugs.openjdk.org/browse/JDK-8338881): GenShen: Use explicit third temp register for post barrier (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/97.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/97.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/97#issuecomment-2353803442)