### PR TITLE
8339616: GenShen: Introduce new state to distinguish promote-in-place phase as distinct from concurrent evacuation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -386,9 +386,7 @@ bool ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_arraycopy
 
 template <class T, bool HAS_FWD, bool EVAC, bool ENQUEUE>
 void ShenandoahBarrierSet::arraycopy_work(T* src, size_t count) {
-  // We allow forwarding in young generation and marking in old generation
-  // to happen simultaneously.
-  assert(_heap->mode()->is_generational() || HAS_FWD == _heap->has_forwarded_objects(), "Forwarded object status is sane");
+  assert(HAS_FWD == _heap->has_forwarded_objects(), "Forwarded object status is sane");
 
   Thread* thread = Thread::current();
   SATBMarkQueue& queue = ShenandoahThreadLocalData::satb_mark_queue(thread);

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -210,9 +210,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_evac)) {
       return false;
     }
-  }
 
-  if (heap->has_forwarded_objects()) {
     // Perform update-refs phase.
     vmop_entry_init_updaterefs();
     entry_updaterefs();
@@ -231,10 +229,23 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     // Update references freed up collection set, kick the cleanup to reclaim the space.
     entry_cleanup_complete();
   } else {
-    // We chose not to evacuate because we found sufficient immediate garbage. Note that we
-    // do not check for cancellation here because, at this point, the cycle is effectively
-    // complete. If the cycle has been cancelled here, the control thread will detect it
-    // on its next iteration and run a degenerated young cycle.
+    // We chose not to evacuate because we found sufficient immediate garbage.
+    // However, there may still be regions to promote in place, so do that now.
+    if (has_in_place_promotions(heap)) {
+      entry_promote_in_place();
+
+      // If the promote-in-place operation was cancelled, we can have the degenerated
+      // cycle complete the operation. It will see that no evacuations are in progress,
+      // and that there are regions wanting promotion. The risk with not handling the
+      // cancellation would be failing to restore top for these regions and leaving
+      // them unable to serve allocations for the old generation.
+      if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_evac)) {
+        return false;
+      }
+    }
+
+    // At this point, the cycle is effectively complete. If the cycle has been cancelled here,
+    // the control thread will detect it on its next iteration and run a degenerated young cycle.
     vmop_entry_final_roots();
     _abbreviated = true;
   }
@@ -529,6 +540,23 @@ void ShenandoahConcurrentGC::entry_evacuate() {
   op_evacuate();
 }
 
+void ShenandoahConcurrentGC::entry_promote_in_place() {
+  shenandoah_assert_generational();
+
+  ShenandoahHeap* const heap = ShenandoahHeap::heap();
+  TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
+
+  static const char* msg = "Promote in place";
+  ShenandoahConcurrentPhase gc_phase(msg, ShenandoahPhaseTimings::promote_in_place);
+  EventMark em("%s", msg);
+
+  ShenandoahWorkerScope scope(heap->workers(),
+                              ShenandoahWorkerPolicy::calc_workers_for_conc_evac(),
+                              "promote in place");
+
+  ShenandoahGenerationalHeap::heap()->promote_regions_in_place(true);
+}
+
 void ShenandoahConcurrentGC::entry_update_thread_roots() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
@@ -708,10 +736,7 @@ void ShenandoahConcurrentGC::op_final_mark() {
     // Has to be done after cset selection
     heap->prepare_concurrent_roots();
 
-    if (!heap->collection_set()->is_empty() || has_in_place_promotions(heap)) {
-      // Even if the collection set is empty, we need to do evacuation if there are regions to be promoted in place.
-      // Concurrent evacuation takes responsibility for registering objects and setting the remembered set cards to dirty.
-
+    if (!heap->collection_set()->is_empty()) {
       LogTarget(Debug, gc, cset) lt;
       if (lt.is_enabled()) {
         ResourceMark rm;
@@ -724,33 +749,23 @@ void ShenandoahConcurrentGC::op_final_mark() {
       }
 
       heap->set_evacuation_in_progress(true);
-
-      // Verify before arming for concurrent processing.
-      // Otherwise, verification can trigger stack processing.
-      if (ShenandoahVerify) {
-        heap->verifier()->verify_during_evacuation();
-      }
-
-      // Generational mode may promote objects in place during the evacuation phase.
-      // If that is the only reason we are evacuating, we don't need to update references
-      // and there will be no forwarded objects on the heap.
-      heap->set_has_forwarded_objects(!heap->collection_set()->is_empty());
+      // From here on, we need to update references.
+      heap->set_has_forwarded_objects(true);
 
       // Arm nmethods/stack for concurrent processing
-      if (!heap->collection_set()->is_empty()) {
-        // Iff objects will be evaluated, arm the nmethod barriers. These will be disarmed
-        // under the same condition (established in prepare_concurrent_roots) after strong
-        // root evacuation has completed (see op_strong_roots).
-        ShenandoahCodeRoots::arm_nmethods_for_evac();
-        ShenandoahStackWatermark::change_epoch_id();
-      }
+      ShenandoahCodeRoots::arm_nmethods_for_evac();
+      ShenandoahStackWatermark::change_epoch_id();
 
       if (ShenandoahPacing) {
         heap->pacer()->setup_for_evac();
       }
     } else {
       if (ShenandoahVerify) {
-        heap->verifier()->verify_after_concmark();
+        if (has_in_place_promotions(heap)) {
+          heap->verifier()->verify_after_concmark_with_promotions();
+        } else {
+          heap->verifier()->verify_after_concmark();
+        }
       }
 
       if (VerifyAfterGC) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -107,6 +107,9 @@ private:
 
   void entry_cleanup_complete();
 
+  // Called when the collection set is empty, but the generational mode has regions to promote in place
+  void entry_promote_in_place();
+
   // Actual work for the phases
   void op_reset();
   void op_init_mark();

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -251,9 +251,13 @@ void ShenandoahDegenGC::op_degenerated() {
           op_degenerated_fail();
           return;
         }
+      } else if (has_in_place_promotions(heap)) {
+        // We have nothing to evacuate, but there are still regions to promote in place.
+        ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_promote_regions);
+        ShenandoahGenerationalHeap::heap()->promote_regions_in_place(false /* concurrent*/);
       }
 
-      // Update collector state regardless of whether or not there are forwarded objects
+      // Update collector state regardless of whether there are forwarded objects
       heap->set_evacuation_in_progress(false);
       heap->set_concurrent_weak_root_in_progress(false);
       heap->set_concurrent_strong_root_in_progress(false);
@@ -349,10 +353,7 @@ void ShenandoahDegenGC::op_prepare_evacuation() {
     heap->tlabs_retire(false);
   }
 
-  if (!heap->collection_set()->is_empty() || has_in_place_promotions(heap)) {
-    // Even if the collection set is empty, we need to do evacuation if there are regions to be promoted in place.
-    // Degenerated evacuation takes responsibility for registering objects and setting the remembered set cards to dirty.
-
+  if (!heap->collection_set()->is_empty()) {
     if (ShenandoahVerify) {
       heap->verifier()->verify_before_evacuation();
     }
@@ -363,10 +364,14 @@ void ShenandoahDegenGC::op_prepare_evacuation() {
       heap->verifier()->verify_during_evacuation();
     }
 
-    heap->set_has_forwarded_objects(!heap->collection_set()->is_empty());
+    heap->set_has_forwarded_objects(true);
   } else {
     if (ShenandoahVerify) {
-      heap->verifier()->verify_after_concmark();
+      if (has_in_place_promotions(heap)) {
+        heap->verifier()->verify_after_concmark_with_promotions();
+      } else {
+        heap->verifier()->verify_after_concmark();
+      }
     }
 
     if (VerifyAfterGC) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.hpp
@@ -38,16 +38,19 @@ private:
   ShenandoahGenerationalHeap* const _heap;
   ShenandoahRegionIterator* _regions;
   bool _concurrent;
+  bool _only_promote_regions;
   uint _tenuring_threshold;
 
 public:
   ShenandoahGenerationalEvacuationTask(ShenandoahGenerationalHeap* sh,
                                        ShenandoahRegionIterator* iterator,
-                                       bool concurrent);
+                                       bool concurrent, bool only_promote_regions);
   void work(uint worker_id) override;
 private:
   void do_work();
-
+  void promote_regions();
+  void evacuate_and_promote_regions();
+  void maybe_promote_region(ShenandoahHeapRegion* region);
   void promote_in_place(ShenandoahHeapRegion* region);
   void promote_humongous(ShenandoahHeapRegion* region);
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -170,6 +170,18 @@ void ShenandoahGenerationalHeap::stop() {
   ShenandoahHeap::stop();
 }
 
+void ShenandoahGenerationalHeap::evacuate_collection_set(bool concurrent) {
+  ShenandoahRegionIterator regions;
+  ShenandoahGenerationalEvacuationTask task(this, &regions, concurrent, false /* only promote regions */);
+  workers()->run_task(&task);
+}
+
+void ShenandoahGenerationalHeap::promote_regions_in_place(bool concurrent) {
+  ShenandoahRegionIterator regions;
+  ShenandoahGenerationalEvacuationTask task(this, &regions, concurrent, true /* only promote regions */);
+  workers()->run_task(&task);
+}
+
 oop ShenandoahGenerationalHeap::evacuate_object(oop p, Thread* thread) {
   assert(thread == Thread::current(), "Expected thread parameter to be current thread.");
   if (ShenandoahThreadLocalData::is_oom_during_evac(thread)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -82,6 +82,8 @@ public:
 
   oop evacuate_object(oop p, Thread* thread) override;
   oop try_evacuate_object(oop p, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahAffiliation target_gen);
+  void evacuate_collection_set(bool concurrent) override;
+  void promote_regions_in_place(bool concurrent);
 
   size_t plab_min_size() const { return _min_plab_size; }
   size_t plab_max_size() const { return _max_plab_size; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1211,14 +1211,8 @@ private:
 };
 
 void ShenandoahHeap::evacuate_collection_set(bool concurrent) {
-  if (mode()->is_generational()) {
-    ShenandoahRegionIterator regions;
-    ShenandoahGenerationalEvacuationTask task(ShenandoahGenerationalHeap::heap(), &regions, concurrent);
-    workers()->run_task(&task);
-  } else {
-    ShenandoahEvacuationTask task(this, _collection_set, concurrent);
-    workers()->run_task(&task);
-  }
+  ShenandoahEvacuationTask task(this, _collection_set, concurrent);
+  workers()->run_task(&task);
 }
 
 oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -469,7 +469,7 @@ protected:
 private:
   // GC support
   // Evacuation
-  void evacuate_collection_set(bool concurrent);
+  virtual void evacuate_collection_set(bool concurrent);
   // Concurrent root processing
   void prepare_concurrent_roots();
   void finish_concurrent_roots();

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -148,7 +148,8 @@ public:
   // See description in field declaration
   void set_expected_humongous_region_promotions(size_t region_count) { _promotable_humongous_regions = region_count; }
   void set_expected_regular_region_promotions(size_t region_count) { _promotable_regular_regions = region_count; }
-  bool has_in_place_promotions() const { return (_promotable_humongous_regions + _promotable_regular_regions) > 0; }
+  size_t get_expected_in_place_promotions() const { return _promotable_humongous_regions + _promotable_regular_regions; }
+  bool has_in_place_promotions() const { return get_expected_in_place_promotions() > 0; }
 
   // Class unloading may render the card table offsets unusable, if they refer to unmarked objects
   bool is_parsable() const   { return _is_parsable; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -103,7 +103,7 @@ class outputStream;
   f(conc_strong_roots,                              "Concurrent Strong Roots")         \
   SHENANDOAH_PAR_PHASE_DO(conc_strong_roots_,       "  CSR: ", f)                      \
   f(conc_evac,                                      "Concurrent Evacuation")           \
-                                                                                       \
+  f(promote_in_place,                               "Concurrent Promote Regions")      \
   f(final_roots_gross,                              "Pause Final Roots (G)")           \
   f(final_roots,                                    "Pause Final Roots (N)")           \
                                                                                        \
@@ -153,6 +153,7 @@ class outputStream;
   f(degen_gc_update_roots,                          "  Degen Update Roots")            \
   SHENANDOAH_PAR_PHASE_DO(degen_gc_update_,         "    DU: ", f)                     \
   f(degen_gc_cleanup_complete,                      "  Cleanup")                       \
+  f(degen_gc_promote_regions,                       "  Degen Promote Regions")         \
   f(degen_gc_coalesce_and_fill,                     "  Degen Coalesce and Fill")       \
   SHENANDOAH_PAR_PHASE_DO(degen_coalesce_,          "    DC&F", f)                     \
                                                                                        \

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -1062,15 +1062,29 @@ void ShenandoahVerifier::verify_before_concmark() {
 void ShenandoahVerifier::verify_after_concmark() {
   verify_at_safepoint(
           "After Mark",
-          _verify_remembered_disable,  // do not verify remembered set
-          _verify_forwarded_none,      // no forwarded references
-          _verify_marked_complete_satb_empty,
-                                       // bitmaps as precise as we can get, except dangling j.l.r.Refs
-          _verify_cset_none,           // no references to cset anymore
-          _verify_liveness_complete,   // liveness data must be complete here
-          _verify_regions_disable,     // trash regions not yet recycled
-          _verify_size_exact,          // expect generation and heap sizes to match exactly
-          _verify_gcstate_stable_weakroots  // heap is still stable, weakroots are in progress
+          _verify_remembered_disable,         // do not verify remembered set
+          _verify_forwarded_none,             // no forwarded references
+          _verify_marked_complete_satb_empty, // bitmaps as precise as we can get, except dangling j.l.r.Refs
+          _verify_cset_none,                  // no references to cset anymore
+          _verify_liveness_complete,          // liveness data must be complete here
+          _verify_regions_disable,            // trash regions not yet recycled
+          _verify_size_exact,                 // expect generation and heap sizes to match exactly
+          _verify_gcstate_stable_weakroots    // heap is still stable, weakroots are in progress
+  );
+}
+
+void ShenandoahVerifier::verify_after_concmark_with_promotions() {
+  verify_at_safepoint(
+          "After Mark",
+          _verify_remembered_disable,         // do not verify remembered set
+          _verify_forwarded_none,             // no forwarded references
+          _verify_marked_complete_satb_empty, // bitmaps as precise as we can get, except dangling j.l.r.Refs
+          _verify_cset_none,                  // no references to cset anymore
+          _verify_liveness_complete,          // liveness data must be complete here
+          _verify_regions_disable,            // trash regions not yet recycled
+          _verify_size_adjusted_for_padding,  // expect generation and heap sizes to match after adjustments
+                                              // for promote in place padding
+          _verify_gcstate_stable_weakroots    // heap is still stable, weakroots are in progress
   );
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -215,6 +215,7 @@ public:
 
   void verify_before_concmark();
   void verify_after_concmark();
+  void verify_after_concmark_with_promotions();
   void verify_before_evacuation();
   void verify_during_evacuation();
   void verify_after_evacuation();


### PR DESCRIPTION
Not clean, but not hard to resolve conflicts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8339616](https://bugs.openjdk.org/browse/JDK-8339616): GenShen: Introduce new state to distinguish promote-in-place phase as distinct from concurrent evacuation (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/105.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/105.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/105#issuecomment-2374753167)