### PR TITLE
8341992: GenShen:  Fix formatting, remove unreachable code, unused imports and unnecessary comments

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAffiliation.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAffiliation.hpp
@@ -41,7 +41,6 @@ inline const char* shenandoah_affiliation_code(ShenandoahAffiliation type) {
       return "O";
     default:
       ShouldNotReachHere();
-      return "?";
   }
 }
 
@@ -55,7 +54,6 @@ inline const char* shenandoah_affiliation_name(ShenandoahAffiliation type) {
       return "OLD";
     default:
       ShouldNotReachHere();
-      return "?";
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -532,9 +532,9 @@ public:
   ShenandoahFreeSet*         free_set()          const { return _free_set;          }
   ShenandoahPacer*           pacer()             const { return _pacer;             }
 
-  ShenandoahPhaseTimings*      phase_timings()   const { return _phase_timings;     }
+  ShenandoahPhaseTimings*    phase_timings()     const { return _phase_timings;     }
 
-  ShenandoahEvacOOMHandler* oom_evac_handler() { return &_oom_evac_handler; }
+  ShenandoahEvacOOMHandler*  oom_evac_handler()        { return &_oom_evac_handler; }
 
   void on_cycle_start(GCCause::Cause cause, ShenandoahGeneration* generation);
   void on_cycle_end(ShenandoahGeneration* generation);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -331,8 +331,6 @@ void ShenandoahHeap::increase_object_age(oop obj, uint additional_age) {
 // necessarily be determined because of concurrent locking by the
 // mutator
 uint ShenandoahHeap::get_object_age(oop obj) {
-  // This is impossible to do unless we "freeze" ABA-type oscillations
-  // With Lilliput, we can do this more easily.
   markWord w = obj->mark();
   assert(!w.is_marked(), "must not be forwarded");
   if (w.has_monitor()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
@@ -25,7 +25,6 @@
 #ifndef SHARE_GC_SHENANDOAH_SHENANDOAHMMUTRACKER_HPP
 #define SHARE_GC_SHENANDOAH_SHENANDOAHMMUTRACKER_HPP
 
-#include "runtime/mutex.hpp"
 #include "utilities/numberSeq.hpp"
 
 class ShenandoahGeneration;


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341992](https://bugs.openjdk.org/browse/JDK-8341992): GenShen:  Fix formatting, remove unreachable code, unused imports and unnecessary comments (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/141/head:pull/141` \
`$ git checkout pull/141`

Update a local copy of the PR: \
`$ git checkout pull/141` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 141`

View PR using the GUI difftool: \
`$ git pr show -t 141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/141.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/141.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/141#issuecomment-2524400510)
</details>
