### PR TITLE
8342044: Increase timeout of gc/shenandoah/oom/TestClassLoaderLeak.java

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestClassLoaderLeak.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestClassLoaderLeak.java
@@ -28,7 +28,7 @@
  * @summary Test OOME in due to classloader leak
  * @requires vm.gc.Shenandoah
  * @library /test/lib
- * @run driver TestClassLoaderLeak
+ * @run driver/timeout=600 TestClassLoaderLeak
  */
 
 import java.util.*;


### PR DESCRIPTION
Clean backport. Increase test timeout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342044](https://bugs.openjdk.org/browse/JDK-8342044): Increase timeout of gc/shenandoah/oom/TestClassLoaderLeak.java (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/131.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/131.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/131#issuecomment-2420656383)