### PR TITLE
8351077: Shenandoah: Update comments in ShenandoahConcurrentGC::op_reset_after_collect

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1228,11 +1228,9 @@ void ShenandoahConcurrentGC::op_reset_after_collect() {
 
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational()) {
-    // Resetting bitmaps of young gen when bootstrap old GC or there is preempted old GC
-    // causes crash due to remembered set violation, hence condition is added to fix the crash.
-    // Assuming bitmaps of young gen are not used at all after the cycle, the crash should not
-    // have happend, it seems to tickle a bug in remembered set scan. Root causing and fixing of the bug
-    // will be tracked via ticket https://bugs.openjdk.org/browse/JDK-8347371
+    // If we are in the midst of an old gc bootstrap or an old marking, we want to leave the mark bit map of
+    // the young generation intact. In particular, reference processing in the old generation may potentially
+    // need the reachability of a young generation referent of a Reference object in the old generation.
     if (!_do_old_gc_bootstrap && !heap->is_concurrent_old_mark_in_progress()) {
       heap->young_generation()->reset_mark_bitmap<false>();
     }


### PR DESCRIPTION
Clean, trivial comment only change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351077](https://bugs.openjdk.org/browse/JDK-8351077): Shenandoah: Update comments in ShenandoahConcurrentGC::op_reset_after_collect (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/175.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/175.diff</a>

</details>
