### PR TITLE
8350905: Shenandoah: Releasing a WeakHandle's referent may extend its lifetime

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -153,10 +153,19 @@ inline void ShenandoahBarrierSet::enqueue(oop obj) {
 
 template <DecoratorSet decorators, typename T>
 inline void ShenandoahBarrierSet::satb_barrier(T *field) {
+  // Uninitialized and no-keepalive stores do not need barrier.
   if (HasDecorator<decorators, IS_DEST_UNINITIALIZED>::value ||
       HasDecorator<decorators, AS_NO_KEEPALIVE>::value) {
     return;
   }
+
+  // Stores to weak/phantom require no barrier. The original references would
+  // have been enqueued in the SATB buffer by the load barrier if they were needed.
+  if (HasDecorator<decorators, ON_WEAK_OOP_REF>::value ||
+      HasDecorator<decorators, ON_PHANTOM_OOP_REF>::value) {
+    return;
+  }
+
   if (ShenandoahSATBBarrier && _heap->is_concurrent_mark_in_progress()) {
     T heap_oop = RawAccess<>::oop_load(field);
     if (!CompressedOops::is_null(heap_oop)) {
@@ -261,6 +270,7 @@ inline void ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_st
 template <DecoratorSet decorators, typename BarrierSetT>
 template <typename T>
 inline void ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_store_not_in_heap(T* addr, oop value) {
+  assert((decorators & ON_UNKNOWN_OOP_REF) == 0, "Reference strength must be known");
   oop_store_common(addr, value);
 }
 


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350905](https://bugs.openjdk.org/browse/JDK-8350905): Shenandoah: Releasing a WeakHandle's referent may extend its lifetime (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/178/head:pull/178` \
`$ git checkout pull/178`

Update a local copy of the PR: \
`$ git checkout pull/178` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 178`

View PR using the GUI difftool: \
`$ git pr show -t 178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/178.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/178.diff</a>

</details>
