### PR TITLE
8341668: Shenandoah: assert(tail_bits < (idx_t)BitsPerWord) failed: precondition

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
@@ -80,6 +80,8 @@ private:
   bool is_forward_consecutive_ones(idx_t start_idx, idx_t count) const;
   bool is_backward_consecutive_ones(idx_t last_idx, idx_t count) const;
 
+  static inline uintx tail_mask(uintx bit_number);
+
 public:
 
   inline idx_t aligned_index(idx_t idx) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
@@ -27,7 +27,7 @@
 
 #include "gc/shenandoah/shenandoahSimpleBitMap.hpp"
 
-inline uintx tail_mask(uintx bit_number) {
+inline uintx ShenandoahSimpleBitMap::tail_mask(uintx bit_number) {
   if (bit_number >= BitsPerWord) {
     return -1;
   }


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341668](https://bugs.openjdk.org/browse/JDK-8341668): Shenandoah: assert(tail_bits &lt; (idx_t)BitsPerWord) failed: precondition (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/122.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/122.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/122#issuecomment-2400988172)