### PR TITLE
8340137: GenShen: Reset mark bitmaps when a region is recycled

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -576,6 +576,10 @@ void ShenandoahHeapRegion::recycle() {
   reset_alloc_metadata();
 
   heap->marking_context()->reset_top_at_mark_start(this);
+  if (heap->is_bitmap_slice_committed(this)) {
+    heap->marking_context()->clear_bitmap(this);
+  }
+
   set_update_watermark(bottom());
 
   make_empty();


### PR DESCRIPTION
Clean back port, critical bug fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340137](https://bugs.openjdk.org/browse/JDK-8340137): GenShen: Reset mark bitmaps when a region is recycled (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/103/head:pull/103` \
`$ git checkout pull/103`

Update a local copy of the PR: \
`$ git checkout pull/103` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 103`

View PR using the GUI difftool: \
`$ git pr show -t 103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/103.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/103.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/103#issuecomment-2354162898)