### PR TITLE
8345423: Shenandoah: Parallelize concurrent cleanup

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1061,7 +1061,10 @@ void ShenandoahConcurrentGC::op_strong_roots() {
 }
 
 void ShenandoahConcurrentGC::op_cleanup_early() {
-  ShenandoahHeap::heap()->free_set()->recycle_trash();
+  ShenandoahWorkerScope scope(ShenandoahHeap::heap()->workers(),
+                              ShenandoahWorkerPolicy::calc_workers_for_conc_cleanup(),
+                              "cleanup early.");
+  ShenandoahHeap::heap()->recycle_trash();
 }
 
 void ShenandoahConcurrentGC::op_evacuate() {
@@ -1200,7 +1203,10 @@ void ShenandoahConcurrentGC::op_final_roots() {
 }
 
 void ShenandoahConcurrentGC::op_cleanup_complete() {
-  ShenandoahHeap::heap()->free_set()->recycle_trash();
+  ShenandoahWorkerScope scope(ShenandoahHeap::heap()->workers(),
+                              ShenandoahWorkerPolicy::calc_workers_for_conc_cleanup(),
+                              "cleanup complete.");
+  ShenandoahHeap::heap()->recycle_trash();
 }
 
 bool ShenandoahConcurrentGC::check_cancellation_and_abort(ShenandoahDegenPoint point) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -729,7 +729,6 @@ void ShenandoahRegionPartitions::assert_bounds() {
 ShenandoahFreeSet::ShenandoahFreeSet(ShenandoahHeap* heap, size_t max_regions) :
   _heap(heap),
   _partitions(max_regions, this),
-  _trash_regions(NEW_C_HEAP_ARRAY(ShenandoahHeapRegion*, max_regions, mtGC)),
   _alloc_bias_weight(0)
 {
   clear_internal();
@@ -1004,7 +1003,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
     return nullptr;
   }
   HeapWord* result = nullptr;
-  try_recycle_trashed(r);
+  r->try_recycle_under_lock();
   in_new_region = r->is_empty();
 
   if (in_new_region) {
@@ -1215,7 +1214,7 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
   // Initialize regions:
   for (idx_t i = beg; i <= end; i++) {
     ShenandoahHeapRegion* r = _heap->get_region(i);
-    try_recycle_trashed(r);
+    r->try_recycle_under_lock();
 
     assert(i == beg || _heap->get_region(i - 1)->index() + 1 == r->index(), "Should be contiguous");
     assert(r->is_empty(), "Should be empty");
@@ -1257,63 +1256,28 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
   return _heap->get_region(beg)->bottom();
 }
 
-void ShenandoahFreeSet::try_recycle_trashed(ShenandoahHeapRegion* r) {
-  if (r->is_trash()) {
-    r->recycle();
+class ShenandoahRecycleTrashedRegionClosure final : public ShenandoahHeapRegionClosure {
+public:
+  ShenandoahRecycleTrashedRegionClosure(): ShenandoahHeapRegionClosure() {}
+
+  void heap_region_do(ShenandoahHeapRegion* r) {
+    r->try_recycle();
   }
-}
+
+  bool is_thread_safe() {
+    return true;
+  }
+};
 
 void ShenandoahFreeSet::recycle_trash() {
-  // lock is not reentrable, check we don't have it
+  // lock is not non-reentrant, check we don't have it
   shenandoah_assert_not_heaplocked();
-  size_t count = 0;
-  for (size_t i = 0; i < _heap->num_regions(); i++) {
-    ShenandoahHeapRegion* r = _heap->get_region(i);
-    if (r->is_trash()) {
-      _trash_regions[count++] = r;
-    }
-  }
 
-  size_t total_batches = 0;
-  jlong batch_start_time = 0;
-  jlong recycle_trash_start_time = os::javaTimeNanos();    // This value will be treated as the initial batch_start_time
-  jlong batch_end_time = recycle_trash_start_time;
-  // Process as many batches as can be processed within 10 us.
-  static constexpr jlong deadline_ns = 10000;               // 10 us
-  size_t idx = 0;
-  jlong predicted_next_batch_end_time;
-  jlong batch_process_time_estimate = 0;
-  while (idx < count) {
-    if (idx > 0) {
-      os::naked_yield(); // Yield to allow allocators to take the lock, except on the first iteration
-    }
-    // Avoid another call to javaTimeNanos() if we already know time at which last batch ended
-    batch_start_time = batch_end_time;
-    const jlong deadline = batch_start_time + deadline_ns;
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  heap->assert_gc_workers(heap->workers()->active_workers());
 
-    ShenandoahHeapLocker locker(_heap->lock());
-    do {
-      // Measurements on typical 2024 hardware suggest it typically requires between 1400 and 2000 ns to process a batch of
-      // 32 regions, assuming low contention with other threads.  Sometimes this goes higher, when mutator threads
-      // are contending for CPU cores and/or the heap lock.  On this hardware with a 10 us deadline, we expect 3-6 batches
-      // to be processed between yields most of the time.
-      //
-      // Note that deadline is enforced since the end of previous batch.  In the case that yield() or acquisition of heap lock
-      // takes a "long time", we will have less time to process regions, but we will always process at least one batch between
-      // yields.  Yielding more frequently when there is heavy contention for the heap lock or for CPU cores is considered the
-      // right thing to do.
-      const size_t REGIONS_PER_BATCH = 32;
-      size_t max_idx = MIN2(count, idx + REGIONS_PER_BATCH);
-      while (idx < max_idx) {
-        try_recycle_trashed(_trash_regions[idx++]);
-      }
-      total_batches++;
-      batch_end_time = os::javaTimeNanos();
-      // Estimate includes historic combination of yield times and heap lock acquisition times.
-      batch_process_time_estimate = (batch_end_time - recycle_trash_start_time) / total_batches;
-      predicted_next_batch_end_time = batch_end_time + batch_process_time_estimate;
-    } while ((idx < count) && (predicted_next_batch_end_time < deadline));
-  }
+  ShenandoahRecycleTrashedRegionClosure closure;
+  heap->parallel_heap_region_iterate(&closure);
 }
 
 void ShenandoahFreeSet::flip_to_old_gc(ShenandoahHeapRegion* r) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -286,7 +286,6 @@ class ShenandoahFreeSet : public CHeapObj<mtGC> {
 private:
   ShenandoahHeap* const _heap;
   ShenandoahRegionPartitions _partitions;
-  ShenandoahHeapRegion** _trash_regions;
 
   HeapWord* allocate_aligned_plab(size_t size, ShenandoahAllocRequest& req, ShenandoahHeapRegion* r);
 
@@ -352,7 +351,6 @@ private:
   HeapWord* try_allocate_from_mutator(ShenandoahAllocRequest& req, bool& in_new_region);
 
   void clear_internal();
-  void try_recycle_trashed(ShenandoahHeapRegion *r);
 
   // Returns true iff this region is entirely available, either because it is empty() or because it has been found to represent
   // immediate trash and we'll be able to immediately recycle it.  Note that we cannot recycle immediate trash if

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -545,7 +545,7 @@ public:
   ShenandoahEnsureHeapActiveClosure() : _heap(ShenandoahHeap::heap()) {}
   void heap_region_do(ShenandoahHeapRegion* r) {
     if (r->is_trash()) {
-      r->recycle();
+      r->try_recycle_under_lock();
     }
     if (r->is_cset()) {
       // Leave affiliation unchanged
@@ -994,7 +994,7 @@ public:
     // Recycle all trash regions
     if (r->is_trash()) {
       live = 0;
-      r->recycle();
+      r->try_recycle_under_lock();
     } else {
       if (r->is_old()) {
         ShenandoahGenerationalFullGC::account_for_region(r, _old_regions, _old_usage, _old_humongous_waste);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -886,8 +886,7 @@ size_t ShenandoahGeneration::increment_affiliated_region_count() {
   // During full gc, multiple GC worker threads may change region affiliations without a lock.  No lock is enforced
   // on read and write of _affiliated_region_count.  At the end of full gc, a single thread overwrites the count with
   // a coherent value.
-  _affiliated_region_count++;
-  return _affiliated_region_count;
+  return Atomic::add(&_affiliated_region_count, (size_t) 1);
 }
 
 size_t ShenandoahGeneration::decrement_affiliated_region_count() {
@@ -895,34 +894,37 @@ size_t ShenandoahGeneration::decrement_affiliated_region_count() {
   // During full gc, multiple GC worker threads may change region affiliations without a lock.  No lock is enforced
   // on read and write of _affiliated_region_count.  At the end of full gc, a single thread overwrites the count with
   // a coherent value.
-  _affiliated_region_count--;
+  auto affiliated_region_count = Atomic::sub(&_affiliated_region_count, (size_t) 1);
   assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
-         (_used + _humongous_waste <= _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
+         (used() + _humongous_waste <= affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
          "used + humongous cannot exceed regions");
-  return _affiliated_region_count;
+  return affiliated_region_count;
+}
+
+size_t ShenandoahGeneration::decrement_affiliated_region_count_without_lock() {
+  return Atomic::sub(&_affiliated_region_count, (size_t) 1);
 }
 
 size_t ShenandoahGeneration::increase_affiliated_region_count(size_t delta) {
   shenandoah_assert_heaplocked_or_safepoint();
-  _affiliated_region_count += delta;
-  return _affiliated_region_count;
+  return Atomic::add(&_affiliated_region_count, delta);
 }
 
 size_t ShenandoahGeneration::decrease_affiliated_region_count(size_t delta) {
   shenandoah_assert_heaplocked_or_safepoint();
-  assert(_affiliated_region_count >= delta, "Affiliated region count cannot be negative");
+  assert(Atomic::load(&_affiliated_region_count) >= delta, "Affiliated region count cannot be negative");
 
-  _affiliated_region_count -= delta;
+  auto const affiliated_region_count = Atomic::sub(&_affiliated_region_count, delta);
   assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
-         (_used + _humongous_waste <= _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
+         (_used + _humongous_waste <= affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
          "used + humongous cannot exceed regions");
-  return _affiliated_region_count;
+  return affiliated_region_count;
 }
 
 void ShenandoahGeneration::establish_usage(size_t num_regions, size_t num_bytes, size_t humongous_waste) {
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "must be at a safepoint");
-  _affiliated_region_count = num_regions;
-  _used = num_bytes;
+  Atomic::store(&_affiliated_region_count, num_regions);
+  Atomic::store(&_used, num_bytes);
   _humongous_waste = humongous_waste;
 }
 
@@ -951,21 +953,22 @@ void ShenandoahGeneration::decrease_used(size_t bytes) {
 }
 
 size_t ShenandoahGeneration::used_regions() const {
-  return _affiliated_region_count;
+  return Atomic::load(&_affiliated_region_count);
 }
 
 size_t ShenandoahGeneration::free_unaffiliated_regions() const {
   size_t result = max_capacity() / ShenandoahHeapRegion::region_size_bytes();
-  if (_affiliated_region_count > result) {
+  auto const used_regions = this->used_regions();
+  if (used_regions > result) {
     result = 0;
   } else {
-    result -= _affiliated_region_count;
+    result -= used_regions;
   }
   return result;
 }
 
 size_t ShenandoahGeneration::used_regions_size() const {
-  return _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes();
+  return used_regions() * ShenandoahHeapRegion::region_size_bytes();
 }
 
 size_t ShenandoahGeneration::available() const {
@@ -999,7 +1002,7 @@ size_t ShenandoahGeneration::increase_capacity(size_t increment) {
 
   // This detects arithmetic wraparound on _used
   assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
-         (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() >= _used),
+         (used_regions_size() >= used()),
          "Affiliated regions must hold more than what is currently used");
   return _max_capacity;
 }
@@ -1023,12 +1026,12 @@ size_t ShenandoahGeneration::decrease_capacity(size_t decrement) {
 
   // This detects arithmetic wraparound on _used
   assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
-         (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() >= _used),
+         (used_regions_size() >= used()),
          "Affiliated regions must hold more than what is currently used");
   assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
          (_used <= _max_capacity), "Cannot use more than capacity");
   assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
-         (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() <= _max_capacity),
+         (used_regions_size() <= _max_capacity),
          "Cannot use more than capacity");
   return _max_capacity;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -52,7 +52,7 @@ private:
 
   ShenandoahReferenceProcessor* const _ref_processor;
 
-  size_t _affiliated_region_count;
+  volatile size_t _affiliated_region_count;
 
   // How much free memory is left in the last region of humongous objects.
   // This is _not_ included in used, but it _is_ deducted from available,
@@ -131,7 +131,7 @@ private:
   virtual size_t used_regions() const;
   virtual size_t used_regions_size() const;
   virtual size_t free_unaffiliated_regions() const;
-  size_t used() const override { return _used; }
+  size_t used() const override { return Atomic::load(&_used); }
   size_t available() const override;
   size_t available_with_reserve() const;
   size_t used_including_humongous_waste() const {
@@ -219,6 +219,8 @@ private:
 
   // Return the updated value of affiliated_region_count
   size_t decrement_affiliated_region_count();
+  // Same as decrement_affiliated_region_count, but w/o the need to hold heap lock before being called.
+  size_t decrement_affiliated_region_count_without_lock();
 
   // Return the updated value of affiliated_region_count
   size_t increase_affiliated_region_count(size_t delta);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -625,10 +625,10 @@ public:
   // such an object as unreachable.
   inline bool is_in_old_during_young_collection(oop obj) const;
 
-  inline ShenandoahAffiliation region_affiliation(const ShenandoahHeapRegion* r);
+  inline ShenandoahAffiliation region_affiliation(const ShenandoahHeapRegion* r) const;
   inline void set_affiliation(ShenandoahHeapRegion* r, ShenandoahAffiliation new_affiliation);
 
-  inline ShenandoahAffiliation region_affiliation(size_t index);
+  inline ShenandoahAffiliation region_affiliation(size_t index) const;
 
   bool requires_barriers(stackChunkOop obj) const override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -368,7 +368,7 @@ inline bool ShenandoahHeap::is_in_active_generation(oop obj) const {
   // No flickering!
   assert(gen == active_generation(), "Race?");
 
-  switch (_affiliations[index]) {
+  switch (region_affiliation(index)) {
   case ShenandoahAffiliation::FREE:
     // Free regions are in old, young, and global collections
     return true;
@@ -379,7 +379,7 @@ inline bool ShenandoahHeap::is_in_active_generation(oop obj) const {
     // Old regions are in old and global collections, not in young collections
     return !gen->is_young();
   default:
-    assert(false, "Bad affiliation (%d) for region " SIZE_FORMAT, _affiliations[index], index);
+    assert(false, "Bad affiliation (%d) for region " SIZE_FORMAT, region_affiliation(index), index);
     return false;
   }
 }
@@ -396,8 +396,8 @@ inline bool ShenandoahHeap::is_in_old_during_young_collection(oop obj) const {
   return active_generation()->is_young() && is_in_old(obj);
 }
 
-inline ShenandoahAffiliation ShenandoahHeap::region_affiliation(const ShenandoahHeapRegion *r) {
-  return (ShenandoahAffiliation) _affiliations[r->index()];
+inline ShenandoahAffiliation ShenandoahHeap::region_affiliation(const ShenandoahHeapRegion *r) const {
+  return region_affiliation(r->index());
 }
 
 inline void ShenandoahHeap::assert_lock_for_affiliation(ShenandoahAffiliation orig_affiliation,
@@ -416,7 +416,7 @@ inline void ShenandoahHeap::assert_lock_for_affiliation(ShenandoahAffiliation or
   //
   // Note: during full GC, all transitions between states are possible.  During Full GC, we should be in a safepoint.
 
-  if ((orig_affiliation == ShenandoahAffiliation::FREE) || (new_affiliation == ShenandoahAffiliation::FREE)) {
+  if (orig_affiliation == ShenandoahAffiliation::FREE) {
     shenandoah_assert_heaplocked_or_safepoint();
   }
 }
@@ -425,11 +425,11 @@ inline void ShenandoahHeap::set_affiliation(ShenandoahHeapRegion* r, ShenandoahA
 #ifdef ASSERT
   assert_lock_for_affiliation(region_affiliation(r), new_affiliation);
 #endif
-  _affiliations[r->index()] = (uint8_t) new_affiliation;
+  Atomic::store(_affiliations + r->index(), (uint8_t) new_affiliation);
 }
 
-inline ShenandoahAffiliation ShenandoahHeap::region_affiliation(size_t index) {
-  return (ShenandoahAffiliation) _affiliations[index];
+inline ShenandoahAffiliation ShenandoahHeap::region_affiliation(size_t index) const {
+  return (ShenandoahAffiliation) Atomic::load(_affiliations + index);
 }
 
 inline bool ShenandoahHeap::requires_marking(const void* entry) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -89,11 +89,12 @@ ShenandoahHeapRegion::ShenandoahHeapRegion(HeapWord* start, size_t index, bool c
   if (ZapUnusedHeapArea && committed) {
     SpaceMangler::mangle_region(MemRegion(_bottom, _end));
   }
+  _recycling.unset();
 }
 
 void ShenandoahHeapRegion::report_illegal_transition(const char *method) {
   stringStream ss;
-  ss.print("Illegal region state transition from \"%s\", at %s\n  ", region_state_to_string(_state), method);
+  ss.print("Illegal region state transition from \"%s\", at %s\n  ", region_state_to_string(state()), method);
   print_on(&ss);
   fatal("%s", ss.freeze());
 }
@@ -101,7 +102,7 @@ void ShenandoahHeapRegion::report_illegal_transition(const char *method) {
 void ShenandoahHeapRegion::make_regular_allocation(ShenandoahAffiliation affiliation) {
   shenandoah_assert_heaplocked();
   reset_age();
-  switch (_state) {
+  switch (state()) {
     case _empty_uncommitted:
       do_commit();
     case _empty_committed:
@@ -121,7 +122,7 @@ void ShenandoahHeapRegion::make_regular_allocation(ShenandoahAffiliation affilia
 void ShenandoahHeapRegion::make_affiliated_maybe() {
   shenandoah_assert_heaplocked();
   assert(!ShenandoahHeap::heap()->mode()->is_generational(), "Only call if non-generational");
-  switch (_state) {
+  switch (state()) {
    case _empty_uncommitted:
    case _empty_committed:
    case _cset:
@@ -145,13 +146,22 @@ void ShenandoahHeapRegion::make_regular_bypass() {
   assert (ShenandoahHeap::heap()->is_full_gc_in_progress() || ShenandoahHeap::heap()->is_degenerated_gc_in_progress(),
           "only for full or degen GC");
   reset_age();
-  switch (_state) {
+  auto cur_state = state();
+  switch (cur_state) {
     case _empty_uncommitted:
       do_commit();
     case _empty_committed:
     case _cset:
     case _humongous_start:
     case _humongous_cont:
+      if (cur_state == _humongous_start || cur_state == _humongous_cont) {
+        // CDS allocates chunks of the heap to fill with regular objects. The allocator
+        // will dutifully track any waste in the unused portion of the last region. Once
+        // CDS has finished initializing the objects, it will convert these regions to
+        // regular regions. The 'waste' in the last region is no longer wasted at this point,
+        // so we must stop treating it as such.
+        decrement_humongous_waste();
+      }
       set_state(_regular);
       return;
     case _pinned_cset:
@@ -168,7 +178,7 @@ void ShenandoahHeapRegion::make_regular_bypass() {
 void ShenandoahHeapRegion::make_humongous_start() {
   shenandoah_assert_heaplocked();
   reset_age();
-  switch (_state) {
+  switch (state()) {
     case _empty_uncommitted:
       do_commit();
     case _empty_committed:
@@ -185,7 +195,7 @@ void ShenandoahHeapRegion::make_humongous_start_bypass(ShenandoahAffiliation aff
   // Don't bother to account for affiliated regions during Full GC.  We recompute totals at end.
   set_affiliation(affiliation);
   reset_age();
-  switch (_state) {
+  switch (state()) {
     case _empty_committed:
     case _regular:
     case _humongous_start:
@@ -200,7 +210,7 @@ void ShenandoahHeapRegion::make_humongous_start_bypass(ShenandoahAffiliation aff
 void ShenandoahHeapRegion::make_humongous_cont() {
   shenandoah_assert_heaplocked();
   reset_age();
-  switch (_state) {
+  switch (state()) {
     case _empty_uncommitted:
       do_commit();
     case _empty_committed:
@@ -217,7 +227,7 @@ void ShenandoahHeapRegion::make_humongous_cont_bypass(ShenandoahAffiliation affi
   set_affiliation(affiliation);
   // Don't bother to account for affiliated regions during Full GC.  We recompute totals at end.
   reset_age();
-  switch (_state) {
+  switch (state()) {
     case _empty_committed:
     case _regular:
     case _humongous_start:
@@ -233,7 +243,7 @@ void ShenandoahHeapRegion::make_pinned() {
   shenandoah_assert_heaplocked();
   assert(pin_count() > 0, "Should have pins: " SIZE_FORMAT, pin_count());
 
-  switch (_state) {
+  switch (state()) {
     case _regular:
       set_state(_pinned);
     case _pinned_cset:
@@ -244,7 +254,7 @@ void ShenandoahHeapRegion::make_pinned() {
     case _pinned_humongous_start:
       return;
     case _cset:
-      _state = _pinned_cset;
+      set_state(_pinned_cset);
       return;
     default:
       report_illegal_transition("pinning");
@@ -255,7 +265,7 @@ void ShenandoahHeapRegion::make_unpinned() {
   shenandoah_assert_heaplocked();
   assert(pin_count() == 0, "Should not have pins: " SIZE_FORMAT, pin_count());
 
-  switch (_state) {
+  switch (state()) {
     case _pinned:
       assert(is_affiliated(), "Pinned region should be affiliated");
       set_state(_regular);
@@ -277,7 +287,7 @@ void ShenandoahHeapRegion::make_unpinned() {
 void ShenandoahHeapRegion::make_cset() {
   shenandoah_assert_heaplocked();
   // Leave age untouched.  We need to consult the age when we are deciding whether to promote evacuated objects.
-  switch (_state) {
+  switch (state()) {
     case _regular:
       set_state(_cset);
     case _cset:
@@ -290,7 +300,7 @@ void ShenandoahHeapRegion::make_cset() {
 void ShenandoahHeapRegion::make_trash() {
   shenandoah_assert_heaplocked();
   reset_age();
-  switch (_state) {
+  switch (state()) {
     case _humongous_start:
     case _humongous_cont:
     {
@@ -320,10 +330,9 @@ void ShenandoahHeapRegion::make_trash_immediate() {
 }
 
 void ShenandoahHeapRegion::make_empty() {
-  shenandoah_assert_heaplocked();
   reset_age();
   CENSUS_NOISE(clear_youth();)
-  switch (_state) {
+  switch (state()) {
     case _trash:
       set_state(_empty_committed);
       _empty_time = os::elapsedTime();
@@ -335,7 +344,7 @@ void ShenandoahHeapRegion::make_empty() {
 
 void ShenandoahHeapRegion::make_uncommitted() {
   shenandoah_assert_heaplocked();
-  switch (_state) {
+  switch (state()) {
     case _empty_committed:
       do_uncommit();
       set_state(_empty_uncommitted);
@@ -349,7 +358,7 @@ void ShenandoahHeapRegion::make_committed_bypass() {
   shenandoah_assert_heaplocked();
   assert (ShenandoahHeap::heap()->is_full_gc_in_progress(), "only for full GC");
 
-  switch (_state) {
+  switch (state()) {
     case _empty_uncommitted:
       do_commit();
       set_state(_empty_committed);
@@ -390,7 +399,7 @@ void ShenandoahHeapRegion::print_on(outputStream* st) const {
   st->print("|");
   st->print(SIZE_FORMAT_W(5), this->_index);
 
-  switch (_state) {
+  switch (state()) {
     case _empty_uncommitted:
       st->print("|EU ");
       break;
@@ -560,27 +569,62 @@ ShenandoahHeapRegion* ShenandoahHeapRegion::humongous_start_region() const {
   return r;
 }
 
-void ShenandoahHeapRegion::recycle() {
-  shenandoah_assert_heaplocked();
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  ShenandoahGeneration* generation = heap->generation_for(affiliation());
 
-  heap->decrease_used(generation, used());
-  generation->decrement_affiliated_region_count();
+void ShenandoahHeapRegion::recycle_internal() {
+  assert(_recycling.is_set() && is_trash(), "Wrong state");
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
 
   set_top(bottom());
   clear_live_data();
   reset_alloc_metadata();
-
   heap->marking_context()->reset_top_at_mark_start(this);
-
   set_update_watermark(bottom());
-
-  make_empty();
-
-  set_affiliation(FREE);
   if (ZapUnusedHeapArea) {
     SpaceMangler::mangle_region(MemRegion(bottom(), end()));
+  }
+
+  make_empty();
+  set_affiliation(FREE);
+}
+
+void ShenandoahHeapRegion::try_recycle_under_lock() {
+  shenandoah_assert_heaplocked();
+  if (is_trash() && _recycling.try_set()) {
+    if (is_trash()) {
+      ShenandoahHeap* heap = ShenandoahHeap::heap();
+      ShenandoahGeneration* generation = heap->generation_for(affiliation());
+
+      heap->decrease_used(generation, used());
+      generation->decrement_affiliated_region_count();
+
+      recycle_internal();
+    }
+    _recycling.unset();
+  } else {
+    // Ensure recycling is unset before returning to mutator to continue memory allocation.
+    while (_recycling.is_set()) {
+      if (os::is_MP()) {
+        SpinPause();
+      } else {
+        os::naked_yield();
+      }
+    }
+  }
+}
+
+void ShenandoahHeapRegion::try_recycle() {
+  shenandoah_assert_not_heaplocked();
+  if (is_trash() && _recycling.try_set()) {
+    // Double check region state after win the race to set recycling flag
+    if (is_trash()) {
+      ShenandoahHeap* heap = ShenandoahHeap::heap();
+      ShenandoahGeneration* generation = heap->generation_for(affiliation());
+      heap->decrease_used(generation, used());
+      generation->decrement_affiliated_region_count_without_lock();
+
+      recycle_internal();
+    }
+    _recycling.unset();
   }
 }
 
@@ -786,11 +830,11 @@ void ShenandoahHeapRegion::set_state(RegionState to) {
     evt.set_index((unsigned) index());
     evt.set_start((uintptr_t)bottom());
     evt.set_used(used());
-    evt.set_from(_state);
+    evt.set_from(state());
     evt.set_to(to);
     evt.commit();
   }
-  _state = to;
+  Atomic::store(&_state, to);
 }
 
 void ShenandoahHeapRegion::record_pin() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.cpp
@@ -74,3 +74,7 @@ uint ShenandoahWorkerPolicy::calc_workers_for_final_update_ref() {
 uint ShenandoahWorkerPolicy::calc_workers_for_conc_reset() {
   return ConcGCThreads;
 }
+
+uint ShenandoahWorkerPolicy::calc_workers_for_conc_cleanup() {
+  return ConcGCThreads;
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
@@ -64,6 +64,9 @@ public:
 
   // Calculate workers for concurrent reset
   static uint calc_workers_for_conc_reset();
+
+  // Calculate workers for concurrent cleanup
+  static uint calc_workers_for_conc_cleanup();
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHWORKERPOLICY_HPP

--- a/src/hotspot/share/gc/shenandoah/vmStructs_shenandoah.hpp
+++ b/src/hotspot/share/gc/shenandoah/vmStructs_shenandoah.hpp
@@ -39,7 +39,7 @@
   volatile_nonstatic_field(ShenandoahGeneration, _used,            size_t)                            \
   static_field(ShenandoahHeapRegion, RegionSizeBytes,              size_t)                            \
   static_field(ShenandoahHeapRegion, RegionSizeBytesShift,         size_t)                            \
-  nonstatic_field(ShenandoahHeapRegion, _state,                    ShenandoahHeapRegion::RegionState) \
+  volatile_nonstatic_field(ShenandoahHeapRegion, _state,           ShenandoahHeapRegion::RegionState) \
   nonstatic_field(ShenandoahHeapRegion, _index,                    size_t const)                      \
   nonstatic_field(ShenandoahHeapRegion, _bottom,                   HeapWord* const)                   \
   nonstatic_field(ShenandoahHeapRegion, _top,                      HeapWord*)                         \


### PR DESCRIPTION
Not clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8345423](https://bugs.openjdk.org/browse/JDK-8345423): Shenandoah: Parallelize concurrent cleanup (**Enhancement** - P4)


### Reviewers
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - no project role)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/172.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/172#issuecomment-2790966576)
</details>
