### PR TITLE
8346569: Shenandoah: Worker initializes ShenandoahThreadLocalData twice results in memory leak

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkGroup.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkGroup.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +74,6 @@ ShenandoahPushWorkerScope::~ShenandoahPushWorkerScope() {
 }
 
 void ShenandoahWorkerThreads::on_create_worker(WorkerThread* worker) {
-  ShenandoahThreadLocalData::create(worker);
   if (_initialize_gclab) {
     ShenandoahThreadLocalData::initialize_gclab(worker);
   }


### PR DESCRIPTION
Clean backport, fixes memory leak.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346569](https://bugs.openjdk.org/browse/JDK-8346569): Shenandoah: Worker initializes ShenandoahThreadLocalData twice results in memory leak (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/158.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/158#issuecomment-2725850685)
</details>
