### PR TITLE
8347804: GenShen: Crash with small GCCardSizeInBytes and small Java heap

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -28,6 +28,7 @@
 #include "gc/shared/tlab_globals.hpp"
 #include "gc/shared/workerPolicy.hpp"
 #include "gc/shenandoah/shenandoahArguments.hpp"
+#include "gc/shenandoah/shenandoahCardTable.hpp"
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
 #include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
@@ -184,6 +185,11 @@ void ShenandoahArguments::initialize() {
   // to converge faster over smaller number of resizing decisions.
   if (FLAG_IS_DEFAULT(TLABAllocationWeight)) {
     FLAG_SET_DEFAULT(TLABAllocationWeight, 90);
+  }
+
+  if (GCCardSizeInBytes < ShenandoahMinCardSizeInBytes) {
+    vm_exit_during_initialization(
+      err_msg("GCCardSizeInBytes ( %u ) must be >= %u\n", GCCardSizeInBytes, (unsigned int) ShenandoahMinCardSizeInBytes));
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCardTable.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCardTable.hpp
@@ -30,6 +30,8 @@
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/macros.hpp"
 
+#define ShenandoahMinCardSizeInBytes 128
+
 class ShenandoahCardTable: public CardTable {
   friend class VMStructs;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -729,7 +729,6 @@ size_t ShenandoahRegionChunkIterator::calc_regular_group_size() {
   // half of the remaining heap, the third processes half of what remains and so on.  The smallest chunk size
   // is represented by _smallest_chunk_size_words.  We do not divide work any smaller than this.
   //
-
   size_t group_size = _heap->num_regions() / 2;
   return group_size;
 }
@@ -775,6 +774,7 @@ size_t ShenandoahRegionChunkIterator::calc_num_groups() {
     // Any remaining regions will be treated as if they are part of the most recently created group.  This group will
     // have more than _regular_group_size chunks within it.
   }
+  assert (num_groups <= _maximum_groups, "Cannot have more than %zu groups", _maximum_groups);
   return num_groups;
 }
 
@@ -786,21 +786,31 @@ size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
   size_t current_group_span = _first_group_chunk_size_b4_rebalance * _regular_group_size;
   size_t smallest_group_span = smallest_chunk_size_words() * _regular_group_size;
 
-  // The first group gets special handling because the first chunk size can be no larger than _largest_chunk_size_words
+  // The first group gets special handling because the first chunk size can be no larger than _maximum_chunk_size_words
   if (region_size_words > _maximum_chunk_size_words) {
     // In the case that we shrink the first group's chunk size, certain other groups will also be subsumed within the first group
     size_t effective_chunk_size = _first_group_chunk_size_b4_rebalance;
+    uint coalesced_groups = 0;
     while (effective_chunk_size >= _maximum_chunk_size_words) {
+      // Each iteration of this loop subsumes one original group into a new rebalanced initial group.
       num_chunks += current_group_span / _maximum_chunk_size_words;
       unspanned_heap_size -= current_group_span;
       effective_chunk_size /= 2;
       current_group_span /= 2;
+      coalesced_groups++;
     }
+    assert(effective_chunk_size * 2 == _maximum_chunk_size_words,
+           "We assume _first_group_chunk_size_b4_rebalance is _maximum_chunk_size_words * a power of two");
+    _largest_chunk_size_words = _maximum_chunk_size_words;
+    _adjusted_num_groups = _num_groups - (coalesced_groups - 1);
   } else {
     num_chunks = _regular_group_size;
     unspanned_heap_size -= current_group_span;
+    _largest_chunk_size_words = current_group_span / num_chunks;
+    _adjusted_num_groups = _num_groups;
     current_group_span /= 2;
   }
+
   size_t spanned_groups = 1;
   while (unspanned_heap_size > 0) {
     if (current_group_span <= unspanned_heap_size) {
@@ -858,11 +868,12 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
   size_t expected_chunk_size_words = _clusters_in_smallest_chunk * CardTable::card_size_in_words() * ShenandoahCardCluster::CardsPerCluster;
   assert(smallest_chunk_size_words() == expected_chunk_size_words, "_smallest_chunk_size (" SIZE_FORMAT") is not valid because it does not equal (" SIZE_FORMAT ")",
          smallest_chunk_size_words(), expected_chunk_size_words);
-#endif
   assert(_num_groups <= _maximum_groups,
          "The number of remembered set scanning groups must be less than or equal to maximum groups");
-  assert(smallest_chunk_size_words() << (_maximum_groups - 1) == _maximum_chunk_size_words,
-         "Maximum number of groups needs to span maximum chunk size to smallest chunk size");
+  assert(smallest_chunk_size_words() << (_adjusted_num_groups - 1) == _largest_chunk_size_words,
+         "The number of groups (%zu) needs to span smallest chunk size (%zu) to largest chunk size (%zu)",
+         _adjusted_num_groups, smallest_chunk_size_words(), _largest_chunk_size_words);
+#endif
 
   size_t words_in_region = ShenandoahHeapRegion::region_size_words();
   _region_index[0] = 0;
@@ -885,7 +896,7 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
   }
 
   size_t previous_group_span = _group_entries[0] * _group_chunk_size[0];
-  for (size_t i = 1; i < _num_groups; i++) {
+  for (size_t i = 1; i < _adjusted_num_groups; i++) {
     _group_chunk_size[i] = _group_chunk_size[i-1] / 2;
     size_t chunks_in_group = _regular_group_size;
     size_t this_group_span = _group_chunk_size[i] * chunks_in_group;
@@ -895,19 +906,19 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
     _group_entries[i] = _group_entries[i-1] + _regular_group_size;
     previous_group_span = total_span_of_groups;
   }
-  if (_group_entries[_num_groups-1] < _total_chunks) {
-    assert((_total_chunks - _group_entries[_num_groups-1]) * _group_chunk_size[_num_groups-1] + previous_group_span ==
+  if (_group_entries[_adjusted_num_groups-1] < _total_chunks) {
+    assert((_total_chunks - _group_entries[_adjusted_num_groups-1]) * _group_chunk_size[_adjusted_num_groups-1] + previous_group_span ==
            heap->num_regions() * words_in_region, "Total region chunks (" SIZE_FORMAT
            ") do not span total heap regions (" SIZE_FORMAT ")", _total_chunks, _heap->num_regions());
-    previous_group_span += (_total_chunks - _group_entries[_num_groups-1]) * _group_chunk_size[_num_groups-1];
-    _group_entries[_num_groups-1] = _total_chunks;
+    previous_group_span += (_total_chunks - _group_entries[_adjusted_num_groups-1]) * _group_chunk_size[_adjusted_num_groups-1];
+    _group_entries[_adjusted_num_groups-1] = _total_chunks;
   }
   assert(previous_group_span == heap->num_regions() * words_in_region, "Total region chunks (" SIZE_FORMAT
          ") do not span total heap regions (" SIZE_FORMAT "): " SIZE_FORMAT " does not equal " SIZE_FORMAT,
          _total_chunks, _heap->num_regions(), previous_group_span, heap->num_regions() * words_in_region);
 
   // Not necessary, but keeps things tidy
-  for (size_t i = _num_groups; i < _maximum_groups; i++) {
+  for (size_t i = _adjusted_num_groups; i < _maximum_groups; i++) {
     _region_index[i] = 0;
     _group_offset[i] = 0;
     _group_entries[i] = _group_entries[i-1];

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -233,6 +233,32 @@
  */
 
 /*
+ * @test id=generational-small-card-size
+ * @summary Test clone barriers work correctly
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:GCCardSizeInBytes=128
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:GCCardSizeInBytes=128
+ *                   -Xint
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:GCCardSizeInBytes=128
+ *                   -XX:-TieredCompilation
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:GCCardSizeInBytes=128
+ *                   -XX:TieredStopAtLevel=1
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:GCCardSizeInBytes=128
+ *                   -XX:TieredStopAtLevel=4
+ *                   TestClone
+ */
+
+/*
  * @test id=generational-verify
  * @summary Test clone barriers work correctly
  * @requires vm.gc.Shenandoah


### PR DESCRIPTION
Not clean, conflicts with SIZE_FORMAT macro removal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8347804](https://bugs.openjdk.org/browse/JDK-8347804): GenShen: Crash with small GCCardSizeInBytes and small Java heap (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/170.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/170.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/170#issuecomment-2779642063)
</details>
