### PR TITLE
8343468: GenShen: Enable relocation of remembered set card tables

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4694,7 +4694,7 @@ operand immByteMapBase()
 %{
   // Get base of card map
   predicate(BarrierSet::barrier_set()->is_a(BarrierSet::CardTableBarrierSet) &&
-            !BarrierSet::barrier_set()->is_a(BarrierSet::ShenandoahBarrierSet) &&
+            SHENANDOAHGC_ONLY(!BarrierSet::barrier_set()->is_a(BarrierSet::ShenandoahBarrierSet) &&)
             (CardTable::CardValue*)n->get_ptr() == ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base());
   match(ConP);
 

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4694,6 +4694,7 @@ operand immByteMapBase()
 %{
   // Get base of card map
   predicate(BarrierSet::barrier_set()->is_a(BarrierSet::CardTableBarrierSet) &&
+            !BarrierSet::barrier_set()->is_a(BarrierSet::ShenandoahBarrierSet) &&
             (CardTable::CardValue*)n->get_ptr() == ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base());
   match(ConP);
 

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -383,7 +383,8 @@ void ShenandoahBarrierSetAssembler::store_check(MacroAssembler* masm, Register o
 
   assert(CardTable::dirty_card_val() == 0, "must be");
 
-  __ load_byte_map_base(rscratch1);
+  Address curr_ct_holder_addr(rthread, in_bytes(ShenandoahThreadLocalData::card_table_offset()));
+  __ ldr(rscratch1, curr_ct_holder_addr);
 
   if (UseCondCardMark) {
     Label L_already_dirty;
@@ -638,7 +639,8 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
   // number of bytes to copy
   __ sub(count, end, start);
 
-  __ load_byte_map_base(scratch);
+  Address curr_ct_holder_addr(rthread, in_bytes(ShenandoahThreadLocalData::card_table_offset()));
+  __ ldr(scratch, curr_ct_holder_addr);
   __ add(start, start, scratch);
   __ bind(L_loop);
   __ strb(zr, Address(start, count));

--- a/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
@@ -588,9 +588,6 @@ void ShenandoahBarrierSetAssembler::load_at(
 
 void ShenandoahBarrierSetAssembler::store_check(MacroAssembler* masm, Register base, RegisterOrConstant ind_or_offs, Register tmp) {
   assert(ShenandoahCardBarrier, "Should have been checked by caller");
-
-  ShenandoahBarrierSet* ctbs = ShenandoahBarrierSet::barrier_set();
-  CardTable* ct = ctbs->card_table();
   assert_different_registers(base, tmp, R0);
 
   if (ind_or_offs.is_constant()) {
@@ -599,7 +596,7 @@ void ShenandoahBarrierSetAssembler::store_check(MacroAssembler* masm, Register b
     __ add(base, ind_or_offs.as_register(), base);
   }
 
-  __ load_const_optimized(tmp, (address)ct->byte_map_base(), R0);
+  __ ld(tmp, in_bytes(ShenandoahThreadLocalData::card_table_offset()), R16_thread); /* tmp = *[R16_thread + card_table_offset] */
   __ srdi(base, base, CardTable::card_shift());
   __ li(R0, CardTable::dirty_card_val());
   __ stbx(R0, tmp, base);
@@ -798,7 +795,8 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
   __ srdi(addr, addr, CardTable::card_shift());
   __ srdi(count, count, CardTable::card_shift());
   __ subf(count, addr, count);
-  __ add_const_optimized(addr, addr, (address)ct->byte_map_base(), R0);
+  __ ld(R0, in_bytes(ShenandoahThreadLocalData::card_table_offset()), R16_thread);
+  __ add(addr, addr, R0);
   __ addi(count, count, 1);
   __ li(R0, 0);
   __ mtctr(count);

--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
@@ -142,7 +142,7 @@ void ShenandoahBarrierSetAssembler::satb_write_barrier_pre(MacroAssembler* masm,
   __ ld(tmp1, index);                  // tmp := *index_adr
   __ beqz(tmp1, runtime);              // tmp == 0? If yes, goto runtime
 
-  __ subi(tmp1, tmp1, wordSize);       // tmp := tmp - wordSize
+  __ sub(tmp1, tmp1, wordSize);       // tmp := tmp - wordSize
   __ sd(tmp1, index);                  // *index_adr := tmp
   __ ld(tmp2, buffer);
   __ add(tmp1, tmp1, tmp2);            // tmp := tmp + *buffer_adr
@@ -562,7 +562,7 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
   // end = start + count << LogBytesPerHeapOop
   // last element address to make inclusive
   __ shadd(end, count, start, tmp, LogBytesPerHeapOop);
-  __ subi(end, end, BytesPerHeapOop);
+  __ sub(end, end, BytesPerHeapOop);
   __ srli(start, start, CardTable::card_shift());
   __ srli(end, end, CardTable::card_shift());
 
@@ -576,7 +576,7 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
   __ bind(L_loop);
   __ add(tmp, start, count);
   __ sb(zr, Address(tmp));
-  __ subi(count, count, 1);
+  __ sub(count, count, 1);
   __ bgez(count, L_loop);
   __ bind(L_done);
 }
@@ -691,7 +691,7 @@ void ShenandoahBarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAss
   __ ld(tmp, queue_index);
   __ beqz(tmp, runtime);
 
-  __ subi(tmp, tmp, wordSize);
+  __ sub(tmp, tmp, wordSize);
   __ sd(tmp, queue_index);
   __ ld(t1, buffer);
   __ add(tmp, tmp, t1);

--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.hpp
@@ -57,9 +57,15 @@ private:
                                     bool tosca_live,
                                     bool expand_call);
 
+  void store_check(MacroAssembler* masm, Register obj);
+
   void resolve_forward_pointer(MacroAssembler* masm, Register dst, Register tmp = noreg);
   void resolve_forward_pointer_not_null(MacroAssembler* masm, Register dst, Register tmp = noreg);
   void load_reference_barrier(MacroAssembler* masm, Register dst, Address load_addr, DecoratorSet decorators);
+
+  void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators,
+                                        Register start, Register count,
+                                        Register tmp, RegSet saved_regs);
 
 public:
 
@@ -74,6 +80,9 @@ public:
 
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
                                   Register src, Register dst, Register count, RegSet saved_regs);
+
+  virtual void arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
+                                  Register start, Register count, Register tmp, RegSet saved_regs);
 
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register dst, Address src, Register tmp1, Register tmp2);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2875,6 +2875,7 @@ operand immByteMapBase()
 %{
   // Get base of card map
   predicate(BarrierSet::barrier_set()->is_a(BarrierSet::CardTableBarrierSet) &&
+            !BarrierSet::barrier_set()->is_a(BarrierSet::ShenandoahBarrierSet) &&
             (CardTable::CardValue*)n->get_ptr() ==
              ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base());
   match(ConP);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2875,7 +2875,7 @@ operand immByteMapBase()
 %{
   // Get base of card map
   predicate(BarrierSet::barrier_set()->is_a(BarrierSet::CardTableBarrierSet) &&
-            !BarrierSet::barrier_set()->is_a(BarrierSet::ShenandoahBarrierSet) &&
+            SHENANDOAHGC_ONLY(!BarrierSet::barrier_set()->is_a(BarrierSet::ShenandoahBarrierSet) &&)
             (CardTable::CardValue*)n->get_ptr() ==
              ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base());
   match(ConP);

--- a/src/hotspot/cpu/x86/gc/shared/cardTableBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/cardTableBarrierSetAssembler_x86.cpp
@@ -48,6 +48,7 @@ void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembl
   CardTableBarrierSet* ctbs = barrier_set_cast<CardTableBarrierSet>(bs);
   CardTable* ct = ctbs->card_table();
   intptr_t disp = (intptr_t) ct->byte_map_base();
+  SHENANDOAHGC_ONLY(assert(!UseShenandoahGC, "Shenandoah byte_map_base is not constant.");)
 
   Label L_loop, L_done;
   const Register end = count;

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -940,7 +940,7 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
   const Register thread = tmp;
   __ get_thread(thread);
 
-  Address curr_ct_holder_addr(thread, in_bytes(ShenandoahThreadLocalData::byte_map_base_offset()));
+  Address curr_ct_holder_addr(thread, in_bytes(ShenandoahThreadLocalData::card_table_offset()));
   __ movptr(tmp, curr_ct_holder_addr);
 
   __ lea(end, Address(addr, count, Address::times_ptr, -wordSize));

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -615,31 +615,31 @@ void ShenandoahBarrierSetAssembler::store_check(MacroAssembler* masm, Register o
 
   // Does a store check for the oop in register obj. The content of
   // register obj is destroyed afterwards.
-
-  ShenandoahBarrierSet* ctbs = ShenandoahBarrierSet::barrier_set();
-  CardTable* ct = ctbs->card_table();
-
   __ shrptr(obj, CardTable::card_shift());
 
-  Address card_addr;
+  // We'll use this register as the TLS base address and also later on
+  // to hold the byte_map_base.
+  Register thread = LP64_ONLY(r15_thread) NOT_LP64(rcx);
+  Register tmp = LP64_ONLY(rscratch1) NOT_LP64(rdx);
 
-  // The calculation for byte_map_base is as follows:
-  // byte_map_base = _byte_map - (uintptr_t(low_bound) >> card_shift);
-  // So this essentially converts an address to a displacement and it will
-  // never need to be relocated. On 64-bit however the value may be too
-  // large for a 32-bit displacement.
-  intptr_t byte_map_base = (intptr_t)ct->byte_map_base();
-  if (__ is_simm32(byte_map_base)) {
-    card_addr = Address(noreg, obj, Address::times_1, byte_map_base);
-  } else {
-    // By doing it as an ExternalAddress 'byte_map_base' could be converted to a rip-relative
-    // displacement and done in a single instruction given favorable mapping and a
-    // smarter version of as_Address. However, 'ExternalAddress' generates a relocation
-    // entry and that entry is not properly handled by the relocation code.
-    AddressLiteral cardtable((address)byte_map_base, relocInfo::none);
-    Address index(noreg, obj, Address::times_1);
-    card_addr = __ as_Address(ArrayAddress(cardtable, index), rscratch1);
+#ifndef _LP64
+  // The next two ifs are just to get temporary registers to use for TLS and card table base.
+  if (thread == obj) {
+    thread = rdx;
+    tmp = rsi;
   }
+  if (tmp == obj) {
+    tmp = rsi;
+  }
+
+  __ push(thread);
+  __ push(tmp);
+  __ get_thread(thread);
+#endif
+
+  Address curr_ct_holder_addr(thread, in_bytes(ShenandoahThreadLocalData::card_table_offset()));
+  __ movptr(tmp, curr_ct_holder_addr);
+  Address card_addr(tmp, obj, Address::times_1);
 
   int dirty = CardTable::dirty_card_val();
   if (UseCondCardMark) {
@@ -651,6 +651,11 @@ void ShenandoahBarrierSetAssembler::store_check(MacroAssembler* masm, Register o
   } else {
     __ movb(card_addr, dirty);
   }
+
+#ifndef _LP64
+  __ pop(tmp);
+  __ pop(thread);
+#endif
 }
 
 void ShenandoahBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
@@ -906,10 +911,6 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
                                                                      Register tmp) {
   assert(ShenandoahCardBarrier, "Should have been checked by caller");
 
-  ShenandoahBarrierSet* bs = ShenandoahBarrierSet::barrier_set();
-  CardTable* ct = bs->card_table();
-  intptr_t disp = (intptr_t) ct->byte_map_base();
-
   Label L_loop, L_done;
   const Register end = count;
   assert_different_registers(addr, end);
@@ -919,13 +920,16 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
   __ jccb(Assembler::zero, L_done);
 
 #ifdef _LP64
+  const Register thread = r15_thread;
+  Address curr_ct_holder_addr(thread, in_bytes(ShenandoahThreadLocalData::card_table_offset()));
+  __ movptr(tmp, curr_ct_holder_addr);
+
   __ leaq(end, Address(addr, count, TIMES_OOP, 0));  // end == addr+count*oop_size
   __ subptr(end, BytesPerHeapOop); // end - 1 to make inclusive
   __ shrptr(addr, CardTable::card_shift());
   __ shrptr(end, CardTable::card_shift());
   __ subptr(end, addr); // end --> cards count
 
-  __ mov64(tmp, disp);
   __ addptr(addr, tmp);
 
   __ BIND(L_loop);
@@ -933,13 +937,21 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
   __ decrement(count);
   __ jccb(Assembler::greaterEqual, L_loop);
 #else
+  const Register thread = tmp;
+  __ get_thread(thread);
+
+  Address curr_ct_holder_addr(thread, in_bytes(ShenandoahThreadLocalData::byte_map_base_offset()));
+  __ movptr(tmp, curr_ct_holder_addr);
+
   __ lea(end, Address(addr, count, Address::times_ptr, -wordSize));
   __ shrptr(addr, CardTable::card_shift());
   __ shrptr(end,  CardTable::card_shift());
   __ subptr(end, addr); // end --> count
 
+  __ addptr(addr, tmp);
+
   __ BIND(L_loop);
-  Address cardtable(addr, count, Address::times_1, disp);
+  Address cardtable(addr, count, Address::times_1, 0);
   __ movb(cardtable, 0);
   __ decrement(count);
   __ jccb(Assembler::greaterEqual, L_loop);

--- a/src/hotspot/share/ci/ciUtilities.cpp
+++ b/src/hotspot/share/ci/ciUtilities.cpp
@@ -27,6 +27,7 @@
 #include "gc/shared/cardTableBarrierSet.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/collectedHeap.hpp"
+#include "gc/shared/gc_globals.hpp"
 
 // ciUtilities
 //
@@ -46,5 +47,6 @@ CardTable::CardValue* ci_card_table_address() {
   BarrierSet* bs = BarrierSet::barrier_set();
   CardTableBarrierSet* ctbs = barrier_set_cast<CardTableBarrierSet>(bs);
   CardTable* ct = ctbs->card_table();
+  assert(!UseShenandoahGC, "Shenandoah byte_map_base is not constant.");
   return ct->byte_map_base();
 }

--- a/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
@@ -47,6 +47,8 @@ void CardTableBarrierSetC1::post_barrier(LIRAccess& access, LIR_Opr addr, LIR_Op
   CardTableBarrierSet* ctbs = barrier_set_cast<CardTableBarrierSet>(bs);
   CardTable* ct = ctbs->card_table();
   LIR_Const* card_table_base = new LIR_Const(ct->byte_map_base());
+  SHENANDOAHGC_ONLY(assert(!UseShenandoahGC, "Shenandoah byte_map_base is not constant.");)
+
   if (addr->is_address()) {
     LIR_Address* address = addr->as_address_ptr();
     // ptr cannot be an object because we use this barrier for array card marks

--- a/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
@@ -305,10 +305,12 @@ void ShenandoahBarrierSetC1::post_barrier(LIRAccess& access, LIR_Opr addr, LIR_O
     return;
   }
 
-  BarrierSet* bs = BarrierSet::barrier_set();
-  ShenandoahBarrierSet* ctbs = barrier_set_cast<ShenandoahBarrierSet>(bs);
-  CardTable* ct = ctbs->card_table();
-  LIR_Const* card_table_base = new LIR_Const(ct->byte_map_base());
+  LIR_Opr thrd = gen->getThreadPointer();
+  const int curr_ct_holder_offset = in_bytes(ShenandoahThreadLocalData::card_table_offset());
+  LIR_Address* curr_ct_holder_addr = new LIR_Address(thrd, curr_ct_holder_offset, T_ADDRESS);
+  LIR_Opr curr_ct_holder_ptr_reg = gen->new_register(T_ADDRESS);
+  __ move(curr_ct_holder_addr, curr_ct_holder_ptr_reg);
+
   if (addr->is_address()) {
     LIR_Address* address = addr->as_address_ptr();
     // ptr cannot be an object because we use this barrier for array card marks
@@ -332,13 +334,7 @@ void ShenandoahBarrierSetC1::post_barrier(LIRAccess& access, LIR_Opr addr, LIR_O
     __ unsigned_shift_right(addr, CardTable::card_shift(), tmp);
   }
 
-  LIR_Address* card_addr;
-  if (gen->can_inline_as_constant(card_table_base)) {
-    card_addr = new LIR_Address(tmp, card_table_base->as_jint(), T_BYTE);
-  } else {
-    card_addr = new LIR_Address(tmp, gen->load_constant(card_table_base), T_BYTE);
-  }
-
+  LIR_Address* card_addr = new LIR_Address(curr_ct_holder_ptr_reg, tmp, T_BYTE);
   LIR_Opr dirty = LIR_OprFact::intConst(CardTable::dirty_card_val());
   if (UseCondCardMark) {
     LIR_Opr cur_value = gen->new_register(T_INT);

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -433,17 +433,6 @@ void ShenandoahBarrierSetC2::insert_pre_barrier(GraphKit* kit, Node* base_oop, N
   kit->final_sync(ideal);
 }
 
-Node* ShenandoahBarrierSetC2::byte_map_base_node(GraphKit* kit) const {
-  BarrierSet* bs = BarrierSet::barrier_set();
-  ShenandoahBarrierSet* ctbs = barrier_set_cast<ShenandoahBarrierSet>(bs);
-  CardTable::CardValue* card_table_base = ctbs->card_table()->byte_map_base();
-  if (card_table_base != nullptr) {
-    return kit->makecon(TypeRawPtr::make((address)card_table_base));
-  } else {
-    return kit->null();
-  }
-}
-
 void ShenandoahBarrierSetC2::post_barrier(GraphKit* kit,
                                           Node* ctl,
                                           Node* oop_store,
@@ -481,14 +470,20 @@ void ShenandoahBarrierSetC2::post_barrier(GraphKit* kit,
 
   IdealKit ideal(kit, true);
 
+  Node* tls = __ thread(); // ThreadLocalStorage
+
   // Convert the pointer to an int prior to doing math on it
   Node* cast = __ CastPX(__ ctrl(), adr);
+
+  Node* curr_ct_holder_offset = __ ConX(in_bytes(ShenandoahThreadLocalData::card_table_offset()));
+  Node* curr_ct_holder_addr  = __ AddP(__ top(), tls, curr_ct_holder_offset);
+  Node* curr_ct_base_addr = __ load( __ ctrl(), curr_ct_holder_addr, TypeRawPtr::NOTNULL, T_ADDRESS, Compile::AliasIdxRaw);
 
   // Divide by card size
   Node* card_offset = __ URShiftX( cast, __ ConI(CardTable::card_shift()) );
 
   // Combine card table base and card offset
-  Node* card_adr = __ AddP(__ top(), byte_map_base_node(kit), card_offset );
+  Node* card_adr = __ AddP(__ top(), curr_ct_base_addr, card_offset);
 
   // Get the alias_index for raw card-mark memory
   int adr_type = Compile::AliasIdxRaw;

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.hpp
@@ -67,8 +67,6 @@ private:
                                     Node* pre_val,
                                     BasicType bt) const;
 
-  Node* byte_map_base_node(GraphKit* kit) const;
-
   void post_barrier(GraphKit* kit,
                     Node* ctl,
                     Node* store,

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -107,6 +107,11 @@ void ShenandoahBarrierSet::on_thread_attach(Thread *thread) {
   assert(queue.index() == 0, "SATB queue index should be zero");
   queue.set_active(_satb_mark_queue_set.is_active());
 
+  if (ShenandoahCardBarrier) {
+    // Every thread always have a pointer to the _current_ _write_ version of the card table.
+    // The JIT'ed code will use this address (+card entry offset) to mark the card as dirty.
+    ShenandoahThreadLocalData::set_card_table(thread, _card_table->write_byte_map_base());
+  }
   ShenandoahThreadLocalData::set_gc_state(thread, _heap->gc_state());
 
   if (thread->is_Java_thread()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahCardTable.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCardTable.hpp
@@ -70,8 +70,22 @@ public:
 
   size_t last_valid_index();
 
+  CardValue* swap_read_and_write_tables() {
+    swap(_read_byte_map, _write_byte_map);
+    swap(_read_byte_map_base, _write_byte_map_base);
+
+    _byte_map = _write_byte_map;
+    _byte_map_base = _write_byte_map_base;
+
+    return _byte_map_base;
+  }
+
   CardValue* read_byte_map() {
     return _read_byte_map;
+  }
+
+  CardValue* read_byte_map_base() {
+    return _read_byte_map_base;
   }
 
   CardValue* write_byte_map() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -416,6 +416,10 @@ void ShenandoahConcurrentGC::entry_reset() {
                                 msg);
     op_reset();
   }
+
+  if (heap->mode()->is_generational()) {
+    heap->old_generation()->card_scan()->mark_read_table_as_clean();
+  }
 }
 
 void ShenandoahConcurrentGC::entry_scan_remembered_set() {
@@ -680,12 +684,10 @@ void ShenandoahConcurrentGC::op_init_mark() {
   assert(!_generation->is_mark_complete(), "should not be complete");
   assert(!heap->has_forwarded_objects(), "No forwarded objects on this path");
 
-
   if (heap->mode()->is_generational()) {
     if (_generation->is_young()) {
-      // The current implementation of swap_remembered_set() copies the write-card-table to the read-card-table.
       ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_swap_rset);
-      _generation->swap_remembered_set();
+      _generation->swap_card_tables();
     }
 
     if (_generation->is_global()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -75,7 +75,7 @@ protected:
   void vmop_entry_verify_final_roots();
 
   // Entry methods to normally STW GC operations. These set up logging, monitoring
-  // and workers for net VM operation
+  // and workers for next VM operation
   void entry_init_mark();
   void entry_final_mark();
   void entry_init_update_refs();

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -140,7 +140,7 @@ void ShenandoahDegenGC::op_degenerated() {
 
       if (heap->mode()->is_generational() && _generation->is_young()) {
         // Swap remembered sets for young
-        _generation->swap_remembered_set();
+        _generation->swap_card_tables();
       }
 
     case _degenerated_roots:
@@ -172,7 +172,7 @@ void ShenandoahDegenGC::op_degenerated() {
           // We only need this if the concurrent cycle has already swapped the card tables.
           // Marking will use the 'read' table, but interesting pointers may have been
           // recorded in the 'write' table in the time between the cancelled concurrent cycle
-          // and this degenerated cycle. These pointers need to be included the 'read' table
+          // and this degenerated cycle. These pointers need to be included in the 'read' table
           // used to scan the remembered set during the STW mark which follows here.
           _generation->merge_write_table();
         }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -97,20 +97,6 @@ public:
   }
 };
 
-class ShenandoahCopyWriteCardTableToRead: public ShenandoahHeapRegionClosure {
-private:
-  ShenandoahScanRemembered* _scanner;
-public:
-  ShenandoahCopyWriteCardTableToRead(ShenandoahScanRemembered* scanner) : _scanner(scanner) {}
-
-  void heap_region_do(ShenandoahHeapRegion* region) override {
-    assert(region->is_old(), "Don't waste time doing this for non-old regions");
-    _scanner->reset_remset(region->bottom(), ShenandoahHeapRegion::region_size_words());
-  }
-
-  bool is_thread_safe() override { return true; }
-};
-
 // Add [TAMS, top) volume over young regions. Used to correct age 0 cohort census
 // for adaptive tenuring when census is taken during marking.
 // In non-product builds, for the purposes of verification, we also collect the total
@@ -231,19 +217,18 @@ template void ShenandoahGeneration::reset_mark_bitmap<true, false>();
 template void ShenandoahGeneration::reset_mark_bitmap<true, true>();
 template void ShenandoahGeneration::reset_mark_bitmap<false, false>();
 
-// The ideal is to swap the remembered set so the safepoint effort is no more than a few pointer manipulations.
-// However, limitations in the implementation of the mutator write-barrier make it difficult to simply change the
-// location of the card table.  So the interim implementation of swap_remembered_set will copy the write-table
-// onto the read-table and will then clear the write-table.
-void ShenandoahGeneration::swap_remembered_set() {
+// Swap the read and write card table pointers prior to the next remset scan.
+// This avoids the need to synchronize reads of the table by the GC workers
+// doing remset scanning, on the one hand, with the dirtying of the table by
+// mutators on the other.
+void ShenandoahGeneration::swap_card_tables() {
   // Must be sure that marking is complete before we swap remembered set.
   ShenandoahGenerationalHeap* heap = ShenandoahGenerationalHeap::heap();
   heap->assert_gc_workers(heap->workers()->active_workers());
   shenandoah_assert_safepoint();
 
   ShenandoahOldGeneration* old_generation = heap->old_generation();
-  ShenandoahCopyWriteCardTableToRead task(old_generation->card_scan());
-  old_generation->parallel_heap_region_iterate(&task);
+  old_generation->card_scan()->swap_card_tables();
 }
 
 // Copy the write-version of the card-table into the read-version, clearing the

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -163,7 +163,7 @@ private:
   void reset_mark_bitmap();
 
   // Used by concurrent and degenerated GC to reset remembered set.
-  void swap_remembered_set();
+  void swap_card_tables();
 
   // Update the read cards with the state of the write table (write table is not cleared).
   void merge_write_table();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
@@ -89,6 +89,11 @@ void ShenandoahGenerationalFullGC::handle_completion(ShenandoahHeap* heap) {
 
 void ShenandoahGenerationalFullGC::rebuild_remembered_set(ShenandoahHeap* heap) {
   ShenandoahGCPhase phase(ShenandoahPhaseTimings::full_gc_reconstruct_remembered_set);
+
+  ShenandoahScanRemembered* scanner = heap->old_generation()->card_scan();
+  scanner->mark_read_table_as_clean();
+  scanner->swap_card_tables();
+
   ShenandoahRegionIterator regions;
   ShenandoahReconstructRememberedSetTask task(&regions);
   heap->workers()->run_task(&task);

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -31,6 +31,7 @@
 #include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
 #include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
 #include "logging/log.hpp"
+#include "runtime/threads.hpp"
 
 size_t ShenandoahDirectCardMarkRememberedSet::last_valid_index() const {
   return _card_table->last_valid_index();
@@ -70,18 +71,6 @@ void ShenandoahDirectCardMarkRememberedSet::mark_range_as_dirty(size_t card_inde
   }
 }
 
-void ShenandoahDirectCardMarkRememberedSet::mark_card_as_clean(size_t card_index) {
-  CardValue* bp = &(_card_table->write_byte_map())[card_index];
-  bp[0] = CardTable::clean_card_val();
-}
-
-void ShenandoahDirectCardMarkRememberedSet::mark_range_as_clean(size_t card_index, size_t num_cards) {
-  CardValue* bp = &(_card_table->write_byte_map())[card_index];
-  while (num_cards-- > 0) {
-    *bp++ = CardTable::clean_card_val();
-  }
-}
-
 bool ShenandoahDirectCardMarkRememberedSet::is_card_dirty(HeapWord* p) const {
   size_t index = card_index_for_addr(p);
   CardValue* bp = &(_card_table->read_byte_map())[index];
@@ -112,12 +101,6 @@ void ShenandoahDirectCardMarkRememberedSet::mark_range_as_dirty(HeapWord* p, siz
   }
 }
 
-void ShenandoahDirectCardMarkRememberedSet::mark_card_as_clean(HeapWord* p) {
-  size_t index = card_index_for_addr(p);
-  CardValue* bp = &(_card_table->write_byte_map())[index];
-  bp[0] = CardTable::clean_card_val();
-}
-
 void ShenandoahDirectCardMarkRememberedSet::mark_range_as_clean(HeapWord* p, size_t num_heap_words) {
   CardValue* bp = &(_card_table->write_byte_map_base())[uintptr_t(p) >> _card_shift];
   CardValue* end_bp = &(_card_table->write_byte_map_base())[uintptr_t(p + num_heap_words) >> _card_shift];
@@ -128,6 +111,18 @@ void ShenandoahDirectCardMarkRememberedSet::mark_range_as_clean(HeapWord* p, siz
   while (bp < end_bp) {
     *bp++ = CardTable::clean_card_val();
   }
+}
+
+void ShenandoahDirectCardMarkRememberedSet::mark_read_table_as_clean() {
+  CardValue* read_table = _card_table->read_byte_map();
+  CardValue* bp = &(read_table)[0];
+  CardValue* end_bp = &(read_table)[_card_table->last_valid_index()];
+
+  while (bp <= end_bp) {
+    *bp++ = CardTable::clean_card_val();
+  }
+
+  log_info(gc, barrier)("Cleaned read_table from " PTR_FORMAT " to " PTR_FORMAT, p2i(&(read_table)[0]), p2i(end_bp));
 }
 
 // No lock required because arguments align with card boundaries.
@@ -329,12 +324,12 @@ void ShenandoahScanRemembered::mark_range_as_dirty(HeapWord* p, size_t num_heap_
   _rs->mark_range_as_dirty(p, num_heap_words);
 }
 
-void ShenandoahScanRemembered::mark_card_as_clean(HeapWord* p) {
-  _rs->mark_card_as_clean(p);
+void ShenandoahScanRemembered::mark_range_as_clean(HeapWord* p, size_t num_heap_words) {
+  _rs->mark_range_as_clean(p, num_heap_words);
 }
 
-void ShenandoahScanRemembered:: mark_range_as_clean(HeapWord* p, size_t num_heap_words) {
-  _rs->mark_range_as_clean(p, num_heap_words);
+void ShenandoahScanRemembered::mark_read_table_as_clean() {
+  _rs->mark_read_table_as_clean();
 }
 
 void ShenandoahScanRemembered::reset_object_range(HeapWord* from, HeapWord* to) {
@@ -622,30 +617,35 @@ void ShenandoahDirectCardMarkRememberedSet::merge_write_table(HeapWord* start, s
   for (size_t i = 0; i < num; i++) {
     read_table[i] &= write_table[i];
   }
+
+  log_info(gc, remset)("Finished merging write_table into read_table.");
 }
 
-// Destructively copy the write table to the read table, and clean the write table.
-void ShenandoahDirectCardMarkRememberedSet::reset_remset(HeapWord* start, size_t word_count) {
-  size_t start_index = card_index_for_addr(start);
+void ShenandoahDirectCardMarkRememberedSet::swap_card_tables() {
+  CardTable::CardValue* new_ptr = _card_table->swap_read_and_write_tables();
+
 #ifdef ASSERT
-  // avoid querying card_index_for_addr() for an address past end of heap
-  size_t end_index = card_index_for_addr(start + word_count - 1) + 1;
-#endif
-  assert(start_index % ((size_t)1 << LogCardValsPerIntPtr) == 0, "Expected a multiple of CardValsPerIntPtr");
-  assert(end_index % ((size_t)1 << LogCardValsPerIntPtr) == 0, "Expected a multiple of CardValsPerIntPtr");
+  CardValue* start_bp = &(_card_table->write_byte_map())[0];
+  CardValue* end_bp = &(new_ptr)[_card_table->last_valid_index()];
 
-  // We'll access in groups of intptr_t worth of card entries
-  intptr_t* const read_table  = (intptr_t*) &(_card_table->read_byte_map())[start_index];
-  intptr_t* const write_table = (intptr_t*) &(_card_table->write_byte_map())[start_index];
-
-  // Avoid division, use shift instead
-  assert(word_count % ((size_t)1 << (LogCardSizeInWords + LogCardValsPerIntPtr)) == 0, "Expected a multiple of CardSizeInWords*CardValsPerIntPtr");
-  size_t const num = word_count >> (LogCardSizeInWords + LogCardValsPerIntPtr);
-
-  for (size_t i = 0; i < num; i++) {
-    read_table[i]  = write_table[i];
-    write_table[i] = CardTable::clean_card_row_val();
+  while (start_bp <= end_bp) {
+    assert(*start_bp == CardTable::clean_card_val(), "Should be clean: " PTR_FORMAT, p2i(start_bp));
+    start_bp++;
   }
+#endif
+
+  struct SwapTLSCardTable : public ThreadClosure {
+    CardTable::CardValue* _new_ptr;
+    SwapTLSCardTable(CardTable::CardValue* np) : _new_ptr(np) {}
+    virtual void do_thread(Thread* t) {
+      ShenandoahThreadLocalData::set_card_table(t, _new_ptr);
+    }
+  } swap_it(new_ptr);
+
+  // Iterate on threads and adjust thread local data
+  Threads::threads_do(&swap_it);
+
+  log_info(gc, barrier)("Current write_card_table: " PTR_FORMAT, p2i(swap_it._new_ptr));
 }
 
 ShenandoahScanRememberedTask::ShenandoahScanRememberedTask(ShenandoahObjToScanQueueSet* queue_set,
@@ -949,10 +949,7 @@ void ShenandoahReconstructRememberedSetTask::work(uint worker_id) {
         oop obj = cast_to_oop(obj_addr);
         size_t size = obj->size();
 
-        // First, clear the remembered set for all spanned humongous regions
         size_t num_regions = ShenandoahHeapRegion::required_regions(size * HeapWordSize);
-        size_t region_span = num_regions * ShenandoahHeapRegion::region_size_words();
-        scanner->reset_remset(r->bottom(), region_span);
         size_t region_index = r->index();
         ShenandoahHeapRegion* humongous_region = heap->get_region(region_index);
         while (num_regions-- != 0) {
@@ -965,8 +962,6 @@ void ShenandoahReconstructRememberedSetTask::work(uint worker_id) {
         scanner->register_object_without_lock(obj_addr);
         obj->oop_iterate(&dirty_cards_for_cross_generational_pointers);
       } else if (!r->is_humongous()) {
-        // First, clear the remembered set
-        scanner->reset_remset(r->bottom(), ShenandoahHeapRegion::region_size_words());
         scanner->reset_object_range(r->bottom(), r->end());
 
         // Then iterate over all objects, registering object and DIRTYing relevant remembered set cards

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -239,15 +239,17 @@ public:
   inline bool is_write_card_dirty(HeapWord* p) const;
   inline void mark_card_as_dirty(HeapWord* p);
   inline void mark_range_as_dirty(HeapWord* p, size_t num_heap_words);
-  inline void mark_card_as_clean(HeapWord* p);
   inline void mark_range_as_clean(HeapWord* p, size_t num_heap_words);
+
+  // See comment in ShenandoahScanRemembered
+  inline void mark_read_table_as_clean();
 
   // Merge any dirty values from write table into the read table, while leaving
   // the write table unchanged.
   void merge_write_table(HeapWord* start, size_t word_count);
 
-  // Destructively copy the write table to the read table, and clean the write table.
-  void reset_remset(HeapWord* start, size_t word_count);
+  // See comment in ShenandoahScanRemembered
+  void swap_card_tables();
 };
 
 // A ShenandoahCardCluster represents the minimal unit of work
@@ -758,10 +760,18 @@ public:
   bool is_write_card_dirty(HeapWord* p);
   void mark_card_as_dirty(HeapWord* p);
   void mark_range_as_dirty(HeapWord* p, size_t num_heap_words);
-  void mark_card_as_clean(HeapWord* p);
   void mark_range_as_clean(HeapWord* p, size_t num_heap_words);
 
-  void reset_remset(HeapWord* start, size_t word_count) { _rs->reset_remset(start, word_count); }
+  // This method is used to concurrently clean the "read" card table -
+  // currently, as part of the reset phase. Later on the pointers to the "read"
+  // and "write" card tables are swapped everywhere to enable the GC to
+  // concurrently operate on the "read" table while mutators effect changes on
+  // the "write" table.
+  void mark_read_table_as_clean();
+
+  // Swaps read and write card tables pointers in effect setting a clean card
+  // table for the next GC cycle.
+  void swap_card_tables() { _rs->swap_card_tables(); }
 
   void merge_write_table(HeapWord* start, size_t word_count) { _rs->merge_write_table(start, word_count); }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
@@ -36,6 +36,7 @@ ShenandoahThreadLocalData::ShenandoahThreadLocalData() :
   _oom_scope_nesting_level(0),
   _oom_during_evac(false),
   _satb_mark_queue(&ShenandoahBarrierSet::satb_mark_queue_set()),
+  _card_table(nullptr),
   _gclab(nullptr),
   _gclab_size(0),
   _paced_time(0),

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -49,6 +49,9 @@ private:
 
   SATBMarkQueue           _satb_mark_queue;
 
+  // Current active CardTable's byte_map_base for this thread.
+  CardTable::CardValue*   _card_table;
+
   // Thread-local allocation buffer for object evacuations.
   // In generational mode, it is exclusive to the young generation.
   PLAB* _gclab;
@@ -120,6 +123,17 @@ public:
 
   static bool is_gc_state(ShenandoahHeap::GCState state) {
     return is_gc_state(Thread::current(), state);
+  }
+
+  static void set_card_table(Thread* thread, CardTable::CardValue* ct) {
+    assert(ct != nullptr, "trying to set thread local card_table pointer to nullptr.");
+    data(thread)->_card_table = ct;
+  }
+
+  static CardTable::CardValue* card_table(Thread* thread) {
+    CardTable::CardValue* ct = data(thread)->_card_table;
+    assert(ct != nullptr, "returning a null thread local card_table pointer.");
+    return ct;
   }
 
   static void initialize_gclab(Thread* thread) {
@@ -283,6 +297,10 @@ public:
 
   static ByteSize gc_state_offset() {
     return Thread::gc_data_offset() + byte_offset_of(ShenandoahThreadLocalData, _gc_state);
+  }
+
+  static ByteSize card_table_offset() {
+    return Thread::gc_data_offset() + byte_offset_of(ShenandoahThreadLocalData, _card_table);
   }
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -1267,7 +1267,7 @@ public:
       oop obj = CompressedOops::decode_not_null(o);
       if (_heap->is_in_young(obj) && !_scanner->is_card_dirty((HeapWord*) p)) {
         ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, p, nullptr,
-                                         _message, "clean card should be dirty", __FILE__, __LINE__);
+                                         _message, "clean card, it should be dirty.", __FILE__, __LINE__);
       }
     }
   }


### PR DESCRIPTION
Conflict in risc-v code, trivial resolution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issues
 * [JDK-8343468](https://bugs.openjdk.org/browse/JDK-8343468): GenShen: Enable relocation of remembered set card tables (**Enhancement** - P4)
 * [JDK-8351456](https://bugs.openjdk.org/browse/JDK-8351456): Build failure with --disable-jvm-feature-shenandoahgc after 8343468 (**Bug** - P2)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/186/head:pull/186` \
`$ git checkout pull/186`

Update a local copy of the PR: \
`$ git checkout pull/186` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 186`

View PR using the GUI difftool: \
`$ git pr show -t 186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/186.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/186.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/186#issuecomment-2831380172)
</details>
