### PR TITLE
8353596: GenShen: Test TestClone.java#generational-no-coops intermittent timed out

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -273,13 +273,9 @@ void ShenandoahGenerationalControlThread::run_gc_cycle(const ShenandoahGCRequest
     }
   }
 
-  // If this was the requested GC cycle, notify waiters about it
-  if (ShenandoahCollectorPolicy::is_explicit_gc(request.cause)) {
-    notify_gc_waiters();
-  }
-
-  // If this cycle completed successfully, notify threads waiting to retry allocation
+  // If this cycle completed successfully, notify threads waiting for gc
   if (!_heap->cancelled_gc()) {
+    notify_gc_waiters();
     notify_alloc_failure_waiters();
   }
 


### PR DESCRIPTION
Clean backport, low risk, fixes hung compiler threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8353596](https://bugs.openjdk.org/browse/JDK-8353596): GenShen: Test TestClone.java#generational-no-coops intermittent timed out (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk21u.git pull/189/head:pull/189` \
`$ git checkout pull/189`

Update a local copy of the PR: \
`$ git checkout pull/189` \
`$ git pull https://git.openjdk.org/shenandoah-jdk21u.git pull/189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 189`

View PR using the GUI difftool: \
`$ git pr show -t 189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk21u/pull/189.diff">https://git.openjdk.org/shenandoah-jdk21u/pull/189.diff</a>

</details>
