### PR TITLE
8340395: GenShen: Remove unnecessary check on card barrier flag

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -132,11 +132,10 @@ void ShenandoahBarrierSet::on_thread_detach(Thread *thread) {
       gclab->retire();
     }
 
-    if (ShenandoahCardBarrier) {
-      PLAB* plab = ShenandoahThreadLocalData::plab(thread);
-      if (plab != nullptr) {
-        ShenandoahGenerationalHeap::heap()->retire_plab(plab);
-      }
+    PLAB* plab = ShenandoahThreadLocalData::plab(thread);
+    if (plab != nullptr) {
+      // This will assert if plab is not null in non-generational mode
+      ShenandoahGenerationalHeap::heap()->retire_plab(plab);
     }
 
     // SATB protocol requires to keep alive reachable oops from roots at the beginning of GC


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340395](https://bugs.openjdk.org/browse/JDK-8340395): GenShen: Remove unnecessary check on card barrier flag (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/112.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/112.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/112#issuecomment-2384410247)