### PR TITLE
8352185: Shenandoah: Invalid logic for remembered set verification

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -685,10 +685,6 @@ void ShenandoahConcurrentGC::op_init_mark() {
   assert(!heap->has_forwarded_objects(), "No forwarded objects on this path");
 
   if (heap->mode()->is_generational()) {
-    if (_generation->is_young()) {
-      ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_swap_rset);
-      _generation->swap_card_tables();
-    }
 
     if (_generation->is_global()) {
       heap->old_generation()->cancel_gc();
@@ -698,6 +694,14 @@ void ShenandoahConcurrentGC::op_init_mark() {
       // abandoned.
       ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_transfer_satb);
       heap->old_generation()->transfer_pointers_from_satb();
+    }
+    {
+      // After we swap card table below, the write-table is all clean, and the read table holds
+      // cards dirty prior to the start of GC. Young and bootstrap collection will update
+      // the write card table as a side effect of remembered set scanning. Global collection will
+      // update the card table as a side effect of global marking of old objects.
+      ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_swap_rset);
+      _generation->swap_card_tables();
     }
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -1156,6 +1156,9 @@ void ShenandoahFullGC::phase5_epilog() {
 
     heap->free_set()->finish_rebuild(young_cset_regions, old_cset_regions, num_old);
 
+    // Set mark incomplete because the marking bitmaps have been reset except pinned regions.
+    heap->global_generation()->set_mark_incomplete();
+
     heap->clear_cancelled_gc(true /* clear oom handler */);
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -229,14 +229,12 @@ public:
   void verify_before_rebuilding_free_set();
 private:
   template<typename Scanner>
-  void help_verify_region_rem_set(Scanner* scanner, ShenandoahHeapRegion* r, ShenandoahMarkingContext* ctx,
+  void help_verify_region_rem_set(Scanner* scanner, ShenandoahHeapRegion* r,
                                   HeapWord* update_watermark, const char* message);
 
   void verify_rem_set_before_mark();
   void verify_rem_set_before_update_ref();
   void verify_rem_set_after_full_gc();
-
-  ShenandoahMarkingContext* get_marking_context_for_old();
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHVERIFIER_HPP


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8352185](https://bugs.openjdk.org/browse/JDK-8352185): Shenandoah: Invalid logic for remembered set verification (**Bug** - P3)
 * [JDK-8345399](https://bugs.openjdk.org/browse/JDK-8345399): GenShen: Error: Verify init-mark remembered set violation; clean card should be dirty (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/188/head:pull/188` \
`$ git checkout pull/188`

Update a local copy of the PR: \
`$ git checkout pull/188` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 188`

View PR using the GUI difftool: \
`$ git pr show -t 188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/188.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/188.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-jdk21u/pull/188#issuecomment-2842452959)
</details>
