### PR TITLE
8344049: Shenandoah: Eliminate init-update-refs safepoint

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -106,8 +106,10 @@ void ShenandoahBarrierSet::on_thread_attach(Thread *thread) {
   assert(queue.buffer() == nullptr, "SATB queue should not have a buffer");
   assert(queue.index() == 0, "SATB queue index should be zero");
   queue.set_active(_satb_mark_queue_set.is_active());
+
+  ShenandoahThreadLocalData::set_gc_state(thread, _heap->gc_state());
+
   if (thread->is_Java_thread()) {
-    ShenandoahThreadLocalData::set_gc_state(thread, _heap->gc_state());
     ShenandoahThreadLocalData::initialize_gclab(thread);
 
     BarrierSetNMethod* bs_nm = barrier_set_nmethod();

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -480,14 +480,6 @@ void ShenandoahBarrierSet::arraycopy_marking(T* src, T* dst, size_t count, bool 
       // Non-generational, marking
       arraycopy_work<T, false, false, true>(array, count);
     }
-  } else {
-    // Incremental Update mode, marking
-    T* array = src;
-    HeapWord* array_addr = reinterpret_cast<HeapWord*>(array);
-    ShenandoahHeapRegion* r = _heap->heap_region_containing(array_addr);
-    if (array_addr < _heap->marking_context()->top_at_mark_start(r)) {
-      arraycopy_work<T, false, false, true>(array, count);
-    }
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetClone.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetClone.inline.hpp
@@ -95,8 +95,7 @@ void ShenandoahBarrierSet::clone_barrier(oop obj) {
   assert(ShenandoahCloneBarrier, "only get here with clone barriers enabled");
   shenandoah_assert_correct(nullptr, obj);
 
-  int gc_state = _heap->gc_state();
-  if ((gc_state & ShenandoahHeap::EVACUATION) != 0) {
+  if (_heap->is_evacuation_in_progress()) {
     clone_evacuation(obj);
   } else {
     clone_update(obj);

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -965,7 +965,7 @@ void ShenandoahConcurrentGC::op_weak_roots() {
     // on trashed regions could make an oop appear to be marked _after_ the
     // region has been recycled).
     ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_rendezvous);
-    heap->rendezvous_threads("Shenandoah Concurrent Weak Roots");
+    heap->rendezvous_threads();
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -948,11 +948,25 @@ public:
 void ShenandoahConcurrentGC::op_weak_roots() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(heap->is_concurrent_weak_root_in_progress(), "Only during this phase");
-  // Concurrent weak root processing
-  ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_work);
-  ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_roots_work);
-  ShenandoahConcurrentWeakRootsEvacUpdateTask task(ShenandoahPhaseTimings::conc_weak_roots_work);
-  heap->workers()->run_task(&task);
+  {
+    // Concurrent weak root processing
+    ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_work);
+    ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_roots_work);
+    ShenandoahConcurrentWeakRootsEvacUpdateTask task(ShenandoahPhaseTimings::conc_weak_roots_work);
+    heap->workers()->run_task(&task);
+  }
+
+  {
+    // It is possible for mutators executing the load reference barrier to have
+    // loaded an oop through a weak handle that has since been nulled out by
+    // weak root processing. Handshaking here forces them to complete the
+    // barrier before the GC cycle continues and does something that would
+    // change the evaluation of the barrier (for example, resetting the TAMS
+    // on trashed regions could make an oop appear to be marked _after_ the
+    // region has been recycled).
+    ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_rendezvous);
+    heap->rendezvous_threads("Shenandoah Concurrent Weak Roots");
+  }
 }
 
 void ShenandoahConcurrentGC::op_class_unloading() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -30,6 +30,7 @@
 #include "gc/shared/collectorCounters.hpp"
 #include "gc/shared/continuationGCSupport.inline.hpp"
 #include "gc/shenandoah/shenandoahBreakpoint.hpp"
+#include "gc/shenandoah/shenandoahClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
 #include "gc/shenandoah/shenandoahConcurrentGC.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
@@ -40,7 +41,6 @@
 #include "gc/shenandoah/shenandoahLock.hpp"
 #include "gc/shenandoah/shenandoahMark.inline.hpp"
 #include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
-#include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
 #include "gc/shenandoah/shenandoahRootProcessor.inline.hpp"
@@ -141,25 +141,11 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // Complete marking under STW, and start evacuation
   vmop_entry_final_mark();
 
-  // If the GC was cancelled just before final mark (but after the preceding cancellation check),
-  // then the safepoint operation will do nothing and the concurrent mark will still be in progress.
-  // In this case it is safe (and necessary) to resume the degenerated cycle from the marking phase.
-  //
-  // On the other hand, if the GC is cancelled after final mark (but before this check), then the
-  // final mark safepoint operation will have finished the mark (setting concurrent mark in progress
-  // to false). In this case (final mark has completed), we need control to fall past the next
-  // cancellation check and resume the degenerated cycle from the evacuation phase.
+  // If the GC was cancelled before final mark, nothing happens on the safepoint. We are still
+  // in the marking phase and must resume the degenerated cycle from there. If the GC was cancelled
+  // after final mark, then we've entered the evacuation phase and must resume the degenerated cycle
+  // from that phase.
   if (_generation->is_concurrent_mark_in_progress()) {
-    // If the concurrent mark is still in progress after the final mark safepoint, then the GC has
-    // been cancelled. The degenerated cycle must resume from the marking phase. Without this check,
-    // the non-generational mode may fall all the way to the end of this collect routine without
-    // having done anything (besides mark most of the heap). Without having collected anything, we
-    // can expect an 'out of cycle' degenerated GC which will again mark the entire heap. This is
-    // not optimal.
-    // For the generational mode, we cannot allow this. The generational mode relies on marking
-    // (including the final mark) to rebuild portions of the card table. If the generational mode does
-    // not complete marking after it has swapped the card tables, the root set on subsequent GCs will
-    // be incomplete, heap corruption may follow.
     bool cancelled = check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark);
     assert(cancelled, "GC must have been cancelled between concurrent and final mark");
     return false;
@@ -206,8 +192,14 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
       return false;
     }
 
+    // Evacuation is complete, retire gc labs
+    heap->concurrent_prepare_for_update_refs();
+
     // Perform update-refs phase.
-    vmop_entry_init_updaterefs();
+    if (ShenandoahVerify || ShenandoahPacing) {
+      vmop_entry_init_updaterefs();
+    }
+
     entry_updaterefs();
     if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_updaterefs)) {
       return false;
@@ -762,10 +754,6 @@ void ShenandoahConcurrentGC::op_final_mark() {
           heap->verifier()->verify_after_concmark();
         }
       }
-
-      if (VerifyAfterGC) {
-        Universe::verify();
-      }
     }
   }
 }
@@ -865,10 +853,7 @@ void ShenandoahEvacUpdateCleanupOopStorageRootsClosure::do_oop(oop* p) {
     if (!_mark_context->is_marked(obj)) {
       shenandoah_assert_generations_reconciled();
       if (_heap->is_in_active_generation(obj)) {
-        // Here we are asserting that an unmarked from-space object is 'correct'. There seems to be a legitimate
-        // use-case for accessing from-space objects during concurrent class unloading. In all modes of Shenandoah,
-        // concurrent class unloading only happens during a global collection.
-        shenandoah_assert_correct(p, obj);
+        // Note: The obj is dead here. Do not touch it, just clear.
         ShenandoahHeap::atomic_clear_oop(p, obj);
       }
     } else if (_evac_in_progress && _heap->in_collection_set(obj)) {
@@ -937,8 +922,8 @@ public:
     }
 
     // If we are going to perform concurrent class unloading later on, we need to
-    // cleanup the weak oops in CLD and determinate nmethod's unloading state, so that we
-    // can cleanup immediate garbage sooner.
+    // clean up the weak oops in CLD and determine nmethod's unloading state, so that we
+    // can clean up immediate garbage sooner.
     if (ShenandoahHeap::heap()->unload_classes()) {
       // Applies ShenandoahIsCLDAlive closure to CLDs, native barrier will either null the
       // CLD's holder or evacuate it.
@@ -964,21 +949,10 @@ void ShenandoahConcurrentGC::op_weak_roots() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(heap->is_concurrent_weak_root_in_progress(), "Only during this phase");
   // Concurrent weak root processing
-  {
-    ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_work);
-    ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_roots_work);
-    ShenandoahConcurrentWeakRootsEvacUpdateTask task(ShenandoahPhaseTimings::conc_weak_roots_work);
-    heap->workers()->run_task(&task);
-  }
-
-  // Perform handshake to flush out dead oops
-  {
-    ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_rendezvous);
-    heap->rendezvous_threads();
-  }
-  // We can only toggle concurrent_weak_root_in_progress flag
-  // at a safepoint, so that mutators see a consistent
-  // value. The flag will be cleared at the next safepoint.
+  ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_work);
+  ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_roots_work);
+  ShenandoahConcurrentWeakRootsEvacUpdateTask task(ShenandoahPhaseTimings::conc_weak_roots_work);
+  heap->workers()->run_task(&task);
 }
 
 void ShenandoahConcurrentGC::op_class_unloading() {
@@ -1072,14 +1046,9 @@ void ShenandoahConcurrentGC::op_evacuate() {
 
 void ShenandoahConcurrentGC::op_init_updaterefs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  heap->set_evacuation_in_progress(false);
-  heap->set_concurrent_weak_root_in_progress(false);
-  heap->prepare_update_heap_references(true /*concurrent*/);
   if (ShenandoahVerify) {
     heap->verifier()->verify_before_updaterefs();
   }
-
-  heap->set_update_refs_in_progress(true);
   if (ShenandoahPacing) {
     heap->pacer()->setup_for_updaterefs();
   }
@@ -1189,6 +1158,10 @@ void ShenandoahConcurrentGC::op_final_roots() {
     if (!_generation->is_old()) {
       ShenandoahGenerationalHeap::heap()->update_region_ages(_generation->complete_marking_context());
     }
+  }
+
+  if (VerifyAfterGC) {
+    Universe::verify();
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -999,6 +999,8 @@ HeapWord* ShenandoahFreeSet::allocate_aligned_plab(size_t size, ShenandoahAllocR
 HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, ShenandoahAllocRequest& req, bool& in_new_region) {
   assert (has_alloc_capacity(r), "Performance: should avoid full regions on this path: " SIZE_FORMAT, r->index());
   if (_heap->is_concurrent_weak_root_in_progress() && r->is_trash()) {
+    // We cannot use this region for allocation when weak roots are in progress because the collector may need
+    // to reference unmarked oops during concurrent classunloading.
     return nullptr;
   }
   HeapWord* result = nullptr;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1259,11 +1259,18 @@ void ShenandoahHeap::evacuate_collection_set(bool concurrent) {
 }
 
 void ShenandoahHeap::concurrent_prepare_for_update_refs() {
-  // It's possible that evacuation succeeded, but we could still be cancelled when we get here.
-  // A cancellation at this point means the degenerated cycle must resume from update-refs.
-  set_gc_state_concurrent(EVACUATION, false);
-  set_gc_state_concurrent(WEAK_ROOTS, false);
-  set_gc_state_concurrent(UPDATEREFS, true);
+  {
+    // Java threads take this lock while they are being attached and added to the list of thread.
+    // If another thread holds this lock before we update the gc state, it will receive a stale
+    // gc state, but they will have been added to the list of java threads and so will be corrected
+    // by the following handshake.
+    MutexLocker lock(Threads_lock);
+
+    // A cancellation at this point means the degenerated cycle must resume from update-refs.
+    set_gc_state_concurrent(EVACUATION, false);
+    set_gc_state_concurrent(WEAK_ROOTS, false);
+    set_gc_state_concurrent(UPDATEREFS, true);
+  }
 
   // This will propagate the gc state and retire gclabs and plabs for threads that require it.
   ShenandoahPrepareForUpdateRefs prepare_for_update_refs(_gc_state.raw_value());
@@ -2018,6 +2025,12 @@ void ShenandoahHeap::set_gc_state_at_safepoint(uint mask, bool value) {
 }
 
 void ShenandoahHeap::set_gc_state_concurrent(uint mask, bool value) {
+  // Holding the thread lock here assures that any thread created after we change the gc
+  // state will have the correct state. It also prevents attaching threads from seeing
+  // an inconsistent state. See ShenandoahBarrierSet::on_thread_attach for reference. Established
+  // threads will use their thread local copy of the gc state (changed by a handshake, or on a
+  // safepoint).
+  assert(Threads_lock->is_locked(), "Must hold thread lock for concurrent gc state change");
   _gc_state.set_cond(mask, value);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -97,6 +97,7 @@
 #include "runtime/java.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/safepointMechanism.hpp"
+#include "runtime/threads.hpp"
 #include "runtime/vmThread.hpp"
 #include "services/mallocTracker.hpp"
 #include "services/memTracker.hpp"
@@ -618,7 +619,6 @@ class ShenandoahInitWorkerGCLABClosure : public ThreadClosure {
 public:
   void do_thread(Thread* thread) {
     assert(thread != nullptr, "Sanity");
-    assert(thread->is_Worker_thread(), "Only worker thread expected");
     ShenandoahThreadLocalData::initialize_gclab(thread);
   }
 };
@@ -637,6 +637,9 @@ void ShenandoahHeap::post_initialize() {
   // gclab can not be initialized early during VM startup, as it can not determinate its max_size.
   // Now, we will let WorkerThreads to initialize gclab when new worker is created.
   _workers->set_initialize_gclab();
+
+  // Note that the safepoint workers may require gclabs if the threads are used to create a heap dump
+  // during a concurrent evacuation phase.
   if (_safepoint_workers != nullptr) {
     _safepoint_workers->threads_do(&init_gclabs);
     _safepoint_workers->set_initialize_gclab();
@@ -1194,9 +1197,84 @@ private:
   }
 };
 
+class ShenandoahRetireGCLABClosure : public ThreadClosure {
+private:
+  bool const _resize;
+public:
+  explicit ShenandoahRetireGCLABClosure(bool resize) : _resize(resize) {}
+  void do_thread(Thread* thread) override {
+    PLAB* gclab = ShenandoahThreadLocalData::gclab(thread);
+    assert(gclab != nullptr, "GCLAB should be initialized for %s", thread->name());
+    gclab->retire();
+    if (_resize && ShenandoahThreadLocalData::gclab_size(thread) > 0) {
+      ShenandoahThreadLocalData::set_gclab_size(thread, 0);
+    }
+
+    if (ShenandoahHeap::heap()->mode()->is_generational()) {
+      PLAB* plab = ShenandoahThreadLocalData::plab(thread);
+      assert(plab != nullptr, "PLAB should be initialized for %s", thread->name());
+
+      // There are two reasons to retire all plabs between old-gen evacuation passes.
+      //  1. We need to make the plab memory parsable by remembered-set scanning.
+      //  2. We need to establish a trustworthy UpdateWaterMark value within each old-gen heap region
+      ShenandoahGenerationalHeap::heap()->retire_plab(plab, thread);
+      if (_resize && ShenandoahThreadLocalData::plab_size(thread) > 0) {
+        ShenandoahThreadLocalData::set_plab_size(thread, 0);
+      }
+    }
+  }
+};
+
+class ShenandoahGCStatePropagator : public ThreadClosure {
+public:
+  explicit ShenandoahGCStatePropagator(char gc_state) : _gc_state(gc_state) {}
+
+  void do_thread(Thread* thread) override {
+    ShenandoahThreadLocalData::set_gc_state(thread, _gc_state);
+  }
+private:
+  char _gc_state;
+};
+
+class ShenandoahPrepareForUpdateRefs : public HandshakeClosure {
+public:
+  explicit ShenandoahPrepareForUpdateRefs(char gc_state) :
+    HandshakeClosure("Shenandoah Prepare for Update Refs"),
+    _retire(ResizeTLAB), _propagator(gc_state) {}
+
+  void do_thread(Thread* thread) override {
+    _propagator.do_thread(thread);
+    if (ShenandoahThreadLocalData::gclab(thread) != nullptr) {
+      _retire.do_thread(thread);
+    }
+  }
+private:
+  ShenandoahRetireGCLABClosure _retire;
+  ShenandoahGCStatePropagator _propagator;
+};
+
 void ShenandoahHeap::evacuate_collection_set(bool concurrent) {
   ShenandoahEvacuationTask task(this, _collection_set, concurrent);
   workers()->run_task(&task);
+}
+
+void ShenandoahHeap::concurrent_prepare_for_update_refs() {
+  // It's possible that evacuation succeeded, but we could still be cancelled when we get here.
+  // A cancellation at this point means the degenerated cycle must resume from update-refs.
+  set_gc_state_concurrent(EVACUATION, false);
+  set_gc_state_concurrent(WEAK_ROOTS, false);
+  set_gc_state_concurrent(UPDATEREFS, true);
+
+  // This will propagate the gc state and retire gclabs and plabs for threads that require it.
+  ShenandoahPrepareForUpdateRefs prepare_for_update_refs(_gc_state.raw_value());
+
+  // The handshake won't touch worker threads (or control thread, or VM thread), so do those separately.
+  Threads::non_java_threads_do(&prepare_for_update_refs);
+
+  // Now retire gclabs and plabs and propagate gc_state for mutator threads
+  Handshake::execute(&prepare_for_update_refs);
+
+  _update_refs_iterator.reset();
 }
 
 oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
@@ -1353,34 +1431,6 @@ public:
   }
 };
 
-class ShenandoahRetireGCLABClosure : public ThreadClosure {
-private:
-  bool const _resize;
-public:
-  ShenandoahRetireGCLABClosure(bool resize) : _resize(resize) {}
-  void do_thread(Thread* thread) {
-    PLAB* gclab = ShenandoahThreadLocalData::gclab(thread);
-    assert(gclab != nullptr, "GCLAB should be initialized for %s", thread->name());
-    gclab->retire();
-    if (_resize && ShenandoahThreadLocalData::gclab_size(thread) > 0) {
-      ShenandoahThreadLocalData::set_gclab_size(thread, 0);
-    }
-
-    if (ShenandoahHeap::heap()->mode()->is_generational()) {
-      PLAB* plab = ShenandoahThreadLocalData::plab(thread);
-      assert(plab != nullptr, "PLAB should be initialized for %s", thread->name());
-
-      // There are two reasons to retire all plabs between old-gen evacuation passes.
-      //  1. We need to make the plab memory parsable by remembered-set scanning.
-      //  2. We need to establish a trustworthy UpdateWaterMark value within each old-gen heap region
-      ShenandoahGenerationalHeap::heap()->retire_plab(plab, thread);
-      if (_resize && ShenandoahThreadLocalData::plab_size(thread) > 0) {
-        ShenandoahThreadLocalData::set_plab_size(thread, 0);
-      }
-    }
-  }
-};
-
 void ShenandoahHeap::labs_make_parsable() {
   assert(UseTLAB, "Only call with UseTLAB");
 
@@ -1393,6 +1443,10 @@ void ShenandoahHeap::labs_make_parsable() {
   }
 
   workers()->threads_do(&cl);
+
+  if (safepoint_workers() != nullptr) {
+    safepoint_workers()->threads_do(&cl);
+  }
 }
 
 void ShenandoahHeap::tlabs_retire(bool resize) {
@@ -1428,6 +1482,7 @@ void ShenandoahHeap::gclabs_retire(bool resize) {
   for (JavaThreadIteratorWithHandle jtiwh; JavaThread *t = jtiwh.next(); ) {
     cl.do_thread(t);
   }
+
   workers()->threads_do(&cl);
 
   if (safepoint_workers() != nullptr) {
@@ -1947,21 +2002,23 @@ void ShenandoahHeap::prepare_update_heap_references(bool concurrent) {
   _update_refs_iterator.reset();
 }
 
-void ShenandoahHeap::propagate_gc_state_to_java_threads() {
+void ShenandoahHeap::propagate_gc_state_to_all_threads() {
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "Must be at Shenandoah safepoint");
   if (_gc_state_changed) {
+    ShenandoahGCStatePropagator propagator(_gc_state.raw_value());
+    Threads::threads_do(&propagator);
     _gc_state_changed = false;
-    char state = gc_state();
-    for (JavaThreadIteratorWithHandle jtiwh; JavaThread *t = jtiwh.next(); ) {
-      ShenandoahThreadLocalData::set_gc_state(t, state);
-    }
   }
 }
 
-void ShenandoahHeap::set_gc_state(uint mask, bool value) {
+void ShenandoahHeap::set_gc_state_at_safepoint(uint mask, bool value) {
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "Must be at Shenandoah safepoint");
   _gc_state.set_cond(mask, value);
   _gc_state_changed = true;
+}
+
+void ShenandoahHeap::set_gc_state_concurrent(uint mask, bool value) {
+  _gc_state.set_cond(mask, value);
 }
 
 void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
@@ -1975,7 +2032,7 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
   } else {
     mask = MARKING | YOUNG_MARKING;
   }
-  set_gc_state(mask, in_progress);
+  set_gc_state_at_safepoint(mask, in_progress);
   manage_satb_barrier(in_progress);
 }
 
@@ -1991,9 +2048,9 @@ void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
   if (!in_progress && is_concurrent_young_mark_in_progress()) {
     // If young-marking is in progress when we turn off OLD_MARKING, leave MARKING (and YOUNG_MARKING) on
     assert(_gc_state.is_set(MARKING), "concurrent_young_marking_in_progress implies MARKING");
-    set_gc_state(OLD_MARKING, in_progress);
+    set_gc_state_at_safepoint(OLD_MARKING, in_progress);
   } else {
-    set_gc_state(MARKING | OLD_MARKING, in_progress);
+    set_gc_state_at_safepoint(MARKING | OLD_MARKING, in_progress);
   }
   manage_satb_barrier(in_progress);
 }
@@ -2020,7 +2077,7 @@ void ShenandoahHeap::manage_satb_barrier(bool active) {
 
 void ShenandoahHeap::set_evacuation_in_progress(bool in_progress) {
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "Only call this at safepoint");
-  set_gc_state(EVACUATION, in_progress);
+  set_gc_state_at_safepoint(EVACUATION, in_progress);
 }
 
 void ShenandoahHeap::set_concurrent_strong_root_in_progress(bool in_progress) {
@@ -2032,7 +2089,7 @@ void ShenandoahHeap::set_concurrent_strong_root_in_progress(bool in_progress) {
 }
 
 void ShenandoahHeap::set_concurrent_weak_root_in_progress(bool cond) {
-  set_gc_state(WEAK_ROOTS, cond);
+  set_gc_state_at_safepoint(WEAK_ROOTS, cond);
 }
 
 GCTracer* ShenandoahHeap::tracer() {
@@ -2174,7 +2231,7 @@ void ShenandoahHeap::parallel_cleaning(bool full_gc) {
 }
 
 void ShenandoahHeap::set_has_forwarded_objects(bool cond) {
-  set_gc_state(HAS_FORWARDED, cond);
+  set_gc_state_at_safepoint(HAS_FORWARDED, cond);
 }
 
 void ShenandoahHeap::set_unload_classes(bool uc) {
@@ -2214,7 +2271,7 @@ void ShenandoahHeap::set_full_gc_move_in_progress(bool in_progress) {
 }
 
 void ShenandoahHeap::set_update_refs_in_progress(bool in_progress) {
-  set_gc_state(UPDATEREFS, in_progress);
+  set_gc_state_at_safepoint(UPDATEREFS, in_progress);
 }
 
 void ShenandoahHeap::register_nmethod(nmethod* nm) {
@@ -2596,6 +2653,14 @@ bool ShenandoahRegionIterator::has_next() const {
 char ShenandoahHeap::gc_state() const {
   return _gc_state.raw_value();
 }
+
+bool ShenandoahHeap::is_gc_state(GCState state) const {
+  // If the global gc state has been changed, but hasn't yet been propagated to all threads, then
+  // the global gc state is the correct value. Once the gc state has been synchronized with all threads,
+  // _gc_state_changed will be toggled to false and we need to use the thread local state.
+  return _gc_state_changed ? _gc_state.is_set(state) : ShenandoahThreadLocalData::is_gc_state(state);
+}
+
 
 ShenandoahLiveData* ShenandoahHeap::get_liveness_cache(uint worker_id) {
 #ifdef ASSERT

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -359,18 +359,35 @@ private:
 
   size_t _gc_no_progress_count;
 
-  // This updates the singlular, global gc state. This must happen on a safepoint.
-  void set_gc_state(uint mask, bool value);
+  // This updates the singular, global gc state. This call must happen on a safepoint.
+  void set_gc_state_at_safepoint(uint mask, bool value);
+
+  // This also updates the global gc state, but does not need to be called on a safepoint.
+  // Critically, this method will _not_ flag that the global gc state has changed and threads
+  // will continue to use their thread local copy. This is expected to be used in conjunction
+  // with a handshake operation to propagate the new gc state.
+  void set_gc_state_concurrent(uint mask, bool value);
 
 public:
+  // This returns the raw value of the singular, global gc state.
   char gc_state() const;
 
-  // This copies the global gc state into a thread local variable for java threads.
-  // It is primarily intended to support quick access at barriers.
-  void propagate_gc_state_to_java_threads();
+  // Compares the given state against either the global gc state, or the thread local state.
+  // The global gc state may change on a safepoint and is the correct value to use until
+  // the global gc state has been propagated to all threads (after which, this method will
+  // compare against the thread local state). The thread local gc state may also be changed
+  // by a handshake operation, in which case, this function continues using the updated thread
+  // local value.
+  bool is_gc_state(GCState state) const;
+
+  // This copies the global gc state into a thread local variable for all threads.
+  // The thread local gc state is primarily intended to support quick access at barriers.
+  // All threads are updated because in some cases the control thread or the vm thread may
+  // need to execute the load reference barrier.
+  void propagate_gc_state_to_all_threads();
 
   // This is public to support assertions that the state hasn't been changed off of
-  // a safepoint and that any changes were propagated to java threads after the safepoint.
+  // a safepoint and that any changes were propagated to threads after the safepoint.
   bool has_gc_state_changed() const { return _gc_state_changed; }
 
   // Returns true if allocations have occurred in new regions or if regions have been
@@ -390,9 +407,7 @@ public:
   void set_concurrent_strong_root_in_progress(bool cond);
   void set_concurrent_weak_root_in_progress(bool cond);
 
-  inline bool is_stable() const;
   inline bool is_idle() const;
-
   inline bool is_concurrent_mark_in_progress() const;
   inline bool is_concurrent_young_mark_in_progress() const;
   inline bool is_concurrent_old_mark_in_progress() const;
@@ -465,6 +480,10 @@ private:
   void do_class_unloading();
   // Reference updating
   void prepare_update_heap_references(bool concurrent);
+
+  // Retires LABs used for evacuation
+  void concurrent_prepare_for_update_refs();
+
   virtual void update_heap_references(bool concurrent);
   // Final update region states
   void update_heap_region_states(bool concurrent);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -64,10 +64,6 @@ inline ShenandoahHeapRegion* ShenandoahRegionIterator::next() {
   return _heap->get_region(new_index - 1);
 }
 
-inline bool ShenandoahHeap::has_forwarded_objects() const {
-  return _gc_state.is_set(HAS_FORWARDED);
-}
-
 inline WorkerThreads* ShenandoahHeap::workers() const {
   return _workers;
 }
@@ -451,28 +447,36 @@ inline bool ShenandoahHeap::in_collection_set_loc(void* p) const {
   return collection_set()->is_in_loc(p);
 }
 
-inline bool ShenandoahHeap::is_stable() const {
-  return _gc_state.is_clear();
+inline bool ShenandoahHeap::is_idle() const {
+  return _gc_state_changed ? _gc_state.is_clear() : ShenandoahThreadLocalData::gc_state(Thread::current()) == 0;
 }
 
-inline bool ShenandoahHeap::is_idle() const {
-  return _gc_state.is_unset(MARKING | EVACUATION | UPDATEREFS);
+inline bool ShenandoahHeap::has_forwarded_objects() const {
+  return is_gc_state(HAS_FORWARDED);
 }
 
 inline bool ShenandoahHeap::is_concurrent_mark_in_progress() const {
-  return _gc_state.is_set(MARKING);
+  return is_gc_state(MARKING);
 }
 
 inline bool ShenandoahHeap::is_concurrent_young_mark_in_progress() const {
-  return _gc_state.is_set(YOUNG_MARKING);
+  return is_gc_state(YOUNG_MARKING);
 }
 
 inline bool ShenandoahHeap::is_concurrent_old_mark_in_progress() const {
-  return _gc_state.is_set(OLD_MARKING);
+  return is_gc_state(OLD_MARKING);
 }
 
 inline bool ShenandoahHeap::is_evacuation_in_progress() const {
-  return _gc_state.is_set(EVACUATION);
+  return is_gc_state(EVACUATION);
+}
+
+inline bool ShenandoahHeap::is_update_refs_in_progress() const {
+  return is_gc_state(UPDATEREFS);
+}
+
+inline bool ShenandoahHeap::is_concurrent_weak_root_in_progress() const {
+  return is_gc_state(WEAK_ROOTS);
 }
 
 inline bool ShenandoahHeap::is_degenerated_gc_in_progress() const {
@@ -487,20 +491,12 @@ inline bool ShenandoahHeap::is_full_gc_move_in_progress() const {
   return _full_gc_move_in_progress.is_set();
 }
 
-inline bool ShenandoahHeap::is_update_refs_in_progress() const {
-  return _gc_state.is_set(UPDATEREFS);
-}
-
 inline bool ShenandoahHeap::is_stw_gc_in_progress() const {
   return is_full_gc_in_progress() || is_degenerated_gc_in_progress();
 }
 
 inline bool ShenandoahHeap::is_concurrent_strong_root_in_progress() const {
   return _concurrent_strong_root_in_progress.is_set();
-}
-
-inline bool ShenandoahHeap::is_concurrent_weak_root_in_progress() const {
-  return _gc_state.is_set(WEAK_ROOTS);
 }
 
 template<class T>

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
@@ -147,10 +147,10 @@ static int encode_phase(ShenandoahHeap* heap) {
   if (heap->is_update_refs_in_progress() || heap->is_full_gc_move_in_progress()) {
     return 3;
   }
-  if (heap->is_concurrent_mark_in_progress() || heap->is_full_gc_in_progress()) {
+  if (heap->is_concurrent_mark_in_progress() || heap->is_concurrent_weak_root_in_progress() || heap->is_full_gc_in_progress()) {
     return 1;
   }
-  assert(heap->is_idle(), "What is it doing?");
+  assert(heap->is_idle(), "Unexpected gc_state: %d", heap->gc_state());
   return 0;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -47,12 +47,18 @@
 
 ShenandoahGCStateResetter::ShenandoahGCStateResetter() :
   _heap(ShenandoahHeap::heap()),
-  _gc_state(_heap->gc_state()) {
+  _gc_state(_heap->gc_state()),
+  _gc_state_changed(_heap->_gc_state_changed) {
+  // Clear state to deactivate barriers. Indicate that state has changed
+  // so that verifier threads will use this value, rather than thread local
+  // values (which we are _not_ changing here).
   _heap->_gc_state.clear();
+  _heap->_gc_state_changed = true;
 }
 
 ShenandoahGCStateResetter::~ShenandoahGCStateResetter() {
   _heap->_gc_state.set(_gc_state);
+  _heap->_gc_state_changed = _gc_state_changed;
   assert(_heap->gc_state() == _gc_state, "Should be restored");
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
@@ -33,6 +33,7 @@ class ShenandoahGCStateResetter : public StackObj {
 private:
   ShenandoahHeap* const _heap;
   const char _gc_state;
+  const bool _gc_state_changed;
 
 public:
   ShenandoahGCStateResetter();

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -111,12 +111,18 @@ public:
   }
 
   static char gc_state(Thread* thread) {
-    assert(thread->is_Java_thread(), "GC state is only synchronized to java threads");
     return data(thread)->_gc_state;
   }
 
+  static bool is_gc_state(Thread* thread, ShenandoahHeap::GCState state) {
+    return (gc_state(thread) & state) != 0;
+  }
+
+  static bool is_gc_state(ShenandoahHeap::GCState state) {
+    return is_gc_state(Thread::current(), state);
+  }
+
   static void initialize_gclab(Thread* thread) {
-    assert (thread->is_Java_thread() || thread->is_Worker_thread(), "Only Java and GC worker threads are allowed to get GCLABs");
     assert(data(thread)->_gclab == nullptr, "Only initialize once");
     data(thread)->_gclab = new PLAB(PLAB::min_size());
     data(thread)->_gclab_size = 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -84,47 +84,47 @@ void VM_ShenandoahInitMark::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Init Mark", SvcGCMarker::CONCURRENT);
   set_active_generation();
   _gc->entry_init_mark();
-  ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
+  ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 
 void VM_ShenandoahFinalMarkStartEvac::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Final Mark", SvcGCMarker::CONCURRENT);
   set_active_generation();
   _gc->entry_final_mark();
-  ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
+  ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 
 void VM_ShenandoahFullGC::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Full GC", SvcGCMarker::FULL);
   set_active_generation();
   _full_gc->entry_full(_gc_cause);
-  ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
+  ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 
 void VM_ShenandoahDegeneratedGC::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Degenerated GC", SvcGCMarker::CONCURRENT);
   set_active_generation();
   _gc->entry_degenerated();
-  ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
+  ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 
 void VM_ShenandoahInitUpdateRefs::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Init Update Refs", SvcGCMarker::CONCURRENT);
   set_active_generation();
   _gc->entry_init_updaterefs();
-  ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
+  ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 
 void VM_ShenandoahFinalUpdateRefs::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Final Update Refs", SvcGCMarker::CONCURRENT);
   set_active_generation();
   _gc->entry_final_updaterefs();
-  ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
+  ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 
 void VM_ShenandoahFinalRoots::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Final Roots", SvcGCMarker::CONCURRENT);
   set_active_generation();
   _gc->entry_final_roots();
-  ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
+  ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -808,6 +808,10 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
         enabled = true;
         expected = ShenandoahHeap::HAS_FORWARDED;
         break;
+      case _verify_gcstate_updating:
+        enabled = true;
+        expected = ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::UPDATEREFS;
+        break;
       case _verify_gcstate_stable:
         enabled = true;
         expected = ShenandoahHeap::STABLE;
@@ -1112,7 +1116,7 @@ void ShenandoahVerifier::verify_before_updaterefs() {
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_notrash,     // trash regions have been recycled already
           _verify_size_exact,          // expect generation and heap sizes to match exactly
-          _verify_gcstate_forwarded    // evacuation should have produced some forwarded objects
+          _verify_gcstate_updating     // evacuation should have produced some forwarded objects
   );
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -789,7 +789,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
   guarantee(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "only when nothing else happens");
   guarantee(ShenandoahVerify, "only when enabled, and bitmap is initialized in ShenandoahHeap::initialize");
 
-  ShenandoahHeap::heap()->propagate_gc_state_to_java_threads();
+  ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 
   // Avoid side-effect of changing workers' active thread count, but bypass concurrent/parallel protocol check
   ShenandoahPushWorkerScope verify_worker_scope(_heap->workers(), _heap->max_workers(), false /*bypass check*/);

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -169,7 +169,10 @@ public:
     _verify_gcstate_stable_weakroots,
 
     // Nothing is in progress, some objects are forwarded
-    _verify_gcstate_forwarded
+    _verify_gcstate_forwarded,
+
+    // Evacuation is done, some objects are forwarded, updating is in progress
+    _verify_gcstate_updating
   } VerifyGCState;
 
   struct VerifyOptions {


### PR DESCRIPTION
Not clean, has two follow up fixes in this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issues
 * [JDK-8344049](https://bugs.openjdk.org/browse/JDK-8344049): Shenandoah: Eliminate init-update-refs safepoint (**Task** - P4)
 * [JDK-8344050](https://bugs.openjdk.org/browse/JDK-8344050): Shenandoah: Retire GC LABs concurrently (**Sub-task** - P4)
 * [JDK-8344055](https://bugs.openjdk.org/browse/JDK-8344055): Shenandoah: Make all threads use local gc state (**Sub-task** - P4)
 * [JDK-8348268](https://bugs.openjdk.org/browse/JDK-8348268): Test gc/shenandoah/TestResizeTLAB.java#compact: fatal error: Before Updating References: Thread C2 CompilerThread1: expected gc-state 9, actual 21 (**Bug** - P3)
 * [JDK-8348092](https://bugs.openjdk.org/browse/JDK-8348092): Shenandoah: assert(nk &gt;= _lowest_valid_narrow_klass_id &amp;&amp; nk &lt;= _highest_valid_narrow_klass_id) failed: narrowKlass ID out of range (3131947710) (**Bug** - P3)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/161.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/161.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/161#issuecomment-2749622828)
</details>
