### PR TITLE
8342861: GenShen: Old generation in unexpected state when abandoning mixed gc candidates

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -83,6 +83,14 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
     return false;
   }
 
+  if (_old_generation->is_preparing_for_mark()) {
+    // We have unprocessed old collection candidates, but the heuristic has given up on evacuating them.
+    // This is most likely because they were _all_ pinned at the time of the last mixed evacuation (and
+    // this in turn is most likely because there are just one or two candidate regions remaining).
+    log_debug(gc)("Remaining " UINT32_FORMAT " old regions are being coalesced and filled", unprocessed_old_collection_candidates());
+    return false;
+  }
+
   _first_pinned_candidate = NOT_FOUND;
 
   uint included_old_regions = 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -496,6 +496,7 @@ const char* ShenandoahOldGeneration::state_name(State state) {
 void ShenandoahOldGeneration::transition_to(State new_state) {
   if (_state != new_state) {
     log_info(gc)("Old generation transition from %s to %s", state_name(_state), state_name(new_state));
+    EventMark event("Old was %s, now is %s", state_name(_state), state_name(new_state));
     validate_transition(new_state);
     _state = new_state;
   }
@@ -772,6 +773,7 @@ void ShenandoahOldGeneration::abandon_mixed_evacuations() {
       transition_to(ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP);
       break;
     default:
+      log_warning(gc)("Abandon mixed evacuations in unexpected state: %s", state_name(state()));
       ShouldNotReachHere();
       break;
   }


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342861](https://bugs.openjdk.org/browse/JDK-8342861): GenShen: Old generation in unexpected state when abandoning mixed gc candidates (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/133.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/133#issuecomment-2445100901)