### PR TITLE
8346051: MemoryTest fails when Shenandoah's generational mode is enabled

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -58,15 +58,27 @@
  */
 
 /*
- * @test
+ * @test id=Shenandoah
  * @bug     4530538
- * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
- *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc == "Shenandoah"
+ * @summary Shenandoah has a gc mgr bean for cycles and another
+ *          for pauses, they both have one pool.
+ * @requires vm.gc == "Shenandoah" & vm.opt.ShenandoahGCMode != "generational"
  * @author  Mandy Chung
  *
  * @modules jdk.management
  * @run main MemoryTest 2 1
+ */
+
+/*
+ * @test id=Genshen
+ * @bug     4530538
+ * @summary Shenandoah's generational mode has a gc mgr bean for cycles
+ *          and another for pauses. They both reference the young and old pools.
+ * @requires vm.gc == "Shenandoah" & vm.opt.ShenandoahGCMode == "generational"
+ * @author  Mandy Chung
+ *
+ * @modules jdk.management
+ * @run main MemoryTest 2 2
  */
 
 /*


### PR DESCRIPTION
Clean backport. Test only fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346051](https://bugs.openjdk.org/browse/JDK-8346051): MemoryTest fails when Shenandoah's generational mode is enabled (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/146.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/146.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/146#issuecomment-2542067307)
</details>
