### PR TITLE
8346681: Shenandoah: Does not throw OOME when EATests expects it

### DIFF
--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -316,6 +316,7 @@ public class EATests extends TestScaffold {
         public final boolean DeoptimizeObjectsALot;
         public final boolean DoEscapeAnalysis;
         public final boolean ZGCIsSelected;
+        public final boolean ShenandoahGCIsSelected;
         public final boolean StressReflectiveCode;
 
         public TargetVMOptions(EATests env, ClassType testCaseBaseTargetClass) {
@@ -331,6 +332,8 @@ public class EATests extends TestScaffold {
             UseJVMCICompiler = ((PrimitiveValue) val).booleanValue();
             val = testCaseBaseTargetClass.getValue(testCaseBaseTargetClass.fieldByName("ZGCIsSelected"));
             ZGCIsSelected = ((PrimitiveValue) val).booleanValue();
+            val = testCaseBaseTargetClass.getValue(testCaseBaseTargetClass.fieldByName("ShenandoahGCIsSelected"));
+            ShenandoahGCIsSelected = ((PrimitiveValue) val).booleanValue();
             val = testCaseBaseTargetClass.getValue(testCaseBaseTargetClass.fieldByName("StressReflectiveCode"));
             StressReflectiveCode = ((PrimitiveValue) val).booleanValue();
         }
@@ -820,6 +823,7 @@ abstract class EATestCaseBaseTarget extends EATestCaseBaseShared implements Runn
     public static final boolean EliminateAllocations = unbox(WB.getBooleanVMFlag("EliminateAllocations"), UseJVMCICompiler);
     public static final boolean DeoptimizeObjectsALot = WB.getBooleanVMFlag("DeoptimizeObjectsALot");
     public static final boolean ZGCIsSelected = GC.Z.isSelected();
+    public static final boolean ShenandoahGCIsSelected = GC.Shenandoah.isSelected();
     public static final boolean StressReflectiveCode = unbox(WB.getBooleanVMFlag("StressReflectiveCode"), false);
 
     public String testMethodName;
@@ -2684,8 +2688,9 @@ class EAPopFrameNotInlinedReallocFailure extends EATestCaseBaseDebugger {
         // And Graal currently doesn't provide all information about non-escaping objects in debug info
         return super.shouldSkip() ||
                 !env.targetVMOptions.EliminateAllocations ||
-                // With ZGC the OOME is not always thrown as expected
+                // With ZGC or Shenandoah the OOME is not always thrown as expected
                 env.targetVMOptions.ZGCIsSelected ||
+                env.targetVMOptions.ShenandoahGCIsSelected ||
                 env.targetVMOptions.DeoptimizeObjectsALot ||
                 env.targetVMOptions.UseJVMCICompiler;
     }
@@ -2729,8 +2734,9 @@ class EAPopFrameNotInlinedReallocFailureTarget extends EATestCaseBaseTarget {
         // And Graal currently doesn't provide all information about non-escaping objects in debug info
         return super.shouldSkip() ||
                 !EliminateAllocations ||
-                // With ZGC the OOME is not always thrown as expected
+                // With ZGC or Shenandoah the OOME is not always thrown as expected
                 ZGCIsSelected ||
+                ShenandoahGCIsSelected ||
                 DeoptimizeObjectsALot ||
                 UseJVMCICompiler;
     }
@@ -2782,8 +2788,9 @@ class EAPopInlinedMethodWithScalarReplacedObjectsReallocFailure extends EATestCa
         // And Graal currently doesn't provide all information about non-escaping objects in debug info
         return super.shouldSkip() ||
                 !env.targetVMOptions.EliminateAllocations ||
-                // With ZGC the OOME is not always thrown as expected
+                // With ZGC or Shenandoah the OOME is not always thrown as expected
                 env.targetVMOptions.ZGCIsSelected ||
+                env.targetVMOptions.ShenandoahGCIsSelected ||
                 env.targetVMOptions.DeoptimizeObjectsALot ||
                 env.targetVMOptions.UseJVMCICompiler;
     }
@@ -2843,8 +2850,9 @@ class EAPopInlinedMethodWithScalarReplacedObjectsReallocFailureTarget extends EA
         // And Graal currently doesn't provide all information about non-escaping objects in debug info
         return super.shouldSkip() ||
                 !EliminateAllocations ||
-                // With ZGC the OOME is not always thrown as expected
+                // With ZGC or Shenandoah the OOME is not always thrown as expected
                 ZGCIsSelected ||
+                ShenandoahGCIsSelected ||
                 DeoptimizeObjectsALot ||
                 UseJVMCICompiler;
     }
@@ -3049,8 +3057,9 @@ class EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsReallocFailure e
         // And Graal currently doesn't support Force Early Return
         return super.shouldSkip() ||
                 !env.targetVMOptions.EliminateAllocations ||
-                // With ZGC the OOME is not always thrown as expected
+                // With ZGC or Shenandoah the OOME is not always thrown as expected
                 env.targetVMOptions.ZGCIsSelected ||
+                env.targetVMOptions.ShenandoahGCIsSelected ||
                 env.targetVMOptions.DeoptimizeObjectsALot ||
                 env.targetVMOptions.UseJVMCICompiler;
     }
@@ -3111,8 +3120,9 @@ class EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsReallocFailureTa
         // And Graal currently doesn't support Force Early Return
         return super.shouldSkip() ||
                 !EliminateAllocations ||
-                // With ZGC the OOME is not always thrown as expected
+                // With ZGC or Shenandoah the OOME is not always thrown as expected
                 ZGCIsSelected ||
+                ShenandoahGCIsSelected ||
                 DeoptimizeObjectsALot ||
                 UseJVMCICompiler;
     }


### PR DESCRIPTION
The changes to this test reflect the similar changes for ZGC. The test was never backported to 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8346681](https://bugs.openjdk.org/browse/JDK-8346681): Shenandoah: Does not throw OOME when EATests expects it (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/147.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/147.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/147#issuecomment-2555544434)
</details>
