### PR TITLE
8341042: GenShen: Reset mark bitmaps for unaffiliated regions when preparing for a cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -77,7 +77,8 @@ public:
     ShenandoahHeap* heap = ShenandoahHeap::heap();
     ShenandoahMarkingContext* const ctx = heap->marking_context();
     while (region != nullptr) {
-      if (_generation->contains(region) && heap->is_bitmap_slice_committed(region)) {
+      bool needs_reset = _generation->contains(region) || !region->is_affiliated();
+      if (needs_reset && heap->is_bitmap_slice_committed(region)) {
         ctx->clear_bitmap(region);
       }
       region = _regions.next();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -572,13 +572,9 @@ void ShenandoahHeapRegion::recycle() {
 
   set_top(bottom());
   clear_live_data();
-
   reset_alloc_metadata();
 
   heap->marking_context()->reset_top_at_mark_start(this);
-  if (heap->is_bitmap_slice_committed(this)) {
-    heap->marking_context()->clear_bitmap(this);
-  }
 
   set_update_watermark(bottom());
 


### PR DESCRIPTION
Conflict with whitespace change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8341042](https://bugs.openjdk.org/browse/JDK-8341042): GenShen: Reset mark bitmaps for unaffiliated regions when preparing for a cycle (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/107.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/107#issuecomment-2377914950)