### PR TITLE
8346737: GenShen: Generational memory pools should not report zero for maximum capacity

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
@@ -93,11 +93,6 @@ size_t ShenandoahGenerationalMemoryPool::used_in_bytes() {
   return _generation->used();
 }
 
-size_t ShenandoahGenerationalMemoryPool::max_size() const {
-  return _generation->max_capacity();
-}
-
-
 ShenandoahYoungGenMemoryPool::ShenandoahYoungGenMemoryPool(ShenandoahHeap* heap) :
         ShenandoahGenerationalMemoryPool(heap,
                              "Shenandoah Young Gen",

--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.hpp
@@ -55,7 +55,6 @@ public:
   explicit ShenandoahGenerationalMemoryPool(ShenandoahHeap* heap, const char* name, ShenandoahGeneration* generation);
   MemoryUsage get_memory_usage() override;
   size_t used_in_bytes() override;
-  size_t max_size() const override;
 };
 
 class ShenandoahYoungGenMemoryPool : public ShenandoahGenerationalMemoryPool {


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346737](https://bugs.openjdk.org/browse/JDK-8346737): GenShen: Generational memory pools should not report zero for maximum capacity (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/150.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/150.diff</a>

</details>
