### PR TITLE
8342927: GenShen: Guarantee slices of time for coalesce and filling

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -561,12 +561,12 @@
           "Log cumulative card stats every so many remembered set or "      \
           "update refs scans")                                              \
                                                                             \
-  product(uintx, ShenandoahMinimumOldMarkTimeMs, 100, EXPERIMENTAL,         \
-         "Minimum amount of time in milliseconds to run old marking "       \
+  product(uintx, ShenandoahMinimumOldTimeMs, 100, EXPERIMENTAL,             \
+         "Minimum amount of time in milliseconds to run old collections "   \
          "before a young collection is allowed to run. This is intended "   \
          "to prevent starvation of the old collector. Setting this to "     \
          "0 will allow back to back young collections to run during old "   \
-         "marking.")                                                        \
+         "collections.")                                                    \
   // end of GC_SHENANDOAH_FLAGS
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAH_GLOBALS_HPP


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342927](https://bugs.openjdk.org/browse/JDK-8342927): GenShen: Guarantee slices of time for coalesce and filling (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/132.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/132#issuecomment-2436094260)