### PR TITLE
8338688: Shenandoah: Avoid calling java_lang_Class accessors in asserts/verifier

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -257,7 +257,7 @@ void ShenandoahAsserts::assert_correct(void* interior_loc, oop obj, const char* 
   // Do additional checks for special objects: their fields can hold metadata as well.
   // We want to check class loading/unloading did not corrupt them.
 
-  if (java_lang_Class::is_instance(obj)) {
+  if (obj_klass == vmClasses::Class_klass()) {
     Metadata* klass = obj->metadata_field(java_lang_Class::klass_offset());
     if (klass != nullptr && !Metaspace::contains(klass)) {
       print_failure(_safe_all, obj, interior_loc, nullptr, "Shenandoah assert_correct failed",

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -239,7 +239,7 @@ private:
     // Do additional checks for special objects: their fields can hold metadata as well.
     // We want to check class loading/unloading did not corrupt them.
 
-    if (java_lang_Class::is_instance(obj)) {
+    if (obj_klass == vmClasses::Class_klass()) {
       Metadata* klass = obj->metadata_field(java_lang_Class::klass_offset());
       check(ShenandoahAsserts::_safe_oop, obj,
             klass == nullptr || Metaspace::contains(klass),


### PR DESCRIPTION
Trivial to resolve.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8338688](https://bugs.openjdk.org/browse/JDK-8338688): Shenandoah: Avoid calling java_lang_Class accessors in asserts/verifier (**Enhancement** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/128.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/128#issuecomment-2414976462)