### PR TITLE
8339346: GenShen: Remove even more stale TODOs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCardTable.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCardTable.hpp
@@ -68,11 +68,6 @@ public:
 
   size_t last_valid_index();
 
-  void clear_read_table();
-
-  // Exchange the roles of the read and write card tables.
-  void swap_card_tables();
-
   CardValue* read_byte_map() {
     return _read_byte_map;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -124,7 +124,6 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
 
     // Concurrent remembered set scanning
     entry_scan_remembered_set();
-    // TODO: When RS scanning yields, we will need a check_cancellation_and_abort() degeneration point here.
 
     // Concurrent mark roots
     entry_mark_roots();
@@ -746,7 +745,6 @@ void ShenandoahConcurrentGC::op_final_mark() {
         heap->verifier()->verify_before_evacuation();
       }
 
-      // TODO: Do we need to set this if we are only promoting regions in place? We don't need the barriers on for that.
       heap->set_evacuation_in_progress(true);
 
       // Verify before arming for concurrent processing.

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -1170,13 +1170,6 @@ void ShenandoahFullGC::phase5_epilog() {
 
     // We also do not expand old generation size following Full GC because we have scrambled age populations and
     // no longer have objects separated by age into distinct regions.
-
-    // TODO: Do we need to fix FullGC so that it maintains aged segregation of objects into distinct regions?
-    //       A partial solution would be to remember how many objects are of tenure age following Full GC, but
-    //       this is probably suboptimal, because most of these objects will not reside in a region that will be
-    //       selected for the next evacuation phase.
-
-
     if (heap->mode()->is_generational()) {
       ShenandoahGenerationalFullGC::compute_balances();
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -128,13 +128,6 @@ void ShenandoahGenerationalControlThread::run_service() {
         policy->record_alloc_failure_to_degenerated(degen_point);
         set_gc_mode(stw_degenerated);
       } else {
-        // TODO: if humongous_alloc_failure_pending, there might be value in trying a "compacting" degen before
-        // going all the way to full.  But it's a lot of work to implement this, and it may not provide value.
-        // A compacting degen can move young regions around without doing full old-gen mark (relying upon the
-        // remembered set scan), so it might be faster than a full gc.
-        //
-        // Longer term, think about how to defragment humongous memory concurrently.
-
         heuristics->record_allocation_failure_gc();
         policy->record_alloc_failure_to_full();
         generation = GLOBAL;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
@@ -154,7 +154,6 @@ void ShenandoahGenerationalEvacuationTask::promote_in_place(ShenandoahHeapRegion
   scanner->reset_object_range(region->bottom(), region->end());
   scanner->mark_range_as_dirty(region->bottom(), region->get_top_before_promote() - region->bottom());
 
-  // TODO: use an existing coalesce-and-fill function rather than replicating the code here.
   HeapWord* obj_addr = region->bottom();
   while (obj_addr < tams) {
     oop obj = cast_to_oop(obj_addr);
@@ -223,12 +222,6 @@ void ShenandoahGenerationalEvacuationTask::promote_humongous(ShenandoahHeapRegio
   assert(region->age() >= _tenuring_threshold, "Only promote regions that are sufficiently aged");
   assert(marking_context->is_marked(obj), "promoted humongous object should be alive");
 
-  // TODO: Consider not promoting humongous objects that represent primitive arrays.  Leaving a primitive array
-  // (obj->is_typeArray()) in young-gen is harmless because these objects are never relocated and they are not
-  // scanned.  Leaving primitive arrays in young-gen memory allows their memory to be reclaimed more quickly when
-  // it becomes garbage.  Better to not make this change until sizes of young-gen and old-gen are completely
-  // adaptive, as leaving primitive arrays in young-gen might be perceived as an "astonishing result" by someone
-  // has carefully analyzed the required sizes of an application's young-gen and old-gen.
   const size_t used_bytes = obj->size() * HeapWordSize;
   const size_t spanned_regions = ShenandoahHeapRegion::required_regions(used_bytes);
   const size_t humongous_waste = spanned_regions * ShenandoahHeapRegion::region_size_bytes() - obj->size() * HeapWordSize;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -50,8 +50,7 @@ public:
   bool contains(ShenandoahHeapRegion* region) const override;
 
   bool contains(oop obj) const override {
-    // TODO: Should this assert is_in()?
-    return true;
+    return ShenandoahHeap::heap()->is_in_reserved(obj);
   }
 
   void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl) override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1002,8 +1002,6 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
       // Stop retrying and return nullptr to cause OOMError exception if our allocation failed even after:
       //   a) We experienced a GC that had good progress, or
       //   b) We experienced at least one Full GC (whether or not it had good progress)
-      //
-      // TODO: Consider GLOBAL GC rather than Full GC to remediate OOM condition: https://bugs.openjdk.org/browse/JDK-8335910
 
       size_t original_count = shenandoah_policy()->full_gc_count();
       while ((result == nullptr) && (original_count == shenandoah_policy()->full_gc_count())) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -862,8 +862,6 @@ void ShenandoahHeapRegion::set_affiliation(ShenandoahAffiliation new_affiliation
       reset_age();
       break;
     case OLD_GENERATION:
-      // TODO: should we reset_age() for OLD as well?  Examine invocations of set_affiliation(). Some contexts redundantly
-      //       invoke reset_age().
       break;
     default:
       ShouldNotReachHere();

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.hpp
@@ -61,16 +61,15 @@ public:
   inline bool mark_weak(oop obj);
 
   // Simple versions of marking accessors, to be used outside of marking (e.g. no possible concurrent updates)
-  // TODO: Do these really need to be const?
-  inline bool is_marked(const oop) const;
-  inline bool is_marked_strong(const oop obj) const;
-  inline bool is_marked_weak(const oop obj) const;
-  inline bool is_marked_or_old(const oop obj) const;
-  inline bool is_marked_strong_or_old(const oop obj) const;
+  inline bool is_marked(oop) const;
+  inline bool is_marked_strong(oop obj) const;
+  inline bool is_marked_weak(oop obj) const;
+  inline bool is_marked_or_old(oop obj) const;
+  inline bool is_marked_strong_or_old(oop obj) const;
 
   inline HeapWord* get_next_marked_addr(const HeapWord* addr, const HeapWord* limit) const;
 
-  inline bool allocated_after_mark_start(const oop obj) const;
+  inline bool allocated_after_mark_start(oop obj) const;
   inline bool allocated_after_mark_start(const HeapWord* addr) const;
 
   inline HeapWord* top_at_mark_start(const ShenandoahHeapRegion* r) const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
@@ -38,23 +38,23 @@ inline bool ShenandoahMarkingContext::mark_weak(oop obj) {
   return !allocated_after_mark_start(obj) && _mark_bit_map.mark_weak(cast_from_oop<HeapWord *>(obj));
 }
 
-inline bool ShenandoahMarkingContext::is_marked(const oop obj) const {
+inline bool ShenandoahMarkingContext::is_marked(oop obj) const {
   return allocated_after_mark_start(obj) || _mark_bit_map.is_marked(cast_from_oop<HeapWord *>(obj));
 }
 
-inline bool ShenandoahMarkingContext::is_marked_strong(const oop obj) const {
+inline bool ShenandoahMarkingContext::is_marked_strong(oop obj) const {
   return allocated_after_mark_start(obj) || _mark_bit_map.is_marked_strong(cast_from_oop<HeapWord*>(obj));
 }
 
-inline bool ShenandoahMarkingContext::is_marked_weak(const oop obj) const {
+inline bool ShenandoahMarkingContext::is_marked_weak(oop obj) const {
   return allocated_after_mark_start(obj) || _mark_bit_map.is_marked_weak(cast_from_oop<HeapWord *>(obj));
 }
 
-inline bool ShenandoahMarkingContext::is_marked_or_old(const oop obj) const {
+inline bool ShenandoahMarkingContext::is_marked_or_old(oop obj) const {
   return is_marked(obj) || ShenandoahHeap::heap()->is_old(obj);
 }
 
-inline bool ShenandoahMarkingContext::is_marked_strong_or_old(const oop obj) const {
+inline bool ShenandoahMarkingContext::is_marked_strong_or_old(oop obj) const {
   return is_marked_strong(obj) || ShenandoahHeap::heap()->is_old(obj);
 }
 
@@ -62,7 +62,7 @@ inline HeapWord* ShenandoahMarkingContext::get_next_marked_addr(const HeapWord* 
   return _mark_bit_map.get_next_marked_addr(start, limit);
 }
 
-inline bool ShenandoahMarkingContext::allocated_after_mark_start(const oop obj) const {
+inline bool ShenandoahMarkingContext::allocated_after_mark_start(oop obj) const {
   const HeapWord* addr = cast_from_oop<HeapWord*>(obj);
   return allocated_after_mark_start(addr);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -143,7 +143,6 @@ void ShenandoahMmuTracker::record_mixed(size_t gcid) {
 void ShenandoahMmuTracker::record_degenerated(size_t gcid, bool is_old_bootstrap) {
   if ((gcid == _most_recent_gcid) && _most_recent_is_full) {
     // Do nothing.  This is a redundant recording for the full gc that just completed.
-    // TODO: avoid making the call to record_degenerated() in the case that this degenerated upgraded to full gc.
   } else if (is_old_bootstrap) {
     update_utilization(gcid, "Degenerated Bootstrap Old GC");
   } else {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -136,15 +136,6 @@ bool ShenandoahOldGC::collect(GCCause::Cause cause) {
     heap->free_set()->log_status();
   }
 
-
-  // TODO: Old marking doesn't support class unloading yet
-  // Perform concurrent class unloading
-  // if (heap->unload_classes() &&
-  //     heap->is_concurrent_weak_root_in_progress()) {
-  //   entry_class_unloading();
-  // }
-
-
   assert(!heap->is_concurrent_strong_root_in_progress(), "No evacuations during old gc.");
 
   // We must execute this vm operation if we completed final mark. We cannot

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -171,8 +171,6 @@ void ShenandoahScanRemembered::process_clusters(size_t first_cluster, size_t cou
       // process a new dirty range on the object. This is always
       // the case for large object arrays, which are typically more
       // common.
-      // TODO: It is worthwhile to memoize this, so as to avoid that
-      // overhead, and it is easy to do, but deferred to a follow-up.
       HeapWord* p = _scc->block_start(dirty_l);
       oop obj = cast_to_oop(p);
 


### PR DESCRIPTION
Clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339346](https://bugs.openjdk.org/browse/JDK-8339346): GenShen: Remove even more stale TODOs (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/100.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/100.diff</a>

</details>
