### PR TITLE
8347617: Shenandoah: Use consistent name for update references phase

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -420,7 +420,7 @@ void ShenandoahBarrierSet::arraycopy_barrier(T* src, T* dst, size_t count) {
   char gc_state = ShenandoahThreadLocalData::gc_state(Thread::current());
   if ((gc_state & ShenandoahHeap::EVACUATION) != 0) {
     arraycopy_evacuation(src, count);
-  } else if ((gc_state & ShenandoahHeap::UPDATEREFS) != 0) {
+  } else if ((gc_state & ShenandoahHeap::UPDATE_REFS) != 0) {
     arraycopy_update(src, count);
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -197,21 +197,21 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
 
     // Perform update-refs phase.
     if (ShenandoahVerify || ShenandoahPacing) {
-      vmop_entry_init_updaterefs();
+      vmop_entry_init_update_refs();
     }
 
-    entry_updaterefs();
-    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_updaterefs)) {
+    entry_update_refs();
+    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_update_refs)) {
       return false;
     }
 
     // Concurrent update thread roots
     entry_update_thread_roots();
-    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_updaterefs)) {
+    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_update_refs)) {
       return false;
     }
 
-    vmop_entry_final_updaterefs();
+    vmop_entry_final_update_refs();
 
     // Update references freed up collection set, kick the cleanup to reclaim the space.
     entry_cleanup_complete();
@@ -265,7 +265,7 @@ void ShenandoahConcurrentGC::vmop_entry_final_mark() {
   VMThread::execute(&op); // jump to entry_final_mark under safepoint
 }
 
-void ShenandoahConcurrentGC::vmop_entry_init_updaterefs() {
+void ShenandoahConcurrentGC::vmop_entry_init_update_refs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   TraceCollectorStats tcs(heap->monitoring_support()->stw_collection_counters());
   ShenandoahTimingsTracker timing(ShenandoahPhaseTimings::init_update_refs_gross);
@@ -275,7 +275,7 @@ void ShenandoahConcurrentGC::vmop_entry_init_updaterefs() {
   VMThread::execute(&op);
 }
 
-void ShenandoahConcurrentGC::vmop_entry_final_updaterefs() {
+void ShenandoahConcurrentGC::vmop_entry_final_update_refs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   TraceCollectorStats tcs(heap->monitoring_support()->stw_collection_counters());
   ShenandoahTimingsTracker timing(ShenandoahPhaseTimings::final_update_refs_gross);
@@ -320,16 +320,16 @@ void ShenandoahConcurrentGC::entry_final_mark() {
   op_final_mark();
 }
 
-void ShenandoahConcurrentGC::entry_init_updaterefs() {
+void ShenandoahConcurrentGC::entry_init_update_refs() {
   static const char* msg = "Pause Init Update Refs";
   ShenandoahPausePhase gc_phase(msg, ShenandoahPhaseTimings::init_update_refs);
   EventMark em("%s", msg);
 
   // No workers used in this phase, no setup required
-  op_init_updaterefs();
+  op_init_update_refs();
 }
 
-void ShenandoahConcurrentGC::entry_final_updaterefs() {
+void ShenandoahConcurrentGC::entry_final_update_refs() {
   static const char* msg = "Pause Final Update Refs";
   ShenandoahPausePhase gc_phase(msg, ShenandoahPhaseTimings::final_update_refs);
   EventMark em("%s", msg);
@@ -338,7 +338,7 @@ void ShenandoahConcurrentGC::entry_final_updaterefs() {
                               ShenandoahWorkerPolicy::calc_workers_for_final_update_ref(),
                               "final reference update");
 
-  op_final_updaterefs();
+  op_final_update_refs();
 }
 
 void ShenandoahConcurrentGC::entry_final_roots() {
@@ -557,7 +557,7 @@ void ShenandoahConcurrentGC::entry_update_thread_roots() {
   op_update_thread_roots();
 }
 
-void ShenandoahConcurrentGC::entry_updaterefs() {
+void ShenandoahConcurrentGC::entry_update_refs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
   static const char* msg = "Concurrent update references";
@@ -569,7 +569,7 @@ void ShenandoahConcurrentGC::entry_updaterefs() {
                               "concurrent reference update");
 
   heap->try_inject_alloc_failure();
-  op_updaterefs();
+  op_update_refs();
 }
 
 void ShenandoahConcurrentGC::entry_cleanup_complete() {
@@ -1058,17 +1058,17 @@ void ShenandoahConcurrentGC::op_evacuate() {
   ShenandoahHeap::heap()->evacuate_collection_set(true /*concurrent*/);
 }
 
-void ShenandoahConcurrentGC::op_init_updaterefs() {
+void ShenandoahConcurrentGC::op_init_update_refs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   if (ShenandoahVerify) {
-    heap->verifier()->verify_before_updaterefs();
+    heap->verifier()->verify_before_update_refs();
   }
   if (ShenandoahPacing) {
-    heap->pacer()->setup_for_updaterefs();
+    heap->pacer()->setup_for_update_refs();
   }
 }
 
-void ShenandoahConcurrentGC::op_updaterefs() {
+void ShenandoahConcurrentGC::op_update_refs() {
   ShenandoahHeap::heap()->update_heap_references(true /*concurrent*/);
 }
 
@@ -1097,7 +1097,7 @@ void ShenandoahConcurrentGC::op_update_thread_roots() {
   Handshake::execute(&cl);
 }
 
-void ShenandoahConcurrentGC::op_final_updaterefs() {
+void ShenandoahConcurrentGC::op_final_update_refs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "must be at safepoint");
   assert(!heap->_update_refs_iterator.has_next(), "Should have finished update references");
@@ -1145,7 +1145,7 @@ void ShenandoahConcurrentGC::op_final_updaterefs() {
   }
 
   if (ShenandoahVerify) {
-    heap->verifier()->verify_after_updaterefs();
+    heap->verifier()->verify_after_update_refs();
   }
 
   if (VerifyAfterGC) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -67,16 +67,16 @@ protected:
   // call the entry method below
   void vmop_entry_init_mark();
   void vmop_entry_final_mark();
-  void vmop_entry_init_updaterefs();
-  void vmop_entry_final_updaterefs();
+  void vmop_entry_init_update_refs();
+  void vmop_entry_final_update_refs();
   void vmop_entry_final_roots();
 
   // Entry methods to normally STW GC operations. These set up logging, monitoring
   // and workers for net VM operation
   void entry_init_mark();
   void entry_final_mark();
-  void entry_init_updaterefs();
-  void entry_final_updaterefs();
+  void entry_init_update_refs();
+  void entry_final_update_refs();
   void entry_final_roots();
 
   // Entry methods to normally concurrent GC operations. These set up logging, monitoring
@@ -93,7 +93,7 @@ protected:
   void entry_cleanup_early();
   void entry_evacuate();
   void entry_update_thread_roots();
-  void entry_updaterefs();
+  void entry_update_refs();
   void entry_cleanup_complete();
 
   // Called when the collection set is empty, but the generational mode has regions to promote in place
@@ -112,10 +112,10 @@ protected:
   void op_strong_roots();
   void op_cleanup_early();
   void op_evacuate();
-  void op_init_updaterefs();
-  void op_updaterefs();
+  void op_init_update_refs();
+  void op_update_refs();
   void op_update_thread_roots();
-  void op_final_updaterefs();
+  void op_final_update_refs();
   void op_final_roots();
   void op_cleanup_complete();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -265,15 +265,15 @@ void ShenandoahDegenGC::op_degenerated() {
       // If heuristics thinks we should do the cycle, this flag would be set,
       // and we need to do update-refs. Otherwise, it would be the shortcut cycle.
       if (heap->has_forwarded_objects()) {
-        op_init_updaterefs();
+        op_init_update_refs();
         assert(!heap->cancelled_gc(), "STW reference update can not OOM");
       } else {
         _abbreviated = true;
       }
 
-    case _degenerated_updaterefs:
+    case _degenerated_update_refs:
       if (heap->has_forwarded_objects()) {
-        op_updaterefs();
+        op_update_refs();
         op_update_roots();
         assert(!heap->cancelled_gc(), "STW reference update can not OOM");
       }
@@ -389,16 +389,16 @@ void ShenandoahDegenGC::op_evacuate() {
   ShenandoahHeap::heap()->evacuate_collection_set(false /* concurrent*/);
 }
 
-void ShenandoahDegenGC::op_init_updaterefs() {
+void ShenandoahDegenGC::op_init_update_refs() {
   // Evacuation has completed
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   heap->prepare_update_heap_references(false /*concurrent*/);
   heap->set_update_refs_in_progress(true);
 }
 
-void ShenandoahDegenGC::op_updaterefs() {
+void ShenandoahDegenGC::op_update_refs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_updaterefs);
+  ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_update_refs);
   // Handed over from concurrent update references phase
   heap->update_heap_references(false /*concurrent*/);
 
@@ -414,7 +414,7 @@ void ShenandoahDegenGC::op_update_roots() {
   heap->update_heap_region_states(false /*concurrent*/);
 
   if (ShenandoahVerify) {
-    heap->verifier()->verify_after_updaterefs();
+    heap->verifier()->verify_after_update_refs();
   }
 
   if (VerifyAfterGC) {
@@ -449,7 +449,7 @@ const char* ShenandoahDegenGC::degen_event_message(ShenandoahDegenPoint point) c
       SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Mark)");
     case _degenerated_evac:
       SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Evacuation)");
-    case _degenerated_updaterefs:
+    case _degenerated_update_refs:
       SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Update Refs)");
     default:
       ShouldNotReachHere();

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -53,8 +53,8 @@ private:
   void op_cleanup_early();
 
   void op_evacuate();
-  void op_init_updaterefs();
-  void op_updaterefs();
+  void op_init_update_refs();
+  void op_update_refs();
   void op_update_roots();
   void op_cleanup_complete();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGC.cpp
@@ -45,7 +45,7 @@ const char* ShenandoahGC::degen_point_to_string(ShenandoahDegenPoint point) {
       return "Mark";
     case _degenerated_evac:
       return "Evacuation";
-    case _degenerated_updaterefs:
+    case _degenerated_update_refs:
       return "Update References";
     default:
       ShouldNotReachHere();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGC.hpp
@@ -53,7 +53,7 @@ public:
     _degenerated_roots,
     _degenerated_mark,
     _degenerated_evac,
-    _degenerated_updaterefs,
+    _degenerated_update_refs,
     _DEGENERATED_LIMIT
   };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -851,7 +851,7 @@ private:
       }
 
       if (region_progress && ShenandoahPacing) {
-        _heap->pacer()->report_updaterefs(pointer_delta(update_watermark, r->bottom()));
+        _heap->pacer()->report_update_refs(pointer_delta(update_watermark, r->bottom()));
       }
 
       if (_heap->check_cancelled_gc_and_yield(CONCURRENT)) {
@@ -911,7 +911,7 @@ private:
         }
 
         if (ShenandoahPacing) {
-          _heap->pacer()->report_updaterefs(pointer_delta(end_of_range, start_of_range));
+          _heap->pacer()->report_update_refs(pointer_delta(end_of_range, start_of_range));
         }
       }
     }
@@ -1071,7 +1071,7 @@ void ShenandoahGenerationalHeap::complete_degenerated_cycle() {
   shenandoah_assert_heaplocked_or_safepoint();
   if (is_concurrent_old_mark_in_progress()) {
     // This is still necessary for degenerated cycles because the degeneration point may occur
-    // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_updaterefs for
+    // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_update_refs for
     // a more detailed explanation.
     old_generation()->transfer_pointers_from_satb();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1269,7 +1269,7 @@ void ShenandoahHeap::concurrent_prepare_for_update_refs() {
     // A cancellation at this point means the degenerated cycle must resume from update-refs.
     set_gc_state_concurrent(EVACUATION, false);
     set_gc_state_concurrent(WEAK_ROOTS, false);
-    set_gc_state_concurrent(UPDATEREFS, true);
+    set_gc_state_concurrent(UPDATE_REFS, true);
   }
 
   // This will propagate the gc state and retire gclabs and plabs for threads that require it.
@@ -2051,9 +2051,9 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
 
 void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
 #ifdef ASSERT
-  // has_forwarded_objects() iff UPDATEREFS or EVACUATION
+  // has_forwarded_objects() iff UPDATE_REFS or EVACUATION
   bool has_forwarded = has_forwarded_objects();
-  bool updating_or_evacuating = _gc_state.is_set(UPDATEREFS | EVACUATION);
+  bool updating_or_evacuating = _gc_state.is_set(UPDATE_REFS | EVACUATION);
   bool evacuating = _gc_state.is_set(EVACUATION);
   assert ((has_forwarded == updating_or_evacuating) || (evacuating && !has_forwarded && collection_set()->is_empty()),
           "Updating or evacuating iff has forwarded objects, or if evacuation phase is promoting in place without forwarding");
@@ -2200,7 +2200,7 @@ void ShenandoahHeap::stw_unload_classes(bool full_gc) {
   DEBUG_ONLY(MetaspaceUtils::verify();)
 }
 
-// Weak roots are either pre-evacuated (final mark) or updated (final updaterefs),
+// Weak roots are either pre-evacuated (final mark) or updated (final update refs),
 // so they should not have forwarded oops.
 // However, we do need to "null" dead oops in the roots, if can not be done
 // in concurrent cycles.
@@ -2284,7 +2284,7 @@ void ShenandoahHeap::set_full_gc_move_in_progress(bool in_progress) {
 }
 
 void ShenandoahHeap::set_update_refs_in_progress(bool in_progress) {
-  set_gc_state_at_safepoint(UPDATEREFS, in_progress);
+  set_gc_state_at_safepoint(UPDATE_REFS, in_progress);
 }
 
 void ShenandoahHeap::register_nmethod(nmethod* nm) {
@@ -2430,7 +2430,7 @@ private:
       if (r->is_active() && !r->is_cset()) {
         _heap->marked_object_oop_iterate(r, &cl, update_watermark);
         if (ShenandoahPacing) {
-          _heap->pacer()->report_updaterefs(pointer_delta(update_watermark, r->bottom()));
+          _heap->pacer()->report_update_refs(pointer_delta(update_watermark, r->bottom()));
         }
       }
       if (_heap->check_cancelled_gc_and_yield(CONCURRENT)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -325,7 +325,7 @@ public:
     EVACUATION_BITPOS = 2,
 
     // Heap is under updating: needs no additional barriers.
-    UPDATEREFS_BITPOS = 3,
+    UPDATE_REFS_BITPOS = 3,
 
     // Heap is under weak-reference/roots processing: needs weak-LRB barriers.
     WEAK_ROOTS_BITPOS  = 4,
@@ -342,7 +342,7 @@ public:
     HAS_FORWARDED = 1 << HAS_FORWARDED_BITPOS,
     MARKING       = 1 << MARKING_BITPOS,
     EVACUATION    = 1 << EVACUATION_BITPOS,
-    UPDATEREFS    = 1 << UPDATEREFS_BITPOS,
+    UPDATE_REFS   = 1 << UPDATE_REFS_BITPOS,
     WEAK_ROOTS    = 1 << WEAK_ROOTS_BITPOS,
     YOUNG_MARKING = 1 << YOUNG_MARKING_BITPOS,
     OLD_MARKING   = 1 << OLD_MARKING_BITPOS

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -472,7 +472,7 @@ inline bool ShenandoahHeap::is_evacuation_in_progress() const {
 }
 
 inline bool ShenandoahHeap::is_update_refs_in_progress() const {
-  return is_gc_state(UPDATEREFS);
+  return is_gc_state(UPDATE_REFS);
 }
 
 inline bool ShenandoahHeap::is_concurrent_weak_root_in_progress() const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -104,7 +104,7 @@ void ShenandoahPacer::setup_for_evac() {
                      tax);
 }
 
-void ShenandoahPacer::setup_for_updaterefs() {
+void ShenandoahPacer::setup_for_update_refs() {
   assert(ShenandoahPacing, "Only be here when pacing is enabled");
 
   size_t used = _heap->used();

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
@@ -97,13 +97,13 @@ public:
   void setup_for_idle();
   void setup_for_mark();
   void setup_for_evac();
-  void setup_for_updaterefs();
+  void setup_for_update_refs();
 
   void setup_for_reset();
 
   inline void report_mark(size_t words);
   inline void report_evac(size_t words);
-  inline void report_updaterefs(size_t words);
+  inline void report_update_refs(size_t words);
 
   inline void report_alloc(size_t words);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.inline.hpp
@@ -38,7 +38,7 @@ inline void ShenandoahPacer::report_evac(size_t words) {
   report_internal(words);
 }
 
-inline void ShenandoahPacer::report_updaterefs(size_t words) {
+inline void ShenandoahPacer::report_update_refs(size_t words) {
   report_internal(words);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -146,7 +146,7 @@ class outputStream;
   f(degen_gc_final_rebuild_freeset,                 "  Rebuild Free Set")              \
   f(degen_gc_stw_evac,                              "  Evacuation")                    \
   f(degen_gc_init_update_refs_manage_gclabs,        "  Manage GCLABs")                 \
-  f(degen_gc_updaterefs,                            "  Update References")             \
+  f(degen_gc_update_refs,                           "  Update References")             \
   f(degen_gc_final_update_refs_finish_work,         "  Finish Work")                   \
   f(degen_gc_final_update_refs_update_region_states,"  Update Region States")          \
   f(degen_gc_final_update_refs_trash_cset,          "  Trash Collection Set")          \

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -111,14 +111,14 @@ void VM_ShenandoahDegeneratedGC::doit() {
 void VM_ShenandoahInitUpdateRefs::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Init Update Refs", SvcGCMarker::CONCURRENT);
   set_active_generation();
-  _gc->entry_init_updaterefs();
+  _gc->entry_init_update_refs();
   ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 
 void VM_ShenandoahFinalUpdateRefs::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Final Update Refs", SvcGCMarker::CONCURRENT);
   set_active_generation();
-  _gc->entry_final_updaterefs();
+  _gc->entry_final_update_refs();
   ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -810,7 +810,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
         break;
       case _verify_gcstate_updating:
         enabled = true;
-        expected = ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::UPDATEREFS;
+        expected = ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::UPDATE_REFS;
         break;
       case _verify_gcstate_stable:
         enabled = true;
@@ -1106,7 +1106,7 @@ void ShenandoahVerifier::verify_before_evacuation() {
   );
 }
 
-void ShenandoahVerifier::verify_before_updaterefs() {
+void ShenandoahVerifier::verify_before_update_refs() {
   verify_at_safepoint(
           "Before Updating References",
           _verify_remembered_before_updating_references,  // verify read-write remembered set
@@ -1121,7 +1121,7 @@ void ShenandoahVerifier::verify_before_updaterefs() {
 }
 
 // We have not yet cleanup (reclaimed) the collection set
-void ShenandoahVerifier::verify_after_updaterefs() {
+void ShenandoahVerifier::verify_after_update_refs() {
   verify_at_safepoint(
           "After Updating References",
           _verify_remembered_disable,  // do not verify remembered set

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -214,8 +214,8 @@ public:
   void verify_after_concmark();
   void verify_after_concmark_with_promotions();
   void verify_before_evacuation();
-  void verify_before_updaterefs();
-  void verify_after_updaterefs();
+  void verify_before_update_refs();
+  void verify_after_update_refs();
   void verify_before_fullgc();
   void verify_after_fullgc();
   void verify_after_degenerated();


### PR DESCRIPTION
Trivial merge conflict.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8347617](https://bugs.openjdk.org/browse/JDK-8347617): Shenandoah: Use consistent name for update references phase (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/163.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/163.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/163#issuecomment-2762528937)
</details>
