### PR TITLE
8346044: GenShen: ShenandoahGenerationalHeap entry missing from Universe.java

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/Universe.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/Universe.java
@@ -35,6 +35,7 @@ import sun.jvm.hotspot.gc.g1.G1CollectedHeap;
 import sun.jvm.hotspot.gc.parallel.ParallelScavengeHeap;
 import sun.jvm.hotspot.gc.serial.SerialHeap;
 import sun.jvm.hotspot.gc.shared.CollectedHeap;
+import sun.jvm.hotspot.gc.shenandoah.ShenandoahGenerationalHeap;
 import sun.jvm.hotspot.gc.shenandoah.ShenandoahHeap;
 import sun.jvm.hotspot.gc.x.XCollectedHeap;
 import sun.jvm.hotspot.gc.z.ZCollectedHeap;
@@ -90,6 +91,7 @@ public class Universe {
     addHeapTypeIfInDB(db, XCollectedHeap.class);
     addHeapTypeIfInDB(db, ZCollectedHeap.class);
     addHeapTypeIfInDB(db, ShenandoahHeap.class);
+    addHeapTypeIfInDB(db, ShenandoahGenerationalHeap.class);
 
     UniverseExt.initialize(heapConstructor);
   }


### PR DESCRIPTION
Looks the genshen backport/merge missed this one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8346044](https://bugs.openjdk.org/browse/JDK-8346044): GenShen: ShenandoahGenerationalHeap entry missing from Universe.java (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/144.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/144.diff</a>

</details>
