### PR TITLE
8339094: Shenandoah: Fix up test output from ShenandoahNumberSeqTest

### DIFF
--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
@@ -55,9 +55,9 @@ class ShenandoahNumberSeqTest: public ::testing::Test {
   void print(HdrSeq& seq, const char* msg) {
     std::cout << "[";
     for (int i = 0; i <= 100; i += 10) {
-      std::cout << "\t" << seq.percentile(i);
+      std::cout << "\t p" << i << ":" << seq.percentile(i);
     }
-    std::cout << " ] : " << msg << "\n";
+    std::cout << "\t] : " << msg << "\n";
   }
 };
 


### PR DESCRIPTION
Clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339094](https://bugs.openjdk.org/browse/JDK-8339094): Shenandoah: Fix up test output from ShenandoahNumberSeqTest (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/98.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/98.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/98#issuecomment-2354057986)