### PR TITLE
8340408: Shenandoah: Remove redundant task stats printing code in ShenandoahTaskQueue

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -298,8 +298,7 @@ void ShenandoahConcurrentMark::finish_mark() {
   assert(Thread::current()->is_VM_thread(), "Must by VM Thread");
   finish_mark_work();
   assert(task_queues()->is_empty(), "Should be empty");
-  TASKQUEUE_STATS_ONLY(task_queues()->print_taskqueue_stats());
-  TASKQUEUE_STATS_ONLY(task_queues()->reset_taskqueue_stats());
+  TASKQUEUE_STATS_ONLY(task_queues()->print_and_reset_taskqueue_stats(""));
 
   _generation->set_concurrent_mark_in_progress(false);
   _generation->set_mark_complete();

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -143,8 +143,7 @@ void ShenandoahSTWMark::mark() {
   ShenandoahCodeRoots::disarm_nmethods();
 
   assert(task_queues()->is_empty(), "Should be empty");
-  TASKQUEUE_STATS_ONLY(task_queues()->print_taskqueue_stats());
-  TASKQUEUE_STATS_ONLY(task_queues()->reset_taskqueue_stats());
+  TASKQUEUE_STATS_ONLY(task_queues()->print_and_reset_taskqueue_stats(""));
 }
 
 void ShenandoahSTWMark::mark_roots(uint worker_id) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.cpp
@@ -51,45 +51,6 @@ bool ShenandoahObjToScanQueueSet::is_empty() {
   return true;
 }
 
-#if TASKQUEUE_STATS
-void ShenandoahObjToScanQueueSet::print_taskqueue_stats_hdr(outputStream* const st) {
-  st->print_raw_cr("GC Task Stats");
-  st->print_raw("thr "); TaskQueueStats::print_header(1, st); st->cr();
-  st->print_raw("--- "); TaskQueueStats::print_header(2, st); st->cr();
-}
-
-void ShenandoahObjToScanQueueSet::print_taskqueue_stats() const {
-  if (!log_develop_is_enabled(Trace, gc, task, stats)) {
-    return;
-  }
-  Log(gc, task, stats) log;
-  ResourceMark rm;
-  LogStream ls(log.trace());
-  outputStream* st = &ls;
-  print_taskqueue_stats_hdr(st);
-
-  ShenandoahObjToScanQueueSet* queues = const_cast<ShenandoahObjToScanQueueSet*>(this);
-  TaskQueueStats totals;
-  const uint n = size();
-  for (uint i = 0; i < n; ++i) {
-    st->print(UINT32_FORMAT_W(3), i);
-    queues->queue(i)->stats.print(st);
-    st->cr();
-    totals += queues->queue(i)->stats;
-  }
-  st->print("tot "); totals.print(st); st->cr();
-  DEBUG_ONLY(totals.verify());
-
-}
-
-void ShenandoahObjToScanQueueSet::reset_taskqueue_stats() {
-  const uint n = size();
-  for (uint i = 0; i < n; ++i) {
-    queue(i)->stats.reset();
-  }
-}
-#endif // TASKQUEUE_STATS
-
 bool ShenandoahTerminatorTerminator::should_exit_termination() {
   return _heap->cancelled_gc();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
@@ -354,12 +354,6 @@ public:
 
   bool is_empty();
   void clear();
-
-#if TASKQUEUE_STATS
-  static void print_taskqueue_stats_hdr(outputStream* const st);
-  void print_taskqueue_stats() const;
-  void reset_taskqueue_stats();
-#endif // TASKQUEUE_STATS
 };
 
 class ShenandoahTerminatorTerminator : public TerminatorTerminator {


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340408](https://bugs.openjdk.org/browse/JDK-8340408): Shenandoah: Remove redundant task stats printing code in ShenandoahTaskQueue (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/123.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/123#issuecomment-2403318487)