### PR TITLE
8342001: GenShen: Factor cases for allocation type into separate methods

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -302,8 +302,10 @@ private:
   // from right-to-left or left-to-right, we reset the value of this counter to _InitialAllocBiasWeight.
   ssize_t _alloc_bias_weight;
 
-  const ssize_t _InitialAllocBiasWeight = 256;
+  const ssize_t INITIAL_ALLOC_BIAS_WEIGHT = 256;
 
+  // Increases used memory for the partition if the allocation is successful. `in_new_region` will be set
+  // if this is the first allocation in the region.
   HeapWord* try_allocate_in(ShenandoahHeapRegion* region, ShenandoahAllocRequest& req, bool& in_new_region);
 
   // While holding the heap lock, allocate memory for a single object or LAB  which is to be entirely contained
@@ -327,6 +329,27 @@ private:
   // the Mutator free set into the Collector or OldCollector free set.
   void flip_to_gc(ShenandoahHeapRegion* r);
   void flip_to_old_gc(ShenandoahHeapRegion* r);
+
+  // Handle allocation for mutator.
+  HeapWord* allocate_for_mutator(ShenandoahAllocRequest &req, bool &in_new_region);
+
+  // Update allocation bias and decided whether to allocate from the left or right side of the heap.
+  void update_allocation_bias();
+
+  // Search for regions to satisfy allocation request starting from the right, moving to the left.
+  HeapWord* allocate_from_right_to_left(ShenandoahAllocRequest& req, bool& in_new_region);
+
+  // Search for regions to satisfy allocation request starting from the left, moving to the right.
+  HeapWord* allocate_from_left_to_right(ShenandoahAllocRequest& req, bool& in_new_region);
+
+  // Handle allocation for collector (for evacuation).
+  HeapWord* allocate_for_collector(ShenandoahAllocRequest& req, bool& in_new_region);
+
+  // Return true if the respective generation for this request has free regions.
+  bool can_allocate_in_new_region(const ShenandoahAllocRequest& req);
+
+  // Attempt to allocate memory for an evacuation from the mutator's partition.
+  HeapWord* try_allocate_from_mutator(ShenandoahAllocRequest& req, bool& in_new_region);
 
   void clear_internal();
   void try_recycle_trashed(ShenandoahHeapRegion *r);


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8342001](https://bugs.openjdk.org/browse/JDK-8342001): GenShen: Factor cases for allocation type into separate methods (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/142.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/142.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/142#issuecomment-2524648649)
</details>
