### PR TITLE
8334315: Shenandoah: reduce GC logging noise

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -54,25 +54,25 @@ static const char* partition_name(ShenandoahFreeSetPartitionId t) {
 
 #ifndef PRODUCT
 void ShenandoahRegionPartitions::dump_bitmap() const {
-  log_info(gc)("Mutator range [" SSIZE_FORMAT ", " SSIZE_FORMAT "], Collector range [" SSIZE_FORMAT ", " SSIZE_FORMAT
-               "], Old Collector range [" SSIZE_FORMAT ", " SSIZE_FORMAT "]",
-               _leftmosts[int(ShenandoahFreeSetPartitionId::Mutator)],
-               _rightmosts[int(ShenandoahFreeSetPartitionId::Mutator)],
-               _leftmosts[int(ShenandoahFreeSetPartitionId::Collector)],
-               _rightmosts[int(ShenandoahFreeSetPartitionId::Collector)],
-               _leftmosts[int(ShenandoahFreeSetPartitionId::OldCollector)],
-               _rightmosts[int(ShenandoahFreeSetPartitionId::OldCollector)]);
-  log_info(gc)("Empty Mutator range [" SSIZE_FORMAT ", " SSIZE_FORMAT
-               "], Empty Collector range [" SSIZE_FORMAT ", " SSIZE_FORMAT
-               "], Empty Old Collecto range [" SSIZE_FORMAT ", " SSIZE_FORMAT "]",
-               _leftmosts_empty[int(ShenandoahFreeSetPartitionId::Mutator)],
-               _rightmosts_empty[int(ShenandoahFreeSetPartitionId::Mutator)],
-               _leftmosts_empty[int(ShenandoahFreeSetPartitionId::Collector)],
-               _rightmosts_empty[int(ShenandoahFreeSetPartitionId::Collector)],
-               _leftmosts_empty[int(ShenandoahFreeSetPartitionId::OldCollector)],
-               _rightmosts_empty[int(ShenandoahFreeSetPartitionId::OldCollector)]);
+  log_debug(gc)("Mutator range [" SSIZE_FORMAT ", " SSIZE_FORMAT "], Collector range [" SSIZE_FORMAT ", " SSIZE_FORMAT
+                "], Old Collector range [" SSIZE_FORMAT ", " SSIZE_FORMAT "]",
+                _leftmosts[int(ShenandoahFreeSetPartitionId::Mutator)],
+                _rightmosts[int(ShenandoahFreeSetPartitionId::Mutator)],
+                _leftmosts[int(ShenandoahFreeSetPartitionId::Collector)],
+                _rightmosts[int(ShenandoahFreeSetPartitionId::Collector)],
+                _leftmosts[int(ShenandoahFreeSetPartitionId::OldCollector)],
+                _rightmosts[int(ShenandoahFreeSetPartitionId::OldCollector)]);
+  log_debug(gc)("Empty Mutator range [" SSIZE_FORMAT ", " SSIZE_FORMAT
+                "], Empty Collector range [" SSIZE_FORMAT ", " SSIZE_FORMAT
+                "], Empty Old Collecto range [" SSIZE_FORMAT ", " SSIZE_FORMAT "]",
+                _leftmosts_empty[int(ShenandoahFreeSetPartitionId::Mutator)],
+                _rightmosts_empty[int(ShenandoahFreeSetPartitionId::Mutator)],
+                _leftmosts_empty[int(ShenandoahFreeSetPartitionId::Collector)],
+                _rightmosts_empty[int(ShenandoahFreeSetPartitionId::Collector)],
+                _leftmosts_empty[int(ShenandoahFreeSetPartitionId::OldCollector)],
+                _rightmosts_empty[int(ShenandoahFreeSetPartitionId::OldCollector)]);
 
-  log_info(gc)("%6s: %18s %18s %18s %18s", "index", "Mutator Bits", "Collector Bits", "Old Collector Bits", "NotFree Bits");
+  log_debug(gc)("%6s: %18s %18s %18s %18s", "index", "Mutator Bits", "Collector Bits", "Old Collector Bits", "NotFree Bits");
   dump_bitmap_range(0, _max-1);
 }
 
@@ -96,8 +96,8 @@ void ShenandoahRegionPartitions::dump_bitmap_row(idx_t region_idx) const {
   uintx old_collector_bits = _membership[int(ShenandoahFreeSetPartitionId::OldCollector)].bits_at(aligned_idx);
   uintx free_bits = mutator_bits | collector_bits | old_collector_bits;
   uintx notfree_bits =  ~free_bits;
-  log_info(gc)(SSIZE_FORMAT_W(6) ": " SIZE_FORMAT_X_0 " 0x" SIZE_FORMAT_X_0 " 0x" SIZE_FORMAT_X_0 " 0x" SIZE_FORMAT_X_0,
-               aligned_idx, mutator_bits, collector_bits, old_collector_bits, notfree_bits);
+  log_debug(gc)(SSIZE_FORMAT_W(6) ": " SIZE_FORMAT_X_0 " 0x" SIZE_FORMAT_X_0 " 0x" SIZE_FORMAT_X_0 " 0x" SIZE_FORMAT_X_0,
+                aligned_idx, mutator_bits, collector_bits, old_collector_bits, notfree_bits);
 }
 #endif
 
@@ -1507,7 +1507,7 @@ void ShenandoahFreeSet::move_regions_from_collector_to_mutator(size_t max_xfer_r
   }
 
   size_t total_xfer = collector_xfer + old_collector_xfer;
-  log_info(gc, free)("At start of update refs, moving " SIZE_FORMAT "%s to Mutator free set from Collector Reserve ("
+  log_info(gc, ergo)("At start of update refs, moving " SIZE_FORMAT "%s to Mutator free set from Collector Reserve ("
                      SIZE_FORMAT "%s) and from Old Collector Reserve (" SIZE_FORMAT "%s)",
                      byte_size_in_proper_unit(total_xfer), proper_unit_for_byte_size(total_xfer),
                      byte_size_in_proper_unit(collector_xfer), proper_unit_for_byte_size(collector_xfer),


### PR DESCRIPTION
Not clean, just logging level changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8334315](https://bugs.openjdk.org/browse/JDK-8334315): Shenandoah: reduce GC logging noise (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/109.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/109#issuecomment-2384222384)