### PR TITLE
8339870: Remove yet more stale TODOs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -700,32 +700,10 @@ void ShenandoahConcurrentGC::op_final_mark() {
     // Notify JVMTI that the tagmap table will need cleaning.
     JvmtiTagMap::set_needs_cleaning();
 
-    // The collection set is chosen by prepare_regions_and_collection_set().
-    //
-    // TODO: Under severe memory overload conditions that can be checked here, we may want to limit
-    // the inclusion of old-gen candidates within the collection set.  This would allow us to prioritize efforts on
-    // evacuating young-gen,  This remediation is most appropriate when old-gen availability is very high (so there
-    // are negligible negative impacts from delaying completion of old-gen evacuation) and when young-gen collections
-    // are "under duress" (as signalled by very low availability of memory within young-gen, indicating that/ young-gen
-    // collections are not triggering frequently enough).
+    // The collection set is chosen by prepare_regions_and_collection_set(). Additionally, certain parameters have been
+    // established to govern the evacuation efforts that are about to begin.  Refer to comments on reserve members in
+    // ShenandoahGeneration and ShenandoahOldGeneration for more detail.
     _generation->prepare_regions_and_collection_set(true /*concurrent*/);
-
-    // Upon return from prepare_regions_and_collection_set(), certain parameters have been established to govern the
-    // evacuation efforts that are about to begin.  In particular:
-    //
-    // heap->get_promoted_reserve() represents the amount of memory within old-gen's available memory that has
-    //   been set aside to hold objects promoted from young-gen memory.  This represents an estimated percentage
-    //   of the live young-gen memory within the collection set.  If there is more data ready to be promoted than
-    //   can fit within this reserve, the promotion of some objects will be deferred until a subsequent evacuation
-    //   pass.
-    //
-    // heap->get_old_evac_reserve() represents the amount of memory within old-gen's available memory that has been
-    //  set aside to hold objects evacuated from the old-gen collection set.
-    //
-    // heap->get_young_evac_reserve() represents the amount of memory within young-gen's available memory that has
-    //  been set aside to hold objects evacuated from the young-gen collection set.  Conservatively, this value
-    //  equals the entire amount of live young-gen memory within the collection set, even though some of this memory
-    //  will likely be promoted.
 
     // Has to be done after cset selection
     heap->prepare_concurrent_roots();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -875,14 +875,6 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
       // allocation request is for evacuation or promotion.  Individual threads limit their use of PLAB memory for
       // promotions, so we already have an assurance that any additional memory set aside for old-gen will be used
       // only for old-gen evacuations.
-
-      // TODO:
-      // if (GC is idle (out of cycle) and mutator allocation fails and there is memory reserved in Collector
-      // or OldCollector sets, transfer a region of memory so that we can satisfy the allocation request, and
-      // immediately trigger the start of GC.  Is better to satisfy the allocation than to trigger out-of-cycle
-      // allocation failure (even if this means we have a little less memory to handle evacuations during the
-      // subsequent GC pass).
-
       if (allow_new_region) {
         // Try to steal an empty region from the mutator view.
         idx_t rightmost_mutator = _partitions.rightmost_empty(ShenandoahFreeSetPartitionId::Mutator);
@@ -1070,10 +1062,6 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       // For GC allocations, we advance update_watermark because the objects relocated into this memory during
       // evacuation are not updated during evacuation.  For both young and old regions r, it is essential that all
       // PLABs be made parsable at the end of evacuation.  This is enabled by retiring all plabs at end of evacuation.
-      // TODO: Making a PLAB parsable involves placing a filler object in its remnant memory but does not require
-      // that the PLAB be disabled for all future purposes.  We may want to introduce a new service to make the
-      // PLABs parsable while still allowing the PLAB to serve future allocation requests that arise during the
-      // next evacuation pass.
       r->set_update_watermark(r->top());
       if (r->is_old()) {
         _partitions.increase_used(ShenandoahFreeSetPartitionId::OldCollector, req.actual_size() * HeapWordSize);
@@ -1739,9 +1727,6 @@ void ShenandoahFreeSet::establish_old_collector_alloc_bias() {
   // Densely packing regions reduces the effort to search for a region that has sufficient memory to satisfy a new allocation
   // request.  Regions become sparsely distributed following a Full GC, which tends to slide all regions to the front of the
   // heap rather than allowing survivor regions to remain at the high end of the heap where we intend for them to congregate.
-
-  // TODO: In the future, we may modify Full GC so that it slides old objects to the end of the heap and young objects to the
-  // front of the heap. If this is done, we can always search survivor Collector and OldCollector regions right to left.
   _partitions.set_bias_from_left_to_right(ShenandoahFreeSetPartitionId::OldCollector,
                                           (available_in_second_half > available_in_first_half));
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -729,11 +729,6 @@ void ShenandoahFullGC::distribute_slices(ShenandoahHeapRegionSet** worker_slices
 #endif
 }
 
-// TODO:
-//  Consider compacting old-gen objects toward the high end of memory and young-gen objects towards the low-end
-//  of memory.  As currently implemented, all regions are compacted toward the low-end of memory.  This creates more
-//  fragmentation of the heap, because old-gen regions get scattered among low-address regions such that it becomes
-//  more difficult to find contiguous regions for humongous objects.
 void ShenandoahFullGC::phase2_calculate_target_addresses(ShenandoahHeapRegionSet** worker_slices) {
   GCTraceTime(Info, gc, phases) time("Phase 2: Compute new object addresses", _gc_timer);
   ShenandoahGCPhase calculate_address_phase(ShenandoahPhaseTimings::full_gc_calculate_addresses);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
@@ -96,8 +96,8 @@ void ShenandoahGenerationalFullGC::rebuild_remembered_set(ShenandoahHeap* heap) 
   // Rebuilding the remembered set recomputes all the card offsets for objects.
   // The adjust pointers phase coalesces and fills all necessary regions. In case
   // we came to the full GC from an incomplete global cycle, we need to indicate
-  // that the old regions are parseable.
-  heap->old_generation()->set_parseable(true);
+  // that the old regions are parsable.
+  heap->old_generation()->set_parsable(true);
 }
 
 void ShenandoahGenerationalFullGC::balance_generations_after_gc(ShenandoahHeap* heap) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -733,7 +733,7 @@ void ShenandoahGenerationalHeap::coalesce_and_fill_old_regions(bool concurrent) 
   // This is not cancellable
   ShenandoahGlobalCoalesceAndFill coalesce(phase);
   workers()->run_task(&coalesce);
-  old_generation()->set_parseable(true);
+  old_generation()->set_parsable(true);
 }
 
 template<bool CONCURRENT>
@@ -1065,14 +1065,14 @@ void ShenandoahGenerationalHeap::complete_degenerated_cycle() {
   // transient state. Otherwise, these actions have no effect.
   reset_generation_reserves();
 
-  if (!old_generation()->is_parseable()) {
+  if (!old_generation()->is_parsable()) {
     ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_coalesce_and_fill);
     coalesce_and_fill_old_regions(false);
   }
 }
 
 void ShenandoahGenerationalHeap::complete_concurrent_cycle() {
-  if (!old_generation()->is_parseable()) {
+  if (!old_generation()->is_parsable()) {
     // Class unloading may render the card offsets unusable, so we must rebuild them before
     // the next remembered set scan. We _could_ let the control thread do this sometime after
     // the global cycle has completed and before the next young collection, but under memory

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1928,7 +1928,7 @@ void ShenandoahHeap::recycle_trash() {
 void ShenandoahHeap::do_class_unloading() {
   _unloader.unload();
   if (mode()->is_generational()) {
-    old_generation()->set_parseable(false);
+    old_generation()->set_parsable(false);
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -54,6 +54,8 @@ private:
 
   // Bytes reserved within old-gen to hold the results of promotion. This is separate from
   // and in addition to the evacuation reserve for intra-generation evacuations (ShenandoahGeneration::_evacuation_reserve).
+  // If there is more data ready to be promoted than can fit within this reserve, the promotion of some objects will be
+  // deferred until a subsequent evacuation pass.
   size_t _promoted_reserve;
 
   // Bytes of old-gen memory expended on promotions. This may be modified concurrently
@@ -81,7 +83,7 @@ private:
   size_t _promotable_regular_regions;
 
   // True if old regions may be safely traversed by the remembered set scan.
-  bool _is_parseable;
+  bool _is_parsable;
 
   bool coalesce_and_fill();
 
@@ -149,8 +151,8 @@ public:
   bool has_in_place_promotions() const { return (_promotable_humongous_regions + _promotable_regular_regions) > 0; }
 
   // Class unloading may render the card table offsets unusable, if they refer to unmarked objects
-  bool is_parseable() const   { return _is_parseable; }
-  void set_parseable(bool parseable);
+  bool is_parsable() const   { return _is_parsable; }
+  void set_parsable(bool parsable);
 
   // This will signal the heuristic to trigger an old generation collection
   void handle_failed_transfer();

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -82,19 +82,25 @@ void ShenandoahDirectCardMarkRememberedSet::mark_range_as_clean(size_t card_inde
   }
 }
 
-bool ShenandoahDirectCardMarkRememberedSet::is_card_dirty(HeapWord *p) const {
+bool ShenandoahDirectCardMarkRememberedSet::is_card_dirty(HeapWord* p) const {
   size_t index = card_index_for_addr(p);
   CardValue* bp = &(_card_table->read_byte_map())[index];
   return (bp[0] == CardTable::dirty_card_val());
 }
 
-void ShenandoahDirectCardMarkRememberedSet::mark_card_as_dirty(HeapWord *p) {
+bool ShenandoahDirectCardMarkRememberedSet::is_write_card_dirty(HeapWord* p) const {
+  size_t index = card_index_for_addr(p);
+  CardValue* bp = &(_card_table->write_byte_map())[index];
+  return (bp[0] == CardTable::dirty_card_val());
+}
+
+void ShenandoahDirectCardMarkRememberedSet::mark_card_as_dirty(HeapWord* p) {
   size_t index = card_index_for_addr(p);
   CardValue* bp = &(_card_table->write_byte_map())[index];
   bp[0] = CardTable::dirty_card_val();
 }
 
-void ShenandoahDirectCardMarkRememberedSet::mark_range_as_dirty(HeapWord *p, size_t num_heap_words) {
+void ShenandoahDirectCardMarkRememberedSet::mark_range_as_dirty(HeapWord* p, size_t num_heap_words) {
   CardValue* bp = &(_card_table->write_byte_map_base())[uintptr_t(p) >> _card_shift];
   CardValue* end_bp = &(_card_table->write_byte_map_base())[uintptr_t(p + num_heap_words) >> _card_shift];
   // If (p + num_heap_words) is not aligned on card boundary, we also need to dirty last card.
@@ -106,13 +112,13 @@ void ShenandoahDirectCardMarkRememberedSet::mark_range_as_dirty(HeapWord *p, siz
   }
 }
 
-void ShenandoahDirectCardMarkRememberedSet::mark_card_as_clean(HeapWord *p) {
+void ShenandoahDirectCardMarkRememberedSet::mark_card_as_clean(HeapWord* p) {
   size_t index = card_index_for_addr(p);
   CardValue* bp = &(_card_table->write_byte_map())[index];
   bp[0] = CardTable::clean_card_val();
 }
 
-void ShenandoahDirectCardMarkRememberedSet::mark_range_as_clean(HeapWord *p, size_t num_heap_words) {
+void ShenandoahDirectCardMarkRememberedSet::mark_range_as_clean(HeapWord* p, size_t num_heap_words) {
   CardValue* bp = &(_card_table->write_byte_map_base())[uintptr_t(p) >> _card_shift];
   CardValue* end_bp = &(_card_table->write_byte_map_base())[uintptr_t(p + num_heap_words) >> _card_shift];
   // If (p + num_heap_words) is not aligned on card boundary, we also need to clean last card.
@@ -147,7 +153,7 @@ void ShenandoahCardCluster::register_object(HeapWord* address) {
 
 void ShenandoahCardCluster::register_object_without_lock(HeapWord* address) {
   size_t card_at_start = _rs->card_index_for_addr(address);
-  HeapWord *card_start_address = _rs->addr_for_card_index(card_at_start);
+  HeapWord* card_start_address = _rs->addr_for_card_index(card_at_start);
   uint8_t offset_in_card = address - card_start_address;
 
   if (!starts_object(card_at_start)) {
@@ -165,7 +171,7 @@ void ShenandoahCardCluster::register_object_without_lock(HeapWord* address) {
 void ShenandoahCardCluster::coalesce_objects(HeapWord* address, size_t length_in_words) {
 
   size_t card_at_start = _rs->card_index_for_addr(address);
-  HeapWord *card_start_address = _rs->addr_for_card_index(card_at_start);
+  HeapWord* card_start_address = _rs->addr_for_card_index(card_at_start);
   size_t card_at_end = card_at_start + ((address + length_in_words) - card_start_address) / CardTable::card_size_in_words();
 
   if (card_at_start == card_at_end) {
@@ -291,7 +297,7 @@ HeapWord* ShenandoahCardCluster::block_start(const size_t card_index) const {
   return p;
 }
 
-size_t ShenandoahScanRemembered::card_index_for_addr(HeapWord *p) {
+size_t ShenandoahScanRemembered::card_index_for_addr(HeapWord* p) {
   return _rs->card_index_for_addr(p);
 }
 
@@ -307,35 +313,39 @@ bool ShenandoahScanRemembered::is_write_card_dirty(size_t card_index) {
   return _rs->is_write_card_dirty(card_index);
 }
 
-bool ShenandoahScanRemembered::is_card_dirty(HeapWord *p) {
+bool ShenandoahScanRemembered::is_card_dirty(HeapWord* p) {
   return _rs->is_card_dirty(p);
 }
 
-void ShenandoahScanRemembered::mark_card_as_dirty(HeapWord *p) {
+void ShenandoahScanRemembered::mark_card_as_dirty(HeapWord* p) {
   _rs->mark_card_as_dirty(p);
 }
 
-void ShenandoahScanRemembered::mark_range_as_dirty(HeapWord *p, size_t num_heap_words) {
+bool ShenandoahScanRemembered::is_write_card_dirty(HeapWord* p) {
+  return _rs->is_write_card_dirty(p);
+}
+
+void ShenandoahScanRemembered::mark_range_as_dirty(HeapWord* p, size_t num_heap_words) {
   _rs->mark_range_as_dirty(p, num_heap_words);
 }
 
-void ShenandoahScanRemembered::mark_card_as_clean(HeapWord *p) {
+void ShenandoahScanRemembered::mark_card_as_clean(HeapWord* p) {
   _rs->mark_card_as_clean(p);
 }
 
-void ShenandoahScanRemembered:: mark_range_as_clean(HeapWord *p, size_t num_heap_words) {
+void ShenandoahScanRemembered:: mark_range_as_clean(HeapWord* p, size_t num_heap_words) {
   _rs->mark_range_as_clean(p, num_heap_words);
 }
 
-void ShenandoahScanRemembered::reset_object_range(HeapWord *from, HeapWord *to) {
+void ShenandoahScanRemembered::reset_object_range(HeapWord* from, HeapWord* to) {
   _scc->reset_object_range(from, to);
 }
 
-void ShenandoahScanRemembered::register_object(HeapWord *addr) {
+void ShenandoahScanRemembered::register_object(HeapWord* addr) {
   _scc->register_object(addr);
 }
 
-void ShenandoahScanRemembered::register_object_without_lock(HeapWord *addr) {
+void ShenandoahScanRemembered::register_object_without_lock(HeapWord* addr) {
   _scc->register_object_without_lock(addr);
 }
 
@@ -443,11 +453,11 @@ bool ShenandoahScanRemembered::verify_registration(HeapWord* address, Shenandoah
   return true;
 }
 
-void ShenandoahScanRemembered::coalesce_objects(HeapWord *addr, size_t length_in_words) {
+void ShenandoahScanRemembered::coalesce_objects(HeapWord* addr, size_t length_in_words) {
   _scc->coalesce_objects(addr, length_in_words);
 }
 
-void ShenandoahScanRemembered::mark_range_as_empty(HeapWord *addr, size_t length_in_words) {
+void ShenandoahScanRemembered::mark_range_as_empty(HeapWord* addr, size_t length_in_words) {
   _rs->mark_range_as_clean(addr, length_in_words);
   _scc->clear_objects_in_range(addr, length_in_words);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
@@ -59,6 +59,5 @@ ShenandoahThreadLocalData::~ShenandoahThreadLocalData() {
     delete _plab;
   }
 
-  // TODO: Preserve these stats somewhere for mutator threads.
   delete _evacuation_stats;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -120,9 +120,6 @@ private:
       //
       // For performance reasons, only fully verify non-marked field values.
       // We are here when the host object for *p is already marked.
-
-      // TODO: We should consider specializing this closure by generation ==/!= null,
-      // to avoid in_generation check on fast path here for non-generational mode.
       if (in_generation(obj) && _map->par_mark(obj)) {
         verify_oop_at(p, obj);
         _stack->push(ShenandoahVerifierTask(obj));
@@ -240,29 +237,21 @@ private:
     }
 
     // ------------ obj and fwd are safe at this point --------------
-    // We allow for marked or old here for two reasons:
-    //  1. If this is a young collect, old objects wouldn't be marked. We've
-    //     recently change the verifier traversal to only follow young objects
-    //     during a young collect so this _shouldn't_ be necessary.
-    //  2. At present, we do not clear dead objects from the remembered set.
-    //     Everything in the remembered set is old (ipso facto), so allowing for
-    //     'marked_or_old' covers the case of stale objects in rset.
-    // TODO: Just use 'is_marked' here.
     switch (_options._verify_marked) {
       case ShenandoahVerifier::_verify_marked_disable:
         // skip
         break;
       case ShenandoahVerifier::_verify_marked_incomplete:
-        check(ShenandoahAsserts::_safe_all, obj, _heap->marking_context()->is_marked_or_old(obj),
+        check(ShenandoahAsserts::_safe_all, obj, _heap->marking_context()->is_marked(obj),
                "Must be marked in incomplete bitmap");
         break;
       case ShenandoahVerifier::_verify_marked_complete:
-        check(ShenandoahAsserts::_safe_all, obj, _heap->complete_marking_context()->is_marked_or_old(obj),
+        check(ShenandoahAsserts::_safe_all, obj, _heap->complete_marking_context()->is_marked(obj),
                "Must be marked in complete bitmap");
         break;
       case ShenandoahVerifier::_verify_marked_complete_except_references:
       case ShenandoahVerifier::_verify_marked_complete_satb_empty:
-        check(ShenandoahAsserts::_safe_all, obj, _heap->complete_marking_context()->is_marked_or_old(obj),
+        check(ShenandoahAsserts::_safe_all, obj, _heap->complete_marking_context()->is_marked(obj),
               "Must be marked in complete bitmap, except j.l.r.Reference referents");
         break;
       default:
@@ -1199,8 +1188,7 @@ void ShenandoahVerifier::verify_after_fullgc() {
   );
 }
 
-// TODO: Why this closure does not visit metadata?
-class ShenandoahVerifyNoForwared : public BasicOopIterateClosure {
+class ShenandoahVerifyNoForwarded : public BasicOopIterateClosure {
 private:
   template <class T>
   void do_oop_work(T* p) {
@@ -1220,7 +1208,6 @@ public:
   void do_oop(oop* p)       { do_oop_work(p); }
 };
 
-// TODO: Why this closure does not visit metadata?
 class ShenandoahVerifyInToSpaceClosure : public BasicOopIterateClosure {
 private:
   template <class T>
@@ -1259,37 +1246,32 @@ void ShenandoahVerifier::verify_roots_in_to_space() {
 }
 
 void ShenandoahVerifier::verify_roots_no_forwarded() {
-  ShenandoahVerifyNoForwared cl;
+  ShenandoahVerifyNoForwarded cl;
   ShenandoahRootVerifier::roots_do(&cl);
 }
 
+template<typename Scanner>
 class ShenandoahVerifyRemSetClosure : public BasicOopIterateClosure {
 protected:
-  bool                        const _init_mark;
   ShenandoahGenerationalHeap* const _heap;
-  ShenandoahScanRemembered*   const _scanner;
+  Scanner*   const _scanner;
+  const char* _message;
 
 public:
   // Argument distinguishes between initial mark or start of update refs verification.
-  explicit ShenandoahVerifyRemSetClosure(bool init_mark) :
-            _init_mark(init_mark),
+  explicit ShenandoahVerifyRemSetClosure(Scanner* scanner, const char* message) :
             _heap(ShenandoahGenerationalHeap::heap()),
-            _scanner(_heap->old_generation()->card_scan()) {}
+            _scanner(scanner),
+            _message(message) {}
 
   template<class T>
   inline void work(T* p) {
     T o = RawAccess<>::oop_load(p);
     if (!CompressedOops::is_null(o)) {
       oop obj = CompressedOops::decode_not_null(o);
-      if (_heap->is_in_young(obj)) {
-        size_t card_index = _scanner->card_index_for_addr((HeapWord*) p);
-        if (_init_mark && !_scanner->is_card_dirty(card_index)) {
-          ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, p, nullptr,
-                                           "Verify init-mark remembered set violation", "clean card should be dirty", __FILE__, __LINE__);
-        } else if (!_init_mark && !_scanner->is_write_card_dirty(card_index)) {
-          ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, p, nullptr,
-                                           "Verify init-update-refs remembered set violation", "clean card should be dirty", __FILE__, __LINE__);
-        }
+      if (_heap->is_in_young(obj) && !_scanner->is_card_dirty((HeapWord*) p)) {
+        ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, p, nullptr,
+                                         _message, "clean card should be dirty", __FILE__, __LINE__);
       }
     }
   }
@@ -1298,20 +1280,27 @@ public:
   void do_oop(oop* p)       override { work(p); }
 };
 
-void ShenandoahVerifier::help_verify_region_rem_set(ShenandoahHeapRegion* r, ShenandoahMarkingContext* ctx, HeapWord* from,
-                                                    HeapWord* top, HeapWord* registration_watermark, const char* message) {
-  ShenandoahScanRemembered* scanner = ShenandoahGenerationalHeap::heap()->old_generation()->card_scan();
-  ShenandoahVerifyRemSetClosure check_interesting_pointers(false);
+ShenandoahMarkingContext* ShenandoahVerifier::get_marking_context_for_old() {
+  shenandoah_assert_generations_reconciled();
+  if (_heap->old_generation()->is_mark_complete() || _heap->gc_generation()->is_global()) {
+    return _heap->complete_marking_context();
+  }
+  return nullptr;
+}
 
+template<typename Scanner>
+void ShenandoahVerifier::help_verify_region_rem_set(Scanner* scanner, ShenandoahHeapRegion* r, ShenandoahMarkingContext* ctx,
+                                                    HeapWord* registration_watermark, const char* message) {
+  ShenandoahVerifyRemSetClosure<Scanner> check_interesting_pointers(scanner, message);
+  HeapWord* from = r->bottom();
   HeapWord* obj_addr = from;
   if (r->is_humongous_start()) {
     oop obj = cast_to_oop(obj_addr);
     if ((ctx == nullptr) || ctx->is_marked(obj)) {
-      size_t card_index = scanner->card_index_for_addr(obj_addr);
       // For humongous objects, the typical object is an array, so the following checks may be overkill
       // For regular objects (not object arrays), if the card holding the start of the object is dirty,
       // we do not need to verify that cards spanning interesting pointers within this object are dirty.
-      if (!scanner->is_write_card_dirty(card_index) || obj->is_objArray()) {
+      if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
         obj->oop_iterate(&check_interesting_pointers);
       }
       // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
@@ -1323,14 +1312,14 @@ void ShenandoahVerifier::help_verify_region_rem_set(ShenandoahHeapRegion* r, She
                                        "object not properly registered", __FILE__, __LINE__);
     }
   } else if (!r->is_humongous()) {
+    HeapWord* top = r->top();
     while (obj_addr < top) {
       oop obj = cast_to_oop(obj_addr);
       // ctx->is_marked() returns true if mark bit set or if obj above TAMS.
       if ((ctx == nullptr) || ctx->is_marked(obj)) {
-        size_t card_index = scanner->card_index_for_addr(obj_addr);
         // For regular objects (not object arrays), if the card holding the start of the object is dirty,
         // we do not need to verify that cards spanning interesting pointers within this object are dirty.
-        if (!scanner->is_write_card_dirty(card_index) || obj->is_objArray()) {
+        if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
           obj->oop_iterate(&check_interesting_pointers);
         }
         // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
@@ -1349,88 +1338,52 @@ void ShenandoahVerifier::help_verify_region_rem_set(ShenandoahHeapRegion* r, She
   }
 }
 
+class ShenandoahWriteTableScanner {
+private:
+  ShenandoahScanRemembered* _scanner;
+public:
+  explicit ShenandoahWriteTableScanner(ShenandoahScanRemembered* scanner) : _scanner(scanner) {}
+
+  bool is_card_dirty(HeapWord* obj_addr) {
+    return _scanner->is_write_card_dirty(obj_addr);
+  }
+
+  bool verify_registration(HeapWord* obj_addr, ShenandoahMarkingContext* ctx) {
+    return _scanner->verify_registration(obj_addr, ctx);
+  }
+};
+
 // Assure that the remember set has a dirty card everywhere there is an interesting pointer.
 // This examines the read_card_table between bottom() and top() since all PLABS are retired
 // before the safepoint for init_mark.  Actually, we retire them before update-references and don't
 // restore them until the start of evacuation.
 void ShenandoahVerifier::verify_rem_set_before_mark() {
   shenandoah_assert_safepoint();
-  assert(_heap->mode()->is_generational(), "Only verify remembered set for generational operational modes");
+  shenandoah_assert_generational();
 
-  ShenandoahScanRemembered* scanner = ShenandoahGenerationalHeap::heap()->old_generation()->card_scan();
-  ShenandoahVerifyRemSetClosure check_interesting_pointers(true);
-  ShenandoahMarkingContext* ctx;
-
+  ShenandoahMarkingContext* ctx = get_marking_context_for_old();
   ShenandoahOldGeneration* old_generation = _heap->old_generation();
+
   log_debug(gc)("Verifying remembered set at %s mark", old_generation->is_doing_mixed_evacuations() ? "mixed" : "young");
 
-  shenandoah_assert_generations_reconciled();
-  if (old_generation->is_mark_complete() || _heap->gc_generation()->is_global()) {
-    ctx = _heap->complete_marking_context();
-  } else {
-    ctx = nullptr;
-  }
-
+  ShenandoahScanRemembered* scanner = old_generation->card_scan();
   for (size_t i = 0, n = _heap->num_regions(); i < n; ++i) {
     ShenandoahHeapRegion* r = _heap->get_region(i);
-    HeapWord* tams = (ctx != nullptr) ? ctx->top_at_mark_start(r) : nullptr;
-
-    // TODO: Is this replaceable with call to help_verify_region_rem_set?
-
     if (r->is_old() && r->is_active()) {
-      HeapWord* obj_addr = r->bottom();
-      if (r->is_humongous_start()) {
-        oop obj = cast_to_oop(obj_addr);
-        if ((ctx == nullptr) || ctx->is_marked(obj)) {
-          // For humongous objects, the typical object is an array, so the following checks may be overkill
-          // For regular objects (not object arrays), if the card holding the start of the object is dirty,
-          // we do not need to verify that cards spanning interesting pointers within this object are dirty.
-          if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
-            obj->oop_iterate(&check_interesting_pointers);
-          }
-          // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
-        }
-        // else, this humongous object is not marked so no need to verify its internal pointers
-        if (!scanner->verify_registration(obj_addr, ctx)) {
-          ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, nullptr, nullptr,
-                                           "Verify init-mark remembered set violation", "object not properly registered", __FILE__, __LINE__);
-        }
-      } else if (!r->is_humongous()) {
-        HeapWord* top = r->top();
-        while (obj_addr < top) {
-          oop obj = cast_to_oop(obj_addr);
-          // ctx->is_marked() returns true if mark bit set (TAMS not relevant during init mark)
-          if ((ctx == nullptr) || ctx->is_marked(obj)) {
-            // For regular objects (not object arrays), if the card holding the start of the object is dirty,
-            // we do not need to verify that cards spanning interesting pointers within this object are dirty.
-            if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
-              obj->oop_iterate(&check_interesting_pointers);
-            }
-            // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
-            if (!scanner->verify_registration(obj_addr, ctx)) {
-              ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, nullptr, nullptr,
-                                               "Verify init-mark remembered set violation", "object not properly registered", __FILE__, __LINE__);
-            }
-            obj_addr += obj->size();
-          } else {
-            // This object is not live so we don't verify dirty cards contained therein
-            assert(tams != nullptr, "If object is not live, ctx and tams should be non-null");
-            obj_addr = ctx->get_next_marked_addr(obj_addr, tams);
-          }
-        }
-      } // else, we ignore humongous continuation region
-    } // else, this is not an OLD region so we ignore it
-  } // all regions have been processed
+      help_verify_region_rem_set(scanner, r, ctx, r->end(), "Verify init-mark remembered set violation");
+    }
+  }
 }
 
 void ShenandoahVerifier::verify_rem_set_after_full_gc() {
   shenandoah_assert_safepoint();
-  assert(_heap->mode()->is_generational(), "Only verify remembered set for generational operational modes");
+  shenandoah_assert_generational();
 
+  ShenandoahWriteTableScanner scanner(ShenandoahGenerationalHeap::heap()->old_generation()->card_scan());
   for (size_t i = 0, n = _heap->num_regions(); i < n; ++i) {
     ShenandoahHeapRegion* r = _heap->get_region(i);
     if (r->is_old() && !r->is_cset()) {
-      help_verify_region_rem_set(r, nullptr, r->bottom(), r->top(), r->top(), "Remembered set violation at end of Full GC");
+      help_verify_region_rem_set(&scanner, r, nullptr, r->top(), "Remembered set violation at end of Full GC");
     }
   }
 }
@@ -1441,22 +1394,14 @@ void ShenandoahVerifier::verify_rem_set_after_full_gc() {
 // all PLABS are retired immediately before the start of update refs.
 void ShenandoahVerifier::verify_rem_set_before_update_ref() {
   shenandoah_assert_safepoint();
-  assert(_heap->mode()->is_generational(), "Only verify remembered set for generational operational modes");
+  shenandoah_assert_generational();
 
-  ShenandoahMarkingContext* ctx;
-
-  shenandoah_assert_generations_reconciled();
-  if (_heap->old_generation()->is_mark_complete() || _heap->gc_generation()->is_global()) {
-    ctx = _heap->complete_marking_context();
-  } else {
-    ctx = nullptr;
-  }
-
+  ShenandoahMarkingContext* ctx = get_marking_context_for_old();
+  ShenandoahWriteTableScanner scanner(_heap->old_generation()->card_scan());
   for (size_t i = 0, n = _heap->num_regions(); i < n; ++i) {
     ShenandoahHeapRegion* r = _heap->get_region(i);
     if (r->is_old() && !r->is_cset()) {
-      help_verify_region_rem_set(r, ctx, r->bottom(), r->top(), r->get_update_watermark(),
-                                 "Remembered set violation at init-update-references");
+      help_verify_region_rem_set(&scanner, r, ctx, r->get_update_watermark(), "Remembered set violation at init-update-references");
     }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -33,6 +33,7 @@
 #include "utilities/stack.hpp"
 
 class ShenandoahHeap;
+class ShenandoahMarkingContext;
 
 #ifdef _WINDOWS
 #pragma warning( disable : 4522 )
@@ -71,8 +72,8 @@ public:
     _verify_remembered_before_updating_references,
 
     // Old objects should be registered and RS cards within *read-write* RS are dirty for all
-    // inter-generational pointers.
-    // TODO: This differs from the previous mode by update-watermark() vs top() end range?
+    // inter-generational pointers. Differs from previous verification modes by using top instead
+    // of update watermark and not using the marking context.
     _verify_remembered_after_full_gc
   } VerifyRememberedSet;
 
@@ -231,12 +232,15 @@ public:
   // Check that generation usages are accurate before rebuilding free set
   void verify_before_rebuilding_free_set();
 private:
-   void help_verify_region_rem_set(ShenandoahHeapRegion* r, ShenandoahMarkingContext* ctx,
-                                    HeapWord* from, HeapWord* top, HeapWord* update_watermark, const char* message);
+  template<typename Scanner>
+  void help_verify_region_rem_set(Scanner* scanner, ShenandoahHeapRegion* r, ShenandoahMarkingContext* ctx,
+                                  HeapWord* update_watermark, const char* message);
 
   void verify_rem_set_before_mark();
   void verify_rem_set_before_update_ref();
   void verify_rem_set_after_full_gc();
+
+  ShenandoahMarkingContext* get_marking_context_for_old();
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHVERIFIER_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -49,8 +49,7 @@ void ShenandoahYoungGeneration::set_concurrent_mark_in_progress(bool in_progress
 }
 
 bool ShenandoahYoungGeneration::contains(ShenandoahHeapRegion* region) const {
-  // TODO: why not test for equals YOUNG_GENERATION?  As written, returns true for regions that are FREE
-  return !region->is_old();
+  return region->is_young();
 }
 
 void ShenandoahYoungGeneration::parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl) {


### PR DESCRIPTION
Clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339870](https://bugs.openjdk.org/browse/JDK-8339870): Remove yet more stale TODOs (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/102.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/102.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/102#issuecomment-2354141235)